### PR TITLE
feat(i18n): nav dropdown language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # (WIP) VitePress 📝💨
 
+[![npm](https://img.shields.io/npm/v/vitepress)](https://www.npmjs.com/package/vitepress)
+
 > [VuePress](http://vuepress.vuejs.org/)' little brother, built on top of [vite](https://github.com/vuejs/vite)
 
 **Note this is early WIP! Currently the focus is on making Vite stable and feature complete first. It is not recommended to use this for anything serious yet.**

--- a/src/client/theme-default/components/NavBarLinks.ts
+++ b/src/client/theme-default/components/NavBarLinks.ts
@@ -44,6 +44,9 @@ export default {
 
     const localeCandidates = computed(() => {
       const locales = siteData.value.themeConfig.locales
+      if (!locales) {
+        return null
+      }
       const localeKeys = Object.keys(locales)
       if (localeKeys.length <= 1) {
         return null

--- a/src/client/theme-default/components/NavBarLinks.ts
+++ b/src/client/theme-default/components/NavBarLinks.ts
@@ -1,5 +1,5 @@
 import { computed } from 'vue'
-import { useSiteData, useSiteDataByRoute } from 'vitepress'
+import { useSiteData, useSiteDataByRoute, useRoute } from 'vitepress'
 import NavBarLink from './NavBarLink.vue'
 import NavDropdownLink from './NavDropdownLink.vue'
 import { DefaultTheme } from '../config'
@@ -17,6 +17,7 @@ export default {
   setup() {
     const siteDataByRoute = useSiteDataByRoute()
     const siteData = useSiteData()
+    const route = useRoute()
     const repoInfo = computed(() => {
       const theme = siteData.value.themeConfig as DefaultTheme.Config
       const repo = theme.docsRepo || theme.repo
@@ -40,6 +41,32 @@ export default {
       }
       return null
     })
+
+    const localeCandidates = computed(() => {
+      const localeKeys = Object.keys(siteData.value.locales)
+      const currentLangBase = localeKeys.find((v) => {
+        if (v === '/') {
+          return false
+        }
+        return route.path.startsWith(v)
+      })
+      const currentContentPath = currentLangBase
+        ? route.path.substring(currentLangBase.length - 1)
+        : route.path
+      const candidates = localeKeys.map((v) => {
+        return {
+          text:
+            siteData.value.locales[v].label || siteData.value.locales[v].lang,
+          link: `${v}${currentContentPath}`
+        }
+      })
+      return {
+        // TODO i18n text
+        text: 'Languages',
+        items: candidates
+      }
+    })
+
     return {
       navData:
         process.env.NODE_ENV === 'production'
@@ -47,7 +74,8 @@ export default {
             siteDataByRoute.value.themeConfig.nav
           : // use computed in dev for hot reload
             computed(() => siteDataByRoute.value.themeConfig.nav),
-      repoInfo
+      repoInfo,
+      localeCandidates
     }
   }
 }

--- a/src/client/theme-default/components/NavBarLinks.ts
+++ b/src/client/theme-default/components/NavBarLinks.ts
@@ -44,6 +44,10 @@ export default {
 
     const localeCandidates = computed(() => {
       const localeKeys = Object.keys(siteData.value.locales)
+      if (localeKeys.length <= 1) {
+        return null
+      }
+
       const currentLangBase = localeKeys.find((v) => {
         if (v === '/') {
           return false

--- a/src/client/theme-default/components/NavBarLinks.ts
+++ b/src/client/theme-default/components/NavBarLinks.ts
@@ -43,7 +43,8 @@ export default {
     })
 
     const localeCandidates = computed(() => {
-      const localeKeys = Object.keys(siteData.value.locales)
+      const locales = siteData.value.themeConfig.locales
+      const localeKeys = Object.keys(locales)
       if (localeKeys.length <= 1) {
         return null
       }
@@ -59,15 +60,14 @@ export default {
         : route.path
       const candidates = localeKeys.map((v) => {
         return {
-          text:
-            siteData.value.locales[v].label || siteData.value.locales[v].lang,
+          text: locales[v].label || locales[v].lang,
           link: `${v}${currentContentPath}`
         }
       })
 
       const currentLangKey = currentLangBase ? currentLangBase : '/'
-      const selectText = siteData.value.locales[currentLangKey].selectText
-        ? siteData.value.locales[currentLangKey].selectText
+      const selectText = locales[currentLangKey].selectText
+        ? locales[currentLangKey].selectText
         : 'Languages'
       return {
         text: selectText,

--- a/src/client/theme-default/components/NavBarLinks.vue
+++ b/src/client/theme-default/components/NavBarLinks.vue
@@ -6,8 +6,8 @@
         <NavBarLink v-else :item="item" />
       </template>
     </template>
-    <NavBarLink v-if="repoInfo" :item="repoInfo" />
     <NavDropdownLink v-if="localeCandidates" :item="localeCandidates" />
+    <NavBarLink v-if="repoInfo" :item="repoInfo" />
   </nav>
 </template>
 

--- a/src/client/theme-default/components/NavBarLinks.vue
+++ b/src/client/theme-default/components/NavBarLinks.vue
@@ -7,6 +7,7 @@
       </template>
     </template>
     <NavBarLink v-if="repoInfo" :item="repoInfo" />
+    <NavDropdownLink v-if="localeCandidates" :item="localeCandidates" />
   </nav>
 </template>
 

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -2,6 +2,7 @@
 
 export interface LocaleConfig {
   lang: string
+  label?: string
   title?: string
   description?: string
   head?: HeadConfig[]


### PR DESCRIPTION
At https://github.com/vuejs/vitepress/pull/50, @antfu implemented i18n support, and said.

>The only thing left is nav dropdown, that would be another PR.

I created that!

![Oct-01-2020 20-42-52](https://user-images.githubusercontent.com/15419227/94805119-d2647780-0426-11eb-8672-72f52384d24f.gif)

Working config is like this

```
...
themeConfig: {
 locales: {
    '/': {
      label: 'English',
      selectText: 'Languages',
    },
    '/zh/': {
      label: '中文',
      selectText: '选择语言',
    },
    '/ja/': {
      label: '日本語',
      selectText: '言語,
    },
  },
}
```

(To set config about site title, description, and lang, you have to use global locale config. Check https://github.com/vuejs/vitepress/pull/50)