### PR TITLE
fix: Don’t prevent the browser’s default behavior for modifier keys

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -98,6 +98,7 @@ export function createRouter(
           // only intercept inbound links
           if (
             target !== `_blank` &&
+            !(e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) &&
             protocol === currentUrl.protocol &&
             hostname === currentUrl.hostname
           ) {


### PR DESCRIPTION
The router seems to prevent the browser’s default behavior for modifier keys on link clicks. This PR changes the browser’s default behavior to take precedence when users are using modifier keys.