### PR TITLE
chore: adding documentation example + normalize root param

### DIFF
--- a/bin/vitepress.js
+++ b/bin/vitepress.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const chalk = require('chalk')
 const argv = require('minimist')(process.argv.slice(2))
+const { join } = require('path')
 
 console.log(chalk.cyan(`vitepress v${require('../package.json').version}`))
 console.log(chalk.cyan(`vite v${require('vite/package.json').version}`))
@@ -11,8 +12,11 @@ if (!command || command === 'dev') {
   const port = argv.port || 3000
   const root = command === 'dev' && argv._[1]
   if (root) {
-    argv.root = root
+    // normalize path it update argv by a custom root
+    argv.root =
+      root.indexOf(process.cwd()) === -1 ? join(__dirname, '..', root) : root
   }
+
   require('../dist')
     .createServer(argv)
     .then((server) => {

--- a/documentation/.vitepress/config.js
+++ b/documentation/.vitepress/config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  // base: string
+  title: /** String */ 'vitepress title',
+  description: /** String */ 'vitepress documentation',
+  head: /** HeadConfig[] */ [
+    [
+      'link',
+      {
+        href:
+          'https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap',
+        rel: 'stylesheet'
+      }
+    ],
+    // [
+    //     'style',
+    //     {},
+    //     "* { font-family: 'Poppins', sans-serif; }"
+    // ],
+    ['script', {}, "console.log('welcome to vitepress')"]
+  ],
+  themeConfig: /** ThemeConfig = any */ {}
+}

--- a/documentation/config.md
+++ b/documentation/config.md
@@ -1,0 +1,13 @@
+# config
+
+Add a config.js inside your .vitepress. Here what you can customize
+
+```js
+module.exports = {
+    base: string
+    title: string
+    description: string
+    head: HeadConfig[] // check our config to have an example
+    themeConfig: ThemeConfig = any // we are not using it currently
+}
+```

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,0 +1,25 @@
+## (WIP) VitePress 📝💨
+
+> [VuePress](http://vuepress.vuejs.org/)' little brother, built on top of [vite](https://github.com/vuejs/vite)
+
+**Note this is early WIP! Currently the focus is on making Vite stable and feature complete first. It is not recommended to use this for anything serious yet.**
+
+``` bash
+npm install -D vitepress
+echo '# Hello VitePress' > index.md
+
+# starts dev server
+npx vitepress
+
+# build > .vitepress/dist
+npx vitepress build
+```
+
+[Customization](./config.md)
+[Theme](./theme.md)
+[Motivation](./motivation.md)
+[Others](./others.md)
+
+## License
+
+MIT

--- a/documentation/motivation.md
+++ b/documentation/motivation.md
@@ -1,0 +1,29 @@
+## Motivation
+
+I love VuePress, but being built on top of webpack, the time it takes to spin up the dev server for a simple doc site with a few pages is just becoming unbearable. Even HMR updates can take up to seconds to reflect in the browser!
+
+As a reference, the [Composition API RFC repo](https://github.com/vuejs/composition-api-rfc) is just two pages, but it takes 4 seconds to spin up the server, and almost 2 seconds for any edit to reflect in the browser.
+
+Fundamentally, this is because VuePress is a webpack app under the hood. Even with just two pages, it's a full on webpack project (including all the theme source files) being compiled. It gets even worse when the project has many pages - every page must first be fully compiled before the server can even display anything!
+
+Incidentally, [vite](https://github.com/vuejs/vite) solves these problems really well: nearly instant server start, on-demand compilation that only compiles the page being served, and lightning fast HMR. Plus, there are a few additional design issues I have noted in VuePress over time, but never had the time to fix due to the amount of refactoring it would require.
+
+Now, with `vite` and Vue 3, it is time to rethink what a "Vue-powered static site generator" can really be.
+
+## Improvements over VuePress
+
+- Uses Vue 3.
+  - Leverages Vue 3's improved template static analysis to stringify static content as much as possible. Static content is sent as string literals instead of JavaScript render function code - the JS payload is therefore *much* cheaper to parse, and hydration also becomes faster.
+
+    Note the optimization is applied while still allowing the user to freely mix Vue components inside markdown content - the compiler does the static/dynamic separation for you automatically and you never need to think about it.
+
+- Uses `vite` under the hood:
+  - Faster dev server start
+  - Faster hot updates
+  - Faster build (uses Rollup internally)
+
+- Lighter page weight.
+  - Vue 3 tree-shaking + Rollup code splitting
+  - Does not ship metadata for every page on every request. This decouples page weight from total number of pages. Only the current page's metadata is sent. Client side navigation fetches the new page's component and metadata together.
+  - Does not use `vue-router` because the need of VitePress is very simple and specific - a simple custom router (under 200 LOC) is used instead.
+  - (WIP) i18n locale data should also be fetched on demand.

--- a/documentation/others.md
+++ b/documentation/others.md
@@ -1,0 +1,9 @@
+## Other Differences
+
+- More opinionated and less configurable: VitePress aims to scale back the complexity in the current VuePress and restart from its minimalist roots.
+
+- Future oriented: VitePress only targets browsers that support native ES module imports. It encourages the use of native JavaScript without transpilation, and CSS variables for theming.
+
+## Will this become the next VuePress in the future?
+
+Maybe! It's currently under a different name so that we don't over commit to the compatibility with the current VuePress ecosystem (mostly themes and plugins). We'll see how close we can get without compromising the design goals listed above. But the overall idea is that VitePress will have a drastically more minimal theming API (preferring JavaScript APIs instead of file layout conventions) and likely no plugins (all customization is done in themes).

--- a/documentation/theme.md
+++ b/documentation/theme.md
@@ -1,0 +1,30 @@
+## Theme
+
+You can develop your custom theme by adding the following files:
+
+`.vitepress/theme/Layout.vue`
+
+```vue
+<template>
+  <h1>Custom Layout!</h1>
+  <Content/><!-- make sure to include markdown outlet -->
+</template>
+```
+
+`.vitepress/theme/index.js`
+
+```js
+import Layout from './Layout.vue'
+
+export default {
+  Layout,
+  NotFound: () => 'custom 404', // <- this is a Vue 3 functional component
+  enhanceApp({ app, router, siteData }) {
+    // app is the Vue 3 app instance from createApp()
+    // router is VitePress' custom router (see `lib/app/router.js`)
+    // siteData is a ref of current site-level metadata.
+  }
+}
+```
+
+Unlike VuePress, the only file with a fixed location in a theme is `index.js` - everything else is imported and exported there like in a normal application.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "dev": "tsc -w -p src",
     "build": "rm -rf dist && tsc -p src",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
-    "prepublishOnly": "yarn build && yarn changelog"
+    "prepublishOnly": "yarn build && yarn changelog",
+    "doc": "bin/vitepress.js dev documentation"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "build": "rm -rf dist && tsc -p src",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "prepublishOnly": "yarn build && yarn changelog",
-    "doc": "bin/vitepress.js dev documentation"
+    "doc:dev": "bin/vitepress.js dev documentation",
+    "doc:build": "bin/vitepress.js build documentation"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,11 +77,13 @@ export async function resolveConfig(
 
 export async function resolveSiteData(root: string): Promise<SiteData> {
   // load user config
+
   const configPath = resolve(root, 'config.js')
   const hasUserConfig = await fs.pathExists(configPath)
   // always delete cache first before loading config
   delete require.cache[configPath]
   const userConfig: UserConfig = hasUserConfig ? require(configPath) : {}
+
   if (hasUserConfig) {
     debug(`loaded config at ${chalk.yellow(configPath)}`)
   } else {

--- a/src/markdown/markdown.ts
+++ b/src/markdown/markdown.ts
@@ -90,6 +90,8 @@ export const createMarkdownRenderer = (
     )
 
   // apply user config
+  // TODO: there is never options passed it alway empty object
+  console.log(options)
   if (options.config) {
     options.config(md)
   }

--- a/src/markdownToVue.ts
+++ b/src/markdownToVue.ts
@@ -83,6 +83,8 @@ function injectPageData(tags: string[], data: PageData) {
 }
 
 const inferTitle = (frontmatter: any, content: string) => {
+  // TODO is it worth it to have this if you want to add translation later ?
+  // by default it will take the first h1 as title
   if (frontmatter.home) {
     return 'Home'
   }

--- a/src/markdownToVue.ts
+++ b/src/markdownToVue.ts
@@ -91,6 +91,8 @@ const inferTitle = (frontmatter: any, content: string) => {
   if (frontmatter.title) {
     return deeplyParseHeader(frontmatter.title)
   }
+
+  // Here if no title or home it will take the the first # in the contect as title
   const match = content.match(/^\s*#+\s+(.*)/m)
   if (match) {
     return deeplyParseHeader(match[1].trim())

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import {
   createServer as createViteServer,
   cachedRead,
   ServerConfig,
-  ServerPlugin
+  PluginContext
 } from 'vite'
 import { resolveConfig, SiteConfig, resolveSiteData } from './config'
 import { createMarkdownToVueRenderFn } from './markdownToVue'
@@ -16,8 +16,8 @@ function createVitePressPlugin({
   themeDir,
   configPath,
   site: initialSiteData
-}: SiteConfig): ServerPlugin {
-  return ({ app, root, watcher, resolver }) => {
+}: SiteConfig) {
+  return ({ app, root, watcher, resolver }: PluginContext) => {
     const markdownToVue = createMarkdownToVueRenderFn(root)
 
     // watch vitepress container app (only when developing vitepress itself)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ESNEXT",
+    "module": "ESNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
Hello I am coming from vuepress it's refreshing to see vitepress. Simpler to read and smaller code base. I like it.

Here just a little example how to use vitepress. Maybe it can be the start of its own documentation too.

I have corrected a ts errors and normalize the root params because:

`vitepress dev folderName` it broked for me with  `Error: Cannot find module 'documentation/.vitepress/config.js'`. He is looking for an absolute path as you do with `process.cwd()`.

I am still reading the code base but it look really easy to understand. More than vuepress in my opinion.