### PR TITLE
fix: always set `base` to `/` in dev mode to avoid broken links

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -41,6 +41,13 @@ export async function resolveConfig(
   const userConfig = await resolveUserConfig(root)
   const site = await resolveSiteData(root)
 
+  // force base path to be `/` when it's running in a non-production
+  // environment. currently, it's hard to implement `base` feature while
+  // making it work with Vite HMR, and this is an easy workaround.
+  if (process.env.NODE_ENV !== 'production') {
+    site.base = '/'
+  }
+
   // resolve theme path
   const userThemeDir = resolve(root, 'theme')
   const themeDir = (await fs.pathExists(userThemeDir))


### PR DESCRIPTION
This PR makes `base` option to always be `/` when running in dev mode (`VitePress dev`).

Currently, when we have `base` path set, all of the links will have `base` prefixed, which is good, but server side can't handle it so it doesn't work. It gets 404.

I was able to fix the request to file handling by doing something like this.

```ts
if (ctx.path.endsWith('.md')) {
  let requestFilePath = ctx.path

  // If `base` option is set, remove it from requested file path.
  if (siteData.base !== '/') {
    const regex = new RegExp(`^${siteData.base}`)

    requestFilePath = ctx.path.replace(regex, '/')
  }

  const file = resolver.requestToFile(requestFilePath)

  if (!existsSync(file)) {
    return next()
  }
}
```

However, I just couldn't make it work with HMR 😢 And I just though well since `vitepress build` works perfectly right now, why don't we just ditch the `base` feature in dev mode. It's easier to access the URL in dev mode, since usually that is `https://localhost:3000`, and you don't have to do `https://localhost:3000/base/`