### PR TITLE
feat: add charset and viewport meta tags (#68)

### DIFF
--- a/src/client/app/composables/head.ts
+++ b/src/client/app/composables/head.ts
@@ -33,6 +33,14 @@ export function useUpdateHead(
     const pageTitle = pageData && pageData.title
     document.title = (pageTitle ? pageTitle + ` | ` : ``) + siteData.title
     updateHeadTags([
+      ['meta', { charset: 'utf-8' }],
+      [
+        'meta',
+        {
+          name: 'viewport',
+          content: 'width=device-width,initial-scale=1'
+        }
+      ],
       [
         'meta',
         {

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -56,6 +56,8 @@ export async function renderPage(
   const html = `
 <html lang="${siteData.lang}">
   <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>${pageData.title ? pageData.title + ` | ` : ``}${
     siteData.title
   }</title>


### PR DESCRIPTION
close #68

This PR adds `charset` and `viewport` meta tag to the `head`.

@antfu For the `src/client/app/composables/head.ts` change, I'm being bit lazy here but I'm kinda thinking this should be done in Vite rather than in VitePress. Like it would be nice if we can pass these meta tag settings through Vite config, or maybe VitePress could include these tags by default. What do you think? Or is is it possible already?