### PR TITLE
Add process.exit to stop build

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -53,4 +53,5 @@ export async function build(buildOptions: BuildOptions = {}) {
     await fs.remove(siteConfig.tempDir)
   }
   console.log('done.')
+  process.exit()
 }


### PR DESCRIPTION
For some reason my builds always kept running even though the 'done' message was shown. By adding process.exit() explicitly it was fix. 

This should not give any problems and will fix it there where necessary when done. 