### PR TITLE
feat: add prev/next links

### DIFF
--- a/src/client/theme-default/components/NextAndPrevLinks.ts
+++ b/src/client/theme-default/components/NextAndPrevLinks.ts
@@ -1,0 +1,22 @@
+import { defineComponent, computed } from 'vue'
+import { usePageData } from 'vitepress'
+
+export default defineComponent({
+  setup() {
+    const pageData = usePageData()
+    const next = computed(() => {
+      return pageData.value.next
+    })
+    const prev = computed(() => {
+      return pageData.value.prev
+    })
+    const hasLinks = computed(() => {
+      return !!next || !!prev
+    })
+    return {
+      next,
+      prev,
+      hasLinks
+    }
+  }
+})

--- a/src/client/theme-default/components/NextAndPrevLinks.vue
+++ b/src/client/theme-default/components/NextAndPrevLinks.vue
@@ -1,0 +1,25 @@
+<template>
+  <div v-if="hasLinks" class="links-wrapper">
+    <div class="prev-link">
+      <div v-if="prev">
+      ← <a :href="prev.link">{{prev.text}}</a>
+      </div>
+    </div>
+    <div class="next-link">
+      <div v-if="next">
+      <a :href="next.link">{{next.text}}</a> →
+      </div>
+    </div>
+  </div>
+</template>
+
+<script src="./NextAndPrevLinks"></script>
+
+<style>
+.links-wrapper {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+}
+</style>

--- a/src/client/theme-default/components/Page.vue
+++ b/src/client/theme-default/components/Page.vue
@@ -1,8 +1,16 @@
 <template>
   <div class="content">
     <Content />
+    <NextAndPrevLinks />
   </div>
 </template>
+
+<script>
+import NextAndPrevLinks from './NextAndPrevLinks.vue'
+export default {
+  components:{ NextAndPrevLinks }
+}
+</script>
 
 <style>
 .content {

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -106,7 +106,7 @@ function createVitePressPlugin({
 
         const pageDataWithLinks = {
           ...pageData,
-          ...getNextAndPrev(siteData.themeConfig.sidebar, ctx.path)
+          ...getNextAndPrev(siteData.themeConfig, ctx.path)
         }
         await next()
 
@@ -131,7 +131,11 @@ function createVitePressPlugin({
   }
 }
 
-function getNextAndPrev(sidebar: { [key: string]: any }, pagePath: string) {
+function getNextAndPrev(themeConfig: any, pagePath: string) {
+  if (!themeConfig.sidebar) {
+    return
+  }
+  const sidebar = themeConfig.sidebar
   let candidates: { text: string; link: string }[] = []
   Object.keys(sidebar).forEach((k) => {
     if (!pagePath.startsWith(k)) {
@@ -149,12 +153,14 @@ function getNextAndPrev(sidebar: { [key: string]: any }, pagePath: string) {
 
   const path = pagePath.replace(/\.(md|html)$/, '')
   const currentLinkIndex = candidates.findIndex((v) => v.link === path)
+  const hideNextLink = themeConfig.nextLinks === false
+  const hidePrevLink = themeConfig.prevLinks === false
 
   return {
-    ...(currentLinkIndex !== -1
+    ...(currentLinkIndex !== -1 && !hideNextLink
       ? { next: candidates[currentLinkIndex + 1] }
       : {}),
-    ...(currentLinkIndex !== -1
+    ...(currentLinkIndex !== -1 && !hidePrevLink
       ? { prev: candidates[currentLinkIndex - 1] }
       : {})
   }

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -26,6 +26,8 @@ export interface PageData {
   frontmatter: Record<string, any>
   headers: Header[]
   lastUpdated: number
+  next?: { text: string; link: string }
+  prev?: { text: string; link: string }
 }
 
 export interface Header {


### PR DESCRIPTION
Resolve #43 

config file is [this](https://github.com/Spice-Z/vite-local-playground/blob/master/docs/.vitepress/config.js)!

<img width="1266" alt="スクリーンショット 2020-07-26 14 06 50" src="https://user-images.githubusercontent.com/15419227/88471919-47a85d80-cf49-11ea-8186-16905004ce17.png">

prev/next data generated from siteData's sidebar config are injected to pageData.
When `themeConfig.prevLinks` or`themeConfig.prevLinks` is explicitly set false, links are not shown.

Not supported frontmatter's customize yet 