### PR TITLE
fix(sidebar): fix sidebar when you open a nested link

### DIFF
--- a/src/client/theme-default/components/SideBar.ts
+++ b/src/client/theme-default/components/SideBar.ts
@@ -129,7 +129,8 @@ function resolveMultiSidebar(
   headers: Header[],
   depth: number
 ): ResolvedSidebar {
-  const item = config[getPathDirName(path)]
+  const paths = [path, Object.keys(config)[0]]
+  const item = paths.map((x) => config[getPathDirName(x)]).find(Boolean)
 
   if (Array.isArray(item)) {
     return resolveArraySidebar(item, depth)


### PR DESCRIPTION
Note this will make an assumption that the first `config` key is the default sidebar.

Maybe we need to change to `/` instead of the "first" key