### PR TITLE
Set required node version to 12.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "yarn build && yarn changelog"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.10.0"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"


### PR DESCRIPTION
The required node versions for the recursive flag of fs.mkdir & fs.rmdir are:
- fs.mkdir: >=v11.3.0
- fs.rmdir: >=v12.10.0