### PR TITLE
fix: resolve relative path on windows

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -29,7 +29,7 @@ export interface SiteConfig<ThemeConfig = any> {
 }
 
 const resolve = (root: string, file: string) =>
-  path.join(root, `.vitepress`, file)
+  path.resolve(root, `.vitepress`, file)
 
 export async function resolveConfig(
   root: string = process.cwd()


### PR DESCRIPTION
Allow resolving the `root` argument as relative

```bash
yarn vitepress dev docs 
```

Getting 
```
Cannot find module 'docs\.vitepress\config.js'
```