### PR TITLE
feat: add multi sidebar support (#38)

### DIFF
--- a/src/client/theme-default/components/SideBar.ts
+++ b/src/client/theme-default/components/SideBar.ts
@@ -1,7 +1,7 @@
 import { useSiteData, usePageData, useRoute } from 'vitepress'
 import { computed, h, FunctionalComponent, VNode } from 'vue'
 import { Header } from '../../../../types/shared'
-import { isActive, resolvePath } from '../utils'
+import { isActive, getPathDirName } from '../utils'
 import { DefaultTheme } from '../config'
 import { useActiveSidebarLinks } from '../composables/activeSidebarLink'
 
@@ -91,6 +91,10 @@ interface ResolvedSidebarItem {
 function resolveAutoSidebar(headers: Header[], depth: number): ResolvedSidebar {
   const ret: ResolvedSidebar = []
 
+  if (headers === undefined) {
+    return []
+  }
+
   let lastH2: ResolvedSidebarItem | undefined = undefined
   headers.forEach(({ level, title, slug }) => {
     if (level - 1 > depth) {
@@ -125,7 +129,7 @@ function resolveMultiSidebar(
   headers: Header[],
   depth: number
 ): ResolvedSidebar {
-  const item = config[resolvePath(path)]
+  const item = config[getPathDirName(path)]
 
   if (Array.isArray(item)) {
     return resolveArraySidebar(item, depth)

--- a/src/client/theme-default/components/SideBar.ts
+++ b/src/client/theme-default/components/SideBar.ts
@@ -1,7 +1,7 @@
 import { useSiteData, usePageData, useRoute } from 'vitepress'
 import { computed, h, FunctionalComponent, VNode } from 'vue'
 import { Header } from '../../../../types/shared'
-import { isActive } from '../utils'
+import { isActive, resolvePath } from '../utils'
 import { DefaultTheme } from '../config'
 import { useActiveSidebarLinks } from '../composables/activeSidebarLink'
 
@@ -62,7 +62,12 @@ export default {
           } else if (themeSidebar === false) {
             return []
           } else if (typeof themeSidebar === 'object') {
-            return resolveMultiSidebar(themeSidebar, route.path, sidebarDepth)
+            return resolveMultiSidebar(
+              themeSidebar,
+              route.path,
+              headers,
+              sidebarDepth
+            )
           }
         }
       })
@@ -117,8 +122,19 @@ function resolveArraySidebar(
 function resolveMultiSidebar(
   config: DefaultTheme.MultiSideBarConfig,
   path: string,
+  headers: Header[],
   depth: number
 ): ResolvedSidebar {
+  const item = config[resolvePath(path)]
+
+  if (Array.isArray(item)) {
+    return resolveArraySidebar(item, depth)
+  }
+
+  if (item === 'auto') {
+    return resolveAutoSidebar(headers, depth)
+  }
+
   return []
 }
 

--- a/src/client/theme-default/utils.ts
+++ b/src/client/theme-default/utils.ts
@@ -27,7 +27,7 @@ export function normalize(path: string): string {
  * path is `/guide/getting-started.html`, this method will return `/guide/`.
  * Always with a trailing slash.
  */
-export function resolvePath(path: string): string {
+export function getPathDirName(path: string): string {
   const segments = path.split('/')
 
   if (segments[segments.length - 1]) {

--- a/src/client/theme-default/utils.ts
+++ b/src/client/theme-default/utils.ts
@@ -21,3 +21,22 @@ export function isActive(route: Route, path?: string): boolean {
 export function normalize(path: string): string {
   return decodeURI(path).replace(hashRE, '').replace(extRE, '')
 }
+
+/**
+ * get the path without filename (the last segment). for example, if the given
+ * path is `/guide/getting-started.html`, this method will return `/guide/`.
+ * Always with a trailing slash.
+ */
+export function resolvePath(path: string): string {
+  const segments = path.split('/')
+
+  if (segments[segments.length - 1]) {
+    segments.pop()
+  }
+
+  return ensureEndingSlash(segments.join('/'))
+}
+
+export function ensureEndingSlash(path: string): string {
+  return /(\.html|\/)$/.test(path) ? path : `${path}/`
+}


### PR DESCRIPTION
close #38 

This PR adds multi sidebar support. It does only support nesting array of objects as currently that is the only format supported by the array sidebar.

```js
{
  sidebar: {
    '/guide/': [
      { text: 'Getting Started', link: '/guide/getting-started' },
      ...
    ],

    '/guide/nested/': [
      { text: 'Nested Index', link: '/guide/nested/' },
      ...
    ],

    // Fallback supported too.
    '/': [
      { text: 'Index', link: '/' },
      { text: 'Root', link: '/root' }
    ]
  }
}
```

- `children` property in each object works as well.
- Active state of Navbar item is not working correctly. It needs to compare correct path but thinking to create another PR for it.
- URL without trailing slash acts differently than VuePress. Currently, if we access `/guide`, it renders `/guide.html`. If we access `/guide/`, it renders `/guide/index.html`. I'm leaving it as is for now but maybe we should have follow up PR for it...?

<img width="1392" alt="Screen Shot 2020-07-05 at 19 49 01" src="https://user-images.githubusercontent.com/3753672/86531175-08629000-befa-11ea-8b61-ac043a390500.png">
