### PR TITLE
fix: code plugins styles

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,7 +28,7 @@ This section will help you build a basic VuePress documentation site from ground
 
 - **Step. 5:** Add some scripts to `package.json`.
 
-  ```json
+  ```json{3,5,7}
   {
     "scripts": {
       "docs:dev": "vitepress dev docs",

--- a/src/client/theme-default/styles/code.css
+++ b/src/client/theme-default/styles/code.css
@@ -1,6 +1,6 @@
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, Courier New, monospace;
-  font-size: 0.85em;
+  font-size: var(--code-font-size);
   color: var(--c-text-light);
   background-color: rgba(27, 31, 35, 0.05);
   padding: 0.25rem 0.5rem;
@@ -59,9 +59,9 @@ div[class*='language-'] {
 /* Line highlighting */
 
 .highlight-lines {
-  font-size: 0.9em;
+  font-size: var(--code-font-size);
   user-select: none;
-  padding-top: 1.3rem;
+  padding-top: var(--code-padding-vertical);
   position: absolute;
   top: 0;
   left: 0;
@@ -87,8 +87,8 @@ div[class*='language-'].line-numbers-mode {
   text-align: center;
   color: #888;
   line-height: 1.5;
-  font-size: 0.9em;
-  padding: 1.3rem 0;
+  font-size: var(--code-font-size);
+  padding: var(--code-padding-vertical) 0;
   border-right: 1px solid rgba(0,0,0,50%);
   z-index: 4;
 }

--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -1,4 +1,4 @@
-/** Base styles */
+/** Base Styles */
 :root {
 
   /**
@@ -34,8 +34,6 @@
    * --------------------------------------------------------------------- */
 
   --header-height: 3.6rem;
-  --code-font-size: 0.85em;
-  --code-padding-vertical: 1.5rem;
 }
 
 /** Fallback Styles */
@@ -48,6 +46,8 @@
 
   --c-bg: var(--c-white);
 
+  --code-padding-vertical: 1.5rem;
+  --code-font-size: .85em;
   --code-bg-color: #282c34;
 
 }

--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -34,6 +34,8 @@
    * --------------------------------------------------------------------- */
 
   --header-height: 3.6rem;
+  --code-font-size: 0.85em;
+  --code-padding-vertical: 1.5rem;
 }
 
 /** Fallback Styles */


### PR DESCRIPTION
Fixes font sizing and vertical padding styles for highlight lines and line numbers code plugins in the default theme

![highlight-lines-style-issue](https://user-images.githubusercontent.com/583075/100019644-ac33d600-2dde-11eb-8c87-cde81423fc55.PNG)

![line-numbers-issue](https://user-images.githubusercontent.com/583075/100019648-adfd9980-2dde-11eb-9404-ad301d12a010.PNG)

I added two new vars: `--code-font-size` and `--code-vertical-padding`. The vertical padding is only modifying the plugin's styles after this PR because it requires a bit of refactoring to make the code padding dynamic and I am not sure what is the best way to do it.

After the fix:

![code-after](https://user-images.githubusercontent.com/583075/100019653-b05ff380-2dde-11eb-9cf4-403a5d20b3c2.PNG)
