### PR TITLE
feat(default-theme): native support for carbon ads

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -60,7 +60,10 @@ function getConfigSidebar() {
   return [
     {
       text: 'App Config',
-      children: [{ text: 'Basics', link: '/config/basics' }]
+      children: [
+        { text: 'Basics', link: '/config/basics' },
+        { text: 'Carbon Ads', link: '/config/carbon-ads' }
+      ]
     }
   ]
 }

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -7,15 +7,15 @@ module.exports = {
     repo: 'vuejs/vitepress',
     docsDir: 'docs',
 
+    editLinks: true,
+    editLinkText: 'Edit this page on GitHub',
+    lastUpdated: 'Last Updated',
+
     carbonAds: {
       carbon: 'CEBDT27Y',
       custom: 'CKYD62QM',
       placement: 'vuejsorg'
     },
-
-    editLinks: true,
-    editLinkText: 'Edit this page on GitHub',
-    lastUpdated: 'Last Updated',
 
     nav: [
       { text: 'Guide', link: '/' },

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -7,6 +7,12 @@ module.exports = {
     repo: 'vuejs/vitepress',
     docsDir: 'docs',
 
+    carbonAds: {
+      carbon: 'CEBDT27Y',
+      custom: 'CKYD62QM',
+      placement: 'vuejsorg'
+    },
+
     editLinks: true,
     editLinkText: 'Edit this page on GitHub',
     lastUpdated: 'Last Updated',

--- a/docs/config/carbon-ads.md
+++ b/docs/config/carbon-ads.md
@@ -1,0 +1,13 @@
+# Carbon Ads
+
+VitePress has built in native support for [Carbon Ads](https://www.carbonads.net). By defining the Carbon Ads credentials in config, VitePress will display ads on the page.
+
+```js
+module.exports = {
+  carbonAds: {
+    carbon: 'your-carbon-key',
+    custom: 'your-carbon-custom',
+    placement: 'your-carbon-placement'
+  }
+}
+```

--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -34,10 +34,24 @@
     <main v-else>
       <Page>
         <template #top>
-          <slot name="page-top" />
+          <slot name="page-top">
+            <CarbonAds
+              v-if="$site.themeConfig.carbonAds"
+              :key="'carbon' + $page.path"
+              :code="$site.themeConfig.carbonAds.carbon"
+              :placement="$site.themeConfig.carbonAds.placement"
+            />
+          </slot>
         </template>
         <template #bottom>
-          <slot name="page-bottom" />
+          <slot name="page-bottom">
+            <BuySellAds
+              v-if="$site.themeConfig.carbonAds"
+              :key="'custom' + $page.path"
+              :code="$site.themeConfig.carbonAds.custom"
+              :placement="$site.themeConfig.carbonAds.placement"
+            />
+          </slot>
         </template>
       </Page>
     </main>
@@ -53,6 +67,8 @@ import ToggleSideBarButton from './components/ToggleSideBarButton.vue'
 import SideBar from './components/SideBar.vue'
 import Page from './components/Page.vue'
 import { useRoute, useSiteData, useSiteDataByRoute } from 'vitepress'
+import CarbonAds from './components/CarbonAds.vue'
+import BuySellAds from './components/BuySellAds.vue'
 
 const route = useRoute()
 const siteData = useSiteData()

--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -34,7 +34,7 @@
     <main v-else>
       <Page>
         <template #top>
-          <slot name="page-top">
+          <slot name="page-top-ads">
             <CarbonAds
               v-if="$site.themeConfig.carbonAds"
               :key="'carbon' + $page.path"
@@ -42,9 +42,11 @@
               :placement="$site.themeConfig.carbonAds.placement"
             />
           </slot>
+          <slot name="page-top" />
         </template>
         <template #bottom>
-          <slot name="page-bottom">
+          <slot name="page-bottom" />
+          <slot name="page-bottom-ads">
             <BuySellAds
               v-if="$site.themeConfig.carbonAds"
               :key="'custom' + $page.path"

--- a/src/client/theme-default/components/BuySellAds.vue
+++ b/src/client/theme-default/components/BuySellAds.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="bsa-cpc-wrapper">
+    <div class="bsa-cpc"></div>
+  </div>
+</template>
+
+<script>
+import { onMounted } from 'vue'
+
+/* global _bsa */
+const ID = 'bsa-cpc-script'
+
+export default {
+  name: 'BuySellAds',
+  props: {
+    code: {
+      type: String,
+      required: true,
+    },
+    placement: {
+      type: String,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    function load() {
+      if (typeof _bsa !== 'undefined' && _bsa) {
+        _bsa.init('default', props.code, `placement:${props.placement}`, {
+          target: '.bsa-cpc',
+          align: 'horizontal',
+          disable_css: 'true',
+        })
+      }
+    }
+
+    onMounted(() => {
+      if (!document.getElementById(ID)) {
+        const s = document.createElement('script')
+        s.id = ID
+        s.src = `//m.servedby-buysellads.com/monetization.js`
+        document.head.appendChild(s)
+        s.onload = () => {
+          load()
+        }
+      } else {
+        load()
+      }
+    })
+  },
+}
+</script>
+
+<style>
+.bsa-cpc-wrapper {
+  font-size: 0.95rem;
+  /* from Page.vue */
+  max-width: 50rem;
+  margin: 0px auto;
+  padding: 1rem 2rem 0;
+  margin-bottom: -1rem;
+}
+
+@media (max-width: 419px) {
+  .bsa-cpc-wrapper {
+    padding: 0 1.5rem;
+  }
+}
+
+.bsa-cpc {
+  font-size: 0.9em;
+  background-color: #f8f8f8;
+  border-radius: 6px;
+}
+
+.bsa-cpc .default-text {
+  display: inline;
+}
+
+.bsa-cpc a._default_ {
+  text-align: left;
+  display: block;
+  text-decoration: none;
+  padding: 10px 15px 12px;
+  margin-bottom: 20px;
+  color: #666;
+  font-weight: 400;
+  line-height: 18px;
+}
+
+.bsa-cpc a._default_ .default-image img {
+  height: 20px;
+  border-radius: 3px;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+}
+
+.bsa-cpc a._default_ .default-title {
+  font-weight: 600;
+}
+
+.bsa-cpc a._default_ .default-description:after {
+  font-size: 0.85em;
+  content: 'Sponsored';
+  color: #1c90f3;
+  border: 1px solid #1c90f3;
+  border-radius: 3px;
+  padding: 0 4px 1px;
+  margin-left: 6px;
+}
+
+.bsa-cpc .default-ad {
+  display: none;
+}
+
+.bsa-cpc a._default_ .default-image,
+.bsa-cpc a._default_ .default-title,
+.bsa-cpc a._default_ .default-description {
+  display: inline;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+</style>

--- a/src/client/theme-default/components/BuySellAds.vue
+++ b/src/client/theme-default/components/BuySellAds.vue
@@ -1,18 +1,18 @@
 <template>
-  <div class="bsa-cpc-wrapper">
-    <div class="bsa-cpc"></div>
+  <div class="buy-sell-ads">
+    <div class="bsa-cpc" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { defineProps, onMounted } from 'vue'
 
-/* global _bsa */
+// global _bsa
 const ID = 'bsa-cpc-script'
-const { code, placement } = defineProps<{ code: string; placement: string }>()
 
 declare global {
   var _bsa: BSA | undefined
+
   interface BSA {
     init(
       name: string,
@@ -27,6 +27,26 @@ declare global {
   }
 }
 
+const { code, placement } = defineProps<{
+  code: string
+  placement: string
+}>()
+
+onMounted(() => {
+  if (!document.getElementById(ID)) {
+    const s = document.createElement('script')
+
+    s.id = ID
+    s.src = '//m.servedby-buysellads.com/monetization.js'
+
+    document.head.appendChild(s)
+
+    s.onload = () => { load() }
+  } else {
+    load()
+  }
+})
+
 function load() {
   if (typeof _bsa !== 'undefined' && _bsa) {
     _bsa.init('default', code, `placement:${placement}`, {
@@ -36,90 +56,91 @@ function load() {
     })
   }
 }
-
-onMounted(() => {
-  if (!document.getElementById(ID)) {
-    const s = document.createElement('script')
-    s.id = ID
-    s.src = `//m.servedby-buysellads.com/monetization.js`
-    document.head.appendChild(s)
-    s.onload = () => {
-      load()
-    }
-  } else {
-    load()
-  }
-})
 </script>
 
-<style>
-.bsa-cpc-wrapper {
-  font-size: 0.95rem;
-  /* from Page.vue */
-  max-width: 50rem;
-  margin: 0px auto;
-  padding: 1rem 2rem 0;
-  margin-bottom: -1rem;
-}
-
-@media (max-width: 419px) {
-  .bsa-cpc-wrapper {
-    padding: 0 1.5rem;
-  }
+<style scoped>
+.buy-sell-ads {
+  margin: 0 auto;
+  padding-top: 2rem;
+  font-size: .85rem;
 }
 
 .bsa-cpc {
-  font-size: 0.9em;
-  background-color: #f8f8f8;
   border-radius: 6px;
+  background-color: #f8f8f8;
 }
 
-.bsa-cpc .default-text {
-  display: inline;
-}
-
-.bsa-cpc a._default_ {
-  text-align: left;
-  display: block;
-  text-decoration: none;
-  padding: 10px 15px 12px;
+.bsa-cpc ::v-deep(a._default_) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
   margin-bottom: 20px;
-  color: #666;
+  padding: 12px;
+  text-decoration: none;
+  line-height: 1.4;
   font-weight: 400;
-  line-height: 18px;
+  color: var(--c-text-light);
 }
 
-.bsa-cpc a._default_ .default-image img {
-  height: 20px;
-  border-radius: 3px;
-  vertical-align: middle;
-  position: relative;
-  top: -1px;
+@media (min-width: 512px) {
+  .bsa-cpc ::v-deep(a._default_) {
+    flex-wrap: nowrap;
+  }
 }
 
-.bsa-cpc a._default_ .default-title {
-  font-weight: 600;
-}
-
-.bsa-cpc a._default_ .default-description:after {
-  font-size: 0.85em;
-  content: 'Sponsored';
-  color: #1c90f3;
-  border: 1px solid #1c90f3;
-  border-radius: 3px;
-  padding: 0 4px 1px;
-  margin-left: 6px;
-}
-
-.bsa-cpc .default-ad {
+.bsa-cpc ::v-deep(.default-ad) {
   display: none;
 }
 
-.bsa-cpc a._default_ .default-image,
-.bsa-cpc a._default_ .default-title,
-.bsa-cpc a._default_ .default-description {
-  display: inline;
+.bsa-cpc ::v-deep(a._default_ .default-image) {
+  flex-shrink: 0;
+  margin-right: 12px;
+  width: 24px;
+}
+
+.bsa-cpc ::v-deep(a._default_ .default-image img) {
+  border-radius: 4px;
+  height: 24px;
   vertical-align: middle;
-  margin-right: 6px;
+}
+
+.bsa-cpc ::v-deep(._default_::after) {
+  border: 1px solid #1c90f3;
+  border-radius: 4px;
+  margin-top: 8px;
+  margin-left: 36px;
+  padding: 0 8px;
+  line-height: 22px;
+  font-size: .85em;
+  font-weight: 500;
+  color: #1c90f3;
+  content: 'Sponsored';
+}
+
+@media (min-width: 512px) {
+  .bsa-cpc ::v-deep(._default_::after) {
+    margin-top: 0px;
+    margin-left: 12px;
+  }
+}
+
+.bsa-cpc ::v-deep(.default-text) {
+  flex-grow: 1;
+  align-self: center;
+  width: calc(100% - 36px);
+}
+
+@media (min-width: 512px) {
+  .bsa-cpc ::v-deep(.default-text) {
+    width: auto;
+  }
+}
+
+.bsa-cpc ::v-deep(.default-title) {
+  font-weight: 600;
+}
+
+.bsa-cpc ::v-deep(.default-description) {
+  padding-left: 8px;
 }
 </style>

--- a/src/client/theme-default/components/BuySellAds.vue
+++ b/src/client/theme-default/components/BuySellAds.vue
@@ -15,12 +15,12 @@ export default {
   props: {
     code: {
       type: String,
-      required: true,
+      required: true
     },
     placement: {
       type: String,
-      required: true,
-    },
+      required: true
+    }
   },
 
   setup(props) {
@@ -29,7 +29,7 @@ export default {
         _bsa.init('default', props.code, `placement:${props.placement}`, {
           target: '.bsa-cpc',
           align: 'horizontal',
-          disable_css: 'true',
+          disable_css: 'true'
         })
       }
     }
@@ -47,7 +47,7 @@ export default {
         load()
       }
     })
-  },
+  }
 }
 </script>
 

--- a/src/client/theme-default/components/BuySellAds.vue
+++ b/src/client/theme-default/components/BuySellAds.vue
@@ -4,51 +4,52 @@
   </div>
 </template>
 
-<script>
-import { onMounted } from 'vue'
+<script setup lang="ts">
+import { defineProps, onMounted } from 'vue'
 
 /* global _bsa */
 const ID = 'bsa-cpc-script'
+const { code, placement } = defineProps<{ code: string; placement: string }>()
 
-export default {
-  name: 'BuySellAds',
-  props: {
-    code: {
-      type: String,
-      required: true
-    },
-    placement: {
-      type: String,
-      required: true
-    }
-  },
-
-  setup(props) {
-    function load() {
-      if (typeof _bsa !== 'undefined' && _bsa) {
-        _bsa.init('default', props.code, `placement:${props.placement}`, {
-          target: '.bsa-cpc',
-          align: 'horizontal',
-          disable_css: 'true'
-        })
+declare global {
+  var _bsa: BSA | undefined
+  interface BSA {
+    init(
+      name: string,
+      code: string,
+      placement: string,
+      options: {
+        target: string
+        align: string
+        disable_css?: 'true' | 'false'
       }
-    }
+    ): void
+  }
+}
 
-    onMounted(() => {
-      if (!document.getElementById(ID)) {
-        const s = document.createElement('script')
-        s.id = ID
-        s.src = `//m.servedby-buysellads.com/monetization.js`
-        document.head.appendChild(s)
-        s.onload = () => {
-          load()
-        }
-      } else {
-        load()
-      }
+function load() {
+  if (typeof _bsa !== 'undefined' && _bsa) {
+    _bsa.init('default', code, `placement:${placement}`, {
+      target: '.bsa-cpc',
+      align: 'horizontal',
+      disable_css: 'true'
     })
   }
 }
+
+onMounted(() => {
+  if (!document.getElementById(ID)) {
+    const s = document.createElement('script')
+    s.id = ID
+    s.src = `//m.servedby-buysellads.com/monetization.js`
+    document.head.appendChild(s)
+    s.onload = () => {
+      load()
+    }
+  } else {
+    load()
+  }
+})
 </script>
 
 <style>

--- a/src/client/theme-default/components/CarbonAds.vue
+++ b/src/client/theme-default/components/CarbonAds.vue
@@ -36,15 +36,14 @@ export default {
 <style>
 .carbon-ads {
   min-height: 102px;
-  padding: 1.5rem 1.5rem 0;
   font-size: 0.75rem;
 
-  width: 125px;
+  width: 130px;
   position: fixed;
   z-index: 19;
   bottom: 0;
   right: 22px;
-  padding: 10px;
+  margin: 10px;
 }
 
 @media screen and (max-width: 425px) {
@@ -59,9 +58,9 @@ export default {
     z-index: 1;
     position: relative;
     top: 12px;
-    right: 20px;
+    right: 0;
     float: right;
-    padding: 0 0 20px 30px;
+    margin: 0 0 20px 30px;
   }
 }
 

--- a/src/client/theme-default/components/CarbonAds.vue
+++ b/src/client/theme-default/components/CarbonAds.vue
@@ -40,7 +40,7 @@ export default {
 
   width: 130px;
   position: fixed;
-  z-index: 19;
+  z-index: 1;
   bottom: 0;
   right: 22px;
   margin: 10px;
@@ -55,7 +55,6 @@ export default {
 
 @media screen and (max-width: 1300px) {
   .carbon-ads {
-    z-index: 1;
     position: relative;
     top: 12px;
     right: 0;

--- a/src/client/theme-default/components/CarbonAds.vue
+++ b/src/client/theme-default/components/CarbonAds.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="carbon-ads" ref="el"></div>
+  <div class="carbon-ads" ref="el" />
 </template>
 
 <script setup lang="ts">
-import { defineProps, onMounted, ref } from 'vue'
+import { defineProps, ref, onMounted } from 'vue'
 
 const { code, placement } = defineProps<{
   code: string
@@ -20,62 +20,83 @@ onMounted(() => {
 })
 </script>
 
-<style>
+<style scoped>
 .carbon-ads {
-  min-height: 102px;
-  font-size: 0.75rem;
-
-  width: 130px;
-  position: fixed;
-  z-index: 1;
-  bottom: 0;
-  right: 22px;
-  margin: 10px;
+  padding: 1.75rem 0 0;
+  border-radius: 4px;
+  margin: 0 auto;
+  max-width: 280px;
+  font-size: .75rem;
+  background-color: rgba(255, 255, 255, .8);
 }
 
-@media screen and (max-width: 425px) {
-  .carbon-ads {
-    width: auto;
-    right: 0;
-  }
+.carbon-ads::after {
+  clear: both;
+  display: block;
+  content: "";
 }
 
-@media screen and (max-width: 1300px) {
+@media (min-width: 420px) {
   .carbon-ads {
     position: relative;
-    top: 12px;
-    right: 0;
+    right: -8px;
+    z-index: 1;
     float: right;
-    margin: 0 0 20px 30px;
+    margin: -8px -8px 24px 24px;
+    padding: 8px;
+    width: 146px;
+    max-width: 100%;
   }
 }
 
-.carbon-ads a {
-  color: #444;
-  font-weight: normal;
-  display: inline;
+@media (min-width: 1400px) {
+  .carbon-ads {
+    position: fixed;
+    top: auto;
+    right: 8px;
+    bottom: 8px;
+    float: none;
+    margin: 0;
+  }
 }
 
-.carbon-ads .carbon-img {
+.carbon-ads ::v-deep(.carbon-img) {
   float: left;
-  margin-right: 1rem;
-  border: 1px solid var(--border-color);
+  margin-right: .75rem;
+  max-width: 100px;
+  border: 1px solid var(--c-divider);
 }
 
-.carbon-ads .carbon-img img {
-  display: block;
-}
-
-.carbon-ads .carbon-poweredby {
-  color: #999;
-  display: block;
-  margin-top: 0.5em;
-}
-
-@media (max-width: 719px) {
-  .carbon-ads .carbon-img img {
-    width: 100px;
-    height: 77px;
+@media (min-width: 420px) {
+  .carbon-ads ::v-deep(.carbon-img) {
+    float: none;
+    display: block;
+    margin-right: 0;
+    max-width: 130px;
   }
+}
+
+.carbon-ads ::v-deep(.carbon-img img) {
+  display: block;
+  width: 100%;
+}
+
+@media (min-width: 420px) {
+  .carbon-ads ::v-deep(.carbon-text) {
+    padding-top: 8px;
+  }
+}
+
+.carbon-ads ::v-deep(.carbon-text) {
+  display: block;
+  font-weight: 400;
+  color: var(--c-text-light);
+}
+
+.carbon-ads ::v-deep(.carbon-poweredby) {
+  display: block;
+  padding-top: 2px;
+  font-weight: 400;
+  color: var(--c-text-lighter);
 }
 </style>

--- a/src/client/theme-default/components/CarbonAds.vue
+++ b/src/client/theme-default/components/CarbonAds.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="carbon-ads" ref="el"></div>
+</template>
+
+<script>
+import { onMounted, ref } from 'vue'
+
+export default {
+  name: 'CarbonAds',
+  props: {
+    code: {
+      type: String,
+      required: true,
+    },
+    placement: {
+      type: String,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    const el = ref()
+
+    onMounted(() => {
+      const s = document.createElement('script')
+      s.id = '_carbonads_js'
+      s.src = `//cdn.carbonads.com/carbon.js?serve=${props.code}&placement=${props.placement}`
+      el.value.appendChild(s)
+    })
+
+    return { el }
+  },
+}
+</script>
+
+<style>
+.carbon-ads {
+  min-height: 102px;
+  padding: 1.5rem 1.5rem 0;
+  font-size: 0.75rem;
+
+  width: 125px;
+  position: fixed;
+  z-index: 19;
+  bottom: 0;
+  right: 22px;
+  padding: 10px;
+}
+
+@media screen and (max-width: 425px) {
+  .carbon-ads {
+    width: auto;
+    right: 0;
+  }
+}
+
+@media screen and (max-width: 1300px) {
+  .carbon-ads {
+    z-index: 1;
+    position: relative;
+    top: 12px;
+    right: 20px;
+    float: right;
+    padding: 0 0 20px 30px;
+  }
+}
+
+.carbon-ads a {
+  color: #444;
+  font-weight: normal;
+  display: inline;
+}
+
+.carbon-ads .carbon-img {
+  float: left;
+  margin-right: 1rem;
+  border: 1px solid var(--border-color);
+}
+
+.carbon-ads .carbon-img img {
+  display: block;
+}
+
+.carbon-ads .carbon-poweredby {
+  color: #999;
+  display: block;
+  margin-top: 0.5em;
+}
+
+@media (max-width: 719px) {
+  .carbon-ads .carbon-img img {
+    width: 100px;
+    height: 77px;
+  }
+}
+</style>

--- a/src/client/theme-default/components/CarbonAds.vue
+++ b/src/client/theme-default/components/CarbonAds.vue
@@ -10,12 +10,12 @@ export default {
   props: {
     code: {
       type: String,
-      required: true,
+      required: true
     },
     placement: {
       type: String,
-      required: true,
-    },
+      required: true
+    }
   },
 
   setup(props) {
@@ -29,7 +29,7 @@ export default {
     })
 
     return { el }
-  },
+  }
 }
 </script>
 

--- a/src/client/theme-default/components/CarbonAds.vue
+++ b/src/client/theme-default/components/CarbonAds.vue
@@ -2,35 +2,22 @@
   <div class="carbon-ads" ref="el"></div>
 </template>
 
-<script>
-import { onMounted, ref } from 'vue'
+<script setup lang="ts">
+import { defineProps, onMounted, ref } from 'vue'
 
-export default {
-  name: 'CarbonAds',
-  props: {
-    code: {
-      type: String,
-      required: true
-    },
-    placement: {
-      type: String,
-      required: true
-    }
-  },
+const { code, placement } = defineProps<{
+  code: string
+  placement: string
+}>()
 
-  setup(props) {
-    const el = ref()
+const el = ref()
 
-    onMounted(() => {
-      const s = document.createElement('script')
-      s.id = '_carbonads_js'
-      s.src = `//cdn.carbonads.com/carbon.js?serve=${props.code}&placement=${props.placement}`
-      el.value.appendChild(s)
-    })
-
-    return { el }
-  }
-}
+onMounted(() => {
+  const s = document.createElement('script')
+  s.id = '_carbonads_js'
+  s.src = `//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+  el.value.appendChild(s)
+})
 </script>
 
 <style>

--- a/src/client/theme-default/styles/custom-blocks.css
+++ b/src/client/theme-default/styles/custom-blocks.css
@@ -4,6 +4,7 @@
   margin: 1rem 0;
   border-left: .5rem solid;
   padding: .1rem 1.5rem;
+  overflow-x: auto;
 }
 
 .custom-block.tip {

--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -13,6 +13,7 @@
 
   --c-text-light-1: #2c3e50;
   --c-text-light-2: #476582;
+  --c-text-light-3: #90a4b7;
 
   --c-brand: #3eaf7c;
   --c-brand-light: #4abf8a;
@@ -45,6 +46,7 @@
 
   --c-text: var(--c-text-light-1);
   --c-text-light: var(--c-text-light-2);
+  --c-text-lighter: var(--c-text-light-3);
 
   --c-bg: var(--c-white);
 


### PR DESCRIPTION
I also added the existing slots sidebar-top/bottom and page-top/bottom because I used them to add the ads components. To make them work and test them, you need to add this config to the `themeConfig`:

```js
    carbonAds: {
      carbon: 'CEBICK3I',
      custom: 'CEBICK3M',
      placement: 'routervuejsorg',
    },
```

