### PR TITLE
feat: add array sidebar support

### DIFF
--- a/src/client/app/exports.ts
+++ b/src/client/app/exports.ts
@@ -7,7 +7,7 @@ export * from './theme'
 // composables
 export { useSiteData } from './composables/siteData'
 export { usePageData } from './composables/pageData'
-export { useRouter, useRoute } from './router'
+export { useRouter, useRoute, Router, Route } from './router'
 
 // components
 export { Content } from './components/Content'

--- a/src/client/theme-default/components/SideBar.vue
+++ b/src/client/theme-default/components/SideBar.vue
@@ -1,43 +1,69 @@
 <template>
-  <div class="sidebar">
-    <ul>
-      <SideBarItem v-for="item of items" :item="item"></SideBarItem>
-    </ul>
-  </div>
+  <ul class="sidebar">
+    <SideBarItem v-for="item of items" :item="item" />
+  </ul>
 </template>
 
 <script src="./SideBar"></script>
 
 <style>
-.sidebar ul {
+.sidebar,
+.sidebar-items {
   list-style-type: none;
   line-height: 2;
   padding: 0;
   margin: 0;
 }
 
-.sidebar a {
-  display: inline-block;
-  color: var(--text-color);
-  padding-left: 1.5rem;
+.sidebar-items .sidebar-items {
+  padding-left: 1rem;
 }
 
-.sidebar a:hover {
-  color: var(--accent-color);
+.sidebar-items .sidebar-item + .sidebar-item {
+  margin-top: 0;
 }
 
-.sidebar a.active {
-  color: var(--accent-color);
+.sidebar-items .sidebar-items .sidebar-link {
+  border-left: 0;
+}
+
+.sidebar-items .sidebar-items .sidebar-link.active {
   font-weight: 500;
 }
 
-.sidebar > ul > li > a.active {
-  padding-left: 1.25rem;
-  border-left: .25rem solid var(--accent-color);
+.sidebar-items .sidebar-link {
+  padding: .35rem 1rem .35rem 2rem;
+  line-height: 1.4;
+  font-size: 1em;
+  font-weight: 400;
 }
 
-.sidebar ul ul {
-  font-size: 0.9em;
-  padding-left: 1rem;
+.sidebar-item + .sidebar-item {
+  margin-top: .75rem;
+}
+
+.sidebar-link {
+  display: block;
+  margin: 0;
+  border-left: .25rem solid transparent;
+  padding: .35rem 1.5rem .35rem 1.25rem;
+  line-height: 1.7;
+  font-size: 1.1em;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+a.sidebar-link {
+  transition: color .15s ease;
+}
+
+a.sidebar-link:hover {
+  color: var(--accent-color);
+}
+
+a.sidebar-link.active {
+  border-left-color: var(--accent-color);
+  font-weight: 600;
+  color: var(--accent-color);
 }
 </style>

--- a/src/client/theme-default/components/SideBar.vue
+++ b/src/client/theme-default/components/SideBar.vue
@@ -19,10 +19,6 @@
   padding-left: 1rem;
 }
 
-.sidebar-items .sidebar-item + .sidebar-item {
-  margin-top: 0;
-}
-
 .sidebar-items .sidebar-items .sidebar-link {
   border-left: 0;
 }
@@ -34,12 +30,8 @@
 .sidebar-items .sidebar-link {
   padding: .35rem 1rem .35rem 2rem;
   line-height: 1.4;
-  font-size: 1em;
+  font-size: 0.9em;
   font-weight: 400;
-}
-
-.sidebar-item + .sidebar-item {
-  margin-top: .75rem;
 }
 
 .sidebar-link {
@@ -48,8 +40,8 @@
   border-left: .25rem solid transparent;
   padding: .35rem 1.5rem .35rem 1.25rem;
   line-height: 1.7;
-  font-size: 1.1em;
-  font-weight: 700;
+  font-size: 1em;
+  font-weight: 600;
   color: var(--text-color);
 }
 

--- a/src/client/theme-default/utils.ts
+++ b/src/client/theme-default/utils.ts
@@ -1,5 +1,23 @@
-import { useSiteData } from 'vitepress'
+import { useSiteData, Route } from 'vitepress'
+
+export const hashRE = /#.*$/
+export const extRE = /\.(md|html)$/
 
 export function withBase(path: string) {
   return (useSiteData().value.base + path).replace(/\/+/g, '/')
+}
+
+export function isActive(route: Route, path?: string): boolean {
+  if (path === undefined) {
+    return false
+  }
+
+  const routePath = normalize(route.path)
+  const pagePath = normalize(path)
+
+  return routePath === pagePath
+}
+
+export function normalize(path: string): string {
+  return decodeURI(path).replace(hashRE, '').replace(extRE, '')
 }

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -43,8 +43,7 @@ function createVitePressPlugin({
           customData: {
             path: resolver.fileToRequest(file),
             pageData
-          },
-          timestamp: Date.now()
+          }
         })
 
         // reload the content component


### PR DESCRIPTION
This PR adds array type sidebar support. It only supports this syntax.

```js
{
  sidebar: [
    {
      text: 'Getting Started',
      link: 'getting-started',
      children: [...]
    }
  ]
}
```

- You can't do `sidebar: ['getting-started']`.
- "Depth" option not supported. The items are always fully shown.
- Sidebar Groups works too, and header links works as well.
- Basic stylings applied, but not responsive design (not collapsable on mobile view).

<img width="1392" alt="Screen Shot 2020-07-02 at 23 29 53" src="https://user-images.githubusercontent.com/3753672/86371810-55592300-bcbc-11ea-924b-7d08c4186201.png">