### PR TITLE
feat: allow passing googleAnalytics option

### DIFF
--- a/src/client/theme-default/ga.ts
+++ b/src/client/theme-default/ga.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import { watchEffect } from 'vue'
+import { Router } from '/@app/router'
+
+export function installGoogleAnalytics(gaId: string, router: Router) {
+  ;(function (i, s, o, g, r, a, m) {
+    i['GoogleAnalyticsObject'] = r
+    i[r] =
+      i[r] ||
+      function () {
+        ;(i[r].q = i[r].q || []).push(arguments)
+      }
+    i[r].l = 1 * new Date()
+    a = s.createElement(o)
+    m = s.getElementsByTagName(o)[0]
+    a.async = 1
+    a.src = g
+    m.parentNode.insertBefore(a, m)
+  })(
+    window,
+    document,
+    'script',
+    'https://www.google-analytics.com/analytics.js',
+    'ga'
+  )
+
+  ga('create', gaId, 'auto')
+  ga('set', 'anonymizeIp', true)
+
+  watchEffect(() => {
+    // console.log('sending', router.route.path)
+    ga('set', 'page', router.route.path)
+    ga('send', 'pageview')
+  })
+}

--- a/src/client/theme-default/index.ts
+++ b/src/client/theme-default/index.ts
@@ -6,10 +6,21 @@ import './styles/custom-blocks.css'
 import Layout from './Layout.vue'
 import NotFound from './NotFound.vue'
 import { Theme } from '../app/theme'
+import { installGoogleAnalytics } from './ga'
 
 const theme: Theme = {
   Layout,
-  NotFound
+  NotFound,
+  enhanceApp({ router, siteData }) {
+    const { googleAnalytics: GA_ID } = siteData.value.themeConfig
+    if (
+      GA_ID &&
+      process.env.NODE_ENV !== 'production' &&
+      typeof window !== 'undefined'
+    ) {
+      installGoogleAnalytics(GA_ID, router)
+    }
+  }
 }
 
 export default theme

--- a/src/client/theme-default/index.ts
+++ b/src/client/theme-default/index.ts
@@ -15,7 +15,7 @@ const theme: Theme = {
     const { googleAnalytics: GA_ID } = siteData.value.themeConfig
     if (
       GA_ID &&
-      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV === 'production' &&
       typeof window !== 'undefined'
     ) {
       installGoogleAnalytics(GA_ID, router)


### PR DESCRIPTION
Allows passing `googleAnalytics: '<id>'` to the `themeConfig` option on the default theme.

I'm starting to think I should group this PR, #86 and another PR for Algolia search into a different vue theme. What do you think?