### PR TITLE
docs: port formatter guide from vuepress

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -38,6 +38,7 @@ function getGuideSidebar() {
         { text: 'Configuration', link: '/guide/configuration' },
         { text: 'Markdown Extensions', link: '/guide/markdown' },
         { text: 'Customization', link: '/guide/customization' },
+        { text: 'Frontmatter', link: '/guide/frontmatter' },
         { text: 'Deploying', link: '/guide/deploy' }
       ]
     }

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -37,8 +37,8 @@ function getGuideSidebar() {
         { text: 'Getting Started', link: '/guide/getting-started' },
         { text: 'Configuration', link: '/guide/configuration' },
         { text: 'Markdown Extensions', link: '/guide/markdown' },
-        { text: 'Customization', link: '/guide/customization' },
         { text: 'Frontmatter', link: '/guide/frontmatter' },
+        { text: 'Customization', link: '/guide/customization' },
         { text: 'Deploying', link: '/guide/deploy' }
       ]
     }

--- a/docs/guide/frontmatter.md
+++ b/docs/guide/frontmatter.md
@@ -2,7 +2,7 @@
 
 Any Markdown file that contains a YAML frontmatter block will be processed by [gray-matter](https://github.com/jonschlinkert/gray-matter). The frontmatter must be at the top of the Markdown file, and must take the form of valid YAML set between triple-dashed lines. Example:
 
-```markdown
+```md
 ---
 title: Docs with VitePress
 editLink: true
@@ -13,7 +13,7 @@ Between the triple-dashed lines, you can set [predefined variables](#predefined-
 
 Here’s an example of how you could use it in your Markdown file:
 
-```markdown
+```md
 ---
 title: Docs with VitePress
 editLink: true
@@ -26,13 +26,13 @@ Guide content
 
 ## Alternative frontmatter Formats
 
-VuePress also supports JSON frontmatter syntax, starting and ending in curly braces:
+VitePress also supports JSON frontmatter syntax, starting and ending in curly braces:
 
-```
+```json
 ---
 {
   "title": "Blogging Like a Hacker",
-  "editLink": "true"
+  "editLink": true
 }
 ---
 ```
@@ -63,10 +63,7 @@ head:
     - name: keywords
       content: super duper SEO
 ---
-
 ```
-
-## Predefined Variables Powered By Default Theme
 
 ### navbar
 
@@ -85,6 +82,6 @@ You can decide to show the sidebar on a specific page with `sidebar: auto` or di
 ### editLink
 
 - Type: `boolean`
-- Default: `siteData.editLinks`
+- Default: `undefined`
 
 Define if this page should include an edit link.

--- a/docs/guide/frontmatter.md
+++ b/docs/guide/frontmatter.md
@@ -1,0 +1,90 @@
+# Frontmatter
+
+Any Markdown file that contains a YAML frontmatter block will be processed by [gray-matter](https://github.com/jonschlinkert/gray-matter). The frontmatter must be at the top of the Markdown file, and must take the form of valid YAML set between triple-dashed lines. Example:
+
+```markdown
+---
+title: Docs with VitePress
+editLink: true
+---
+```
+
+Between the triple-dashed lines, you can set [predefined variables](#predefined-variables), or even create custom ones of your own. These variables can be used via the <code>\$page.frontmatter</code> variable.
+
+Here’s an example of how you could use it in your Markdown file:
+
+```markdown
+---
+title: Docs with VitePress
+editLink: true
+---
+
+# {{ $page.frontmatter.title }}
+
+Guide content
+```
+
+## Alternative frontmatter Formats
+
+VuePress also supports JSON frontmatter syntax, starting and ending in curly braces:
+
+```
+---
+{
+  "title": "Blogging Like a Hacker",
+  "editLink": "true"
+}
+---
+```
+
+## Predefined Variables
+
+### title
+
+- Type: `string`
+- Default: `h1_title || siteData.title`
+
+Title of the current page.
+
+### head
+
+- Type: `array`
+- Default: `undefined`
+
+Specify extra head tags to be injected:
+
+```yaml
+---
+head:
+  - - meta
+    - name: description
+      content: hello
+  - - meta
+    - name: keywords
+      content: super duper SEO
+---
+
+```
+
+## Predefined Variables Powered By Default Theme
+
+### navbar
+
+- Type: `boolean`
+- Default: `undefined`
+
+You can disable the navbar on a specific page with `navbar: false`
+
+### sidebar
+
+- Type: `boolean|'auto'`
+- Default: `undefined`
+
+You can decide to show the sidebar on a specific page with `sidebar: auto` or disable it with `sidebar: false`
+
+### editLink
+
+- Type: `boolean`
+- Default: `siteData.editLinks`
+
+Define if this page should include an edit link.

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -60,6 +60,8 @@ lang: en-US
 
 This data will be available to the rest of the page, along with all custom and theming components.
 
+For more details, see [Frontmatter](./frontmatter.md).
+
 ## GitHub-Style Tables
 
 **Input**


### PR DESCRIPTION
Port of https://vuepress.vuejs.org/guide/frontmatter.html adapted to the currently supported features in vitepress

Changed:
  - `$frontmatter` -> `$page.frontmatter`
  - Predefined Variables: `meta` -> `head`

Removed:
  - toml support (I did not find support for it in the code)
  - Predefined Variables: `lang`, `description`, `layout`, `permalink`, `canonicalUrl`
  - Theme: `prev`, `next`, `search`, `tags`

Added:
  - Theme: `editLink`

We can add back prev and next once they are configurable from the frontmatter (I did not find it at least)

Detail not directly affecting this PR: maybe it is not a bad idea to add `meta` as a shortcut as it is easier to write in vuepress
```
meta:
  - name: description
    content: hello
  - name: keywords
    content: super duper SEO
```
against the vitepress version using head
```
head:
  - - meta
    - name: description
      content: hello
  - - meta
    - name: keywords
      content: super duper SEO
```