### PR TITLE
add box-sizing to Debug

### DIFF
--- a/src/client/app/components/Debug.vue
+++ b/src/client/app/components/Debug.vue
@@ -21,6 +21,7 @@ export default {
 
 <style>
 .debug {
+  box-sizing: border-box;
   position: fixed;
   z-index: 999;
   cursor: pointer;


### PR DESCRIPTION
When using Debug component without the default theme, initially the styling lacks `box-sizing`:

![image](https://user-images.githubusercontent.com/46059092/85313680-4ac6ae80-b4b0-11ea-81ea-77a89ccd0cc4.png)

Adding `box-sizing: border-box` to Debug component without relying on [global css file](https://github.com/vuejs/vitepress/blob/master/src/client/theme-default/styles/layout.css) seems sensible.

![image](https://user-images.githubusercontent.com/46059092/85313745-65008c80-b4b0-11ea-9348-4d0e39400f11.png)
