### PR TITLE
fix($theme-default): display header-anchor links when using keyboard navigation

### DIFF
--- a/src/client/theme-default/styles/layout.css
+++ b/src/client/theme-default/styles/layout.css
@@ -182,15 +182,22 @@ a.header-anchor {
   opacity: 0;
 }
 
+a.header-anchor:focus,
 a.header-anchor:hover {
   text-decoration: none;
 }
 
+h1:focus .header-anchor,
 h1:hover .header-anchor,
+h2:focus .header-anchor,
 h2:hover .header-anchor,
+h3:focus .header-anchor,
 h3:hover .header-anchor,
+h4:focus .header-anchor,
 h4:hover .header-anchor,
+h5:focus .header-anchor,
 h5:hover .header-anchor,
+h6:focus .header-anchor,
 h6:hover .header-anchor {
   opacity: 1;
 }


### PR DESCRIPTION
**a11y: When using keyboard navigation the header-anchor link (the **#** tag before the heading) is not visible, this PR fixies this bug.**

To recreate the issue, try navigating using you keyboard (with the `TAB` key) in a page with many `h1`-`h6` headings. You won't see the heading-anchor link (the **#** tag before the heading). But when you hover with your mouse over a heading you will see the heading-anchor link.

Why? because the code uses only `:hover` (for mouse users). It should also include `:focus` (for keyboard users).

The same PR accepted on vuePress, see https://github.com/vuejs/vuepress/pull/2699