### PR TITLE
Ensure that the base is used for previous and next links

### DIFF
--- a/src/client/theme-default/components/NextAndPrevLinks.vue
+++ b/src/client/theme-default/components/NextAndPrevLinks.vue
@@ -2,13 +2,13 @@
   <div v-if="hasLinks" class="next-and-prev-link">
     <div class="container">
       <div class="prev">
-        <a v-if="prev" class="link" :href="prev.link">
+        <a v-if="prev" class="link" :href="withBase(prev.link)">
           <ArrowLeft class="icon icon-prev" />
           <span class="text">{{ prev.text }}</span>
         </a>
       </div>
       <div class="next">
-        <a v-if="next" class="link" :href="next.link">
+        <a v-if="next" class="link" :href="withBase(next.link)">
           <span class="text">{{ next.text }}</span>
           <ArrowRight class="icon icon-next" />
         </a>
@@ -20,6 +20,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import { useNextAndPrevLinks } from '../composables/nextAndPrevLinks'
+import { withBase } from '../utils'
 import ArrowLeft from './icons/ArrowLeft.vue'
 import ArrowRight from './icons/ArrowRight.vue'
 
@@ -35,7 +36,8 @@ export default defineComponent({
     return {
       hasLinks,
       prev,
-      next
+      next,
+      withBase,
     }
   }
 })


### PR DESCRIPTION
### Description 📖 

This pull request fixes next and previous links in sites with a non-default `base` configuration.


### Background 📜 

#130 recently moved the previous and next page link calculation to the client side.

Because links used in the sidebar don't include the base, rendering them directly causes them to have an incorrect URL.