### PR TITLE
fix: use resolve instead of join

### DIFF
--- a/bin/vitepress.js
+++ b/bin/vitepress.js
@@ -6,13 +6,13 @@ console.log(chalk.cyan(`vitepress v${require('../package.json').version}`))
 console.log(chalk.cyan(`vite v${require('vite/package.json').version}`))
 
 const command = argv._[0]
+const root = argv._[command ? 1 : 0]
+if (root) {
+  argv.root = root
+}
 
 if (!command || command === 'dev') {
   const port = argv.port || 3000
-  const root = command === 'dev' && argv._[1]
-  if (root) {
-    argv.root = root
-  }
   require('../dist/node')
     .createServer(argv)
     .then((server) => {

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -84,7 +84,7 @@ function resolvePageImports(
   // find the page's js chunk and inject script tags for its imports so that
   // they are start fetching as early as possible
 
-  const srcPath = path.join(config.root, page)
+  const srcPath = path.resolve(config.root, page)
   const pageChunk = result.assets.find(
     (chunk) => chunk.type === 'chunk' && chunk.facadeModuleId === srcPath
   ) as OutputChunk

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -29,7 +29,7 @@ export interface SiteConfig<ThemeConfig = any> {
 }
 
 const resolve = (root: string, file: string) =>
-  path.join(root, `.vitepress`, file)
+  path.resolve(root, `.vitepress`, file)
 
 export async function resolveConfig(
   root: string = process.cwd()


### PR DESCRIPTION
Allows the documentation to exist in a folder e.g. `docs`, and running `vitepress dev
docs` as well as `vitepress build docs`.

I noticed things were not working when trying to dev/build files inside a folder. I'm a bit confused by the `root` option in the config file as it has to be passed at the command level for vitepress to load the right config file