### PR TITLE
fix: mixed rgba colors for md code plugins

### DIFF
--- a/src/client/theme-default/styles/code.css
+++ b/src/client/theme-default/styles/code.css
@@ -70,7 +70,7 @@ div[class*='language-'] {
 }
 
 .highlight-lines .highlighted {
-  background-color: rgba(0, 0, 0, 66%);
+  background-color: rgba(0, 0, 0, 0.66);
 }
 
 /* Line numbers mode */
@@ -89,7 +89,7 @@ div[class*='language-'].line-numbers-mode {
   line-height: 1.5;
   font-size: 0.9em;
   padding: 1.3rem 0;
-  border-right: 1px solid rgba(0,0,0,50%);
+  border-right: 1px solid rgba(0,0,0,0.5);
   z-index: 4;
 }
 


### PR DESCRIPTION
Using `rgba(0,0,0,50%)` was working in dev but it was converted to an invalid color `rgba(0,0%,0%,50%)` when building so the highlighted lines were not visible 

![invalid-color](https://user-images.githubusercontent.com/583075/100023657-a7beeb80-2de5-11eb-9533-019d50340be1.PNG)

Switching to a number for alpha (as it is in other rgba values in the css) fixes the issue.

I do not know if `rgba(0,0,0,50%)` is a valid color to be supported, I looked a bit and this conversion doesn't seem to be the responsibility of vitepress.