### PR TITLE
fix(prev/next link): fix logic to correspond with sidebar config change

### DIFF
--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -145,9 +145,14 @@ function getNextAndPrev(themeConfig: any, pagePath: string) {
       if (!sidebarItem.children) {
         return
       }
-      sidebarItem.children.forEach((candidate: any) => {
-        candidates.push(candidate)
-      })
+      sidebarItem.children.forEach(
+        (candidate: { text: string; link: string }) => {
+          candidates.push({
+            text: candidate.text,
+            link: convertToAbsolutePath(candidate.link)
+          })
+        }
+      )
     })
   })
 
@@ -164,6 +169,13 @@ function getNextAndPrev(themeConfig: any, pagePath: string) {
       ? { prev: candidates[currentLinkIndex - 1] }
       : {})
   }
+}
+
+function convertToAbsolutePath(path: string) {
+  if (!path.startsWith('/')) {
+    return `/${path}`
+  }
+  return path
 }
 
 export async function createServer(options: ServerConfig = {}) {


### PR DESCRIPTION
Now, all of prev/next link are not shown without each pages's frontmatter setting.
From https://github.com/vuejs/vitepress/pull/74, sidebar config path was changed.
Prev/Next link is generated from sidebar config, so some changes are needed.