### PR TITLE
Handle links that embed other elements

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -112,8 +112,9 @@ export function createRouter(loadComponent, fallbackComponent) {
        * @param {*} e
        */
       (e) => {
-        if (e.target.tagName === 'A') {
-          const { href, target } = e.target
+        const link = e.target.closest('a')
+        if (link) {
+          const { href, target } = link
           const targetUrl = new URL(href)
           const currentUrl = window.location
           if (
@@ -127,7 +128,7 @@ export function createRouter(loadComponent, fallbackComponent) {
                 e.preventDefault()
                 window.scrollTo({
                   left: 0,
-                  top: e.target.offsetTop,
+                  top: link.offsetTop,
                   behavior: 'smooth'
                 })
               }


### PR DESCRIPTION
This fixes the case, when for example `a` tag, wraps an `img` tag.