### PR TITLE
docs: port of assets page from vuepress

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -36,6 +36,7 @@ function getGuideSidebar() {
         { text: 'What is VitePress?', link: '/' },
         { text: 'Getting Started', link: '/guide/getting-started' },
         { text: 'Configuration', link: '/guide/configuration' },
+        { text: 'Asset Handling', link: '/guide/assets' },
         { text: 'Markdown Extensions', link: '/guide/markdown' },
         { text: 'Deploying', link: '/guide/deploy' }
       ]

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -1,0 +1,29 @@
+# Asset Handling
+
+All Markdown files are compiled into Vue components and processed by [vite](https://github.com/vitejs/vite). You can, **and should**, reference any assets using relative URLs:
+
+```md
+![An image](./image.png)
+```
+
+You can reference static assets in your markdown files, your `*.vue` components in the theme, styles and plain `.css` files either using absolute public paths (based on project root) or relative paths (based on your file system). The latter is similar to the behavior you are used to if you have used `vue-cli` or webpack's `file-loader`.
+
+Common image, media, and font filetypes are detected and included as assets automatically. You can override this using the `assetsInclude` configuration option.
+
+All referenced assets, including those using absolute paths, will be copied to the dist folder with a hashed file name in the production build. Never-referenced assets will not be copied. Similar to `vue-cli`, image assets smaller than 4kb will be base64 inlined.
+
+All **static** path references, including absolute paths, should be based on your working directory structure.
+
+## The `public` Directory
+
+Sometimes you may need to provide static assets that are not directly referenced in any of your Markdown or theme components (for example, favicons and PWA icons). The `public` directory under project root can be used as an escape hatch to provide static assets that either are never referenced in source code (e.g. `robots.txt`), or must retain the exact same file name (without hashing).
+
+Assets placed in `public` will be copied to the root of the dist directory as-is.
+
+Note that you should reference files placed in `public` using root absolute path - for example, `public/icon.png` should always be referenced in source code as `/icon.png`.
+
+## Base URL
+
+If your site is deployed to a non-root URL, you will need to set the `base` option in `.vitepress/config.js`. For example, if you plan to deploy your site to `https://foo.github.io/bar/`, then `base` should be set to `"/bar/"` (it should always start and end with a slash).
+
+With a base URL, to reference an image in `.vitepress/public`, you’d have to use URLs like `/bar/image.png`.

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -1,6 +1,6 @@
 # Asset Handling
 
-All Markdown files are compiled into Vue components and processed by [vite](https://github.com/vitejs/vite). You can, **and should**, reference any assets using relative URLs:
+All Markdown files are compiled into Vue components and processed by [Vite](https://github.com/vitejs/vite). You can, **and should**, reference any assets using relative URLs:
 
 ```md
 ![An image](./image.png)
@@ -8,13 +8,13 @@ All Markdown files are compiled into Vue components and processed by [vite](http
 
 You can reference static assets in your markdown files, your `*.vue` components in the theme, styles and plain `.css` files either using absolute public paths (based on project root) or relative paths (based on your file system). The latter is similar to the behavior you are used to if you have used `vue-cli` or webpack's `file-loader`.
 
-Common image, media, and font filetypes are detected and included as assets automatically. You can override this using the `assetsInclude` configuration option.
+Common image, media, and font filetypes are detected and included as assets automatically.
 
 All referenced assets, including those using absolute paths, will be copied to the dist folder with a hashed file name in the production build. Never-referenced assets will not be copied. Similar to `vue-cli`, image assets smaller than 4kb will be base64 inlined.
 
 All **static** path references, including absolute paths, should be based on your working directory structure.
 
-## The `public` Directory
+## Public Files
 
 Sometimes you may need to provide static assets that are not directly referenced in any of your Markdown or theme components (for example, favicons and PWA icons). The `public` directory under project root can be used as an escape hatch to provide static assets that either are never referenced in source code (e.g. `robots.txt`), or must retain the exact same file name (without hashing).
 
@@ -24,6 +24,12 @@ Note that you should reference files placed in `public` using root absolute path
 
 ## Base URL
 
-If your site is deployed to a non-root URL, you will need to set the `base` option in `.vitepress/config.js`. For example, if you plan to deploy your site to `https://foo.github.io/bar/`, then `base` should be set to `"/bar/"` (it should always start and end with a slash).
+If your site is deployed to a non-root URL, you will need to set the `base` option in `.vitepress/config.js`. For example, if you plan to deploy your site to `https://foo.github.io/bar/`, then `base` should be set to `'/bar/'` (it should always start and end with a slash).
 
-With a base URL, to reference an image in `.vitepress/public`, you’d have to use URLs like `/bar/image.png`.
+With a base URL, to reference an image in `public`, you'd have to use URLs like `/bar/image.png`. But this is brittle if you ever decide to change the base. To help with that, VitePress provides a built-in helper `$withBase` (injected onto Vue's prototype) that generates the correct path:
+
+```html
+<img :src="$withBase('/foo.png')" alt="foo">
+```
+
+Note you can use the above syntax not only in theme components, but in your Markdown files as well.

--- a/docs/guide/global-computed.md
+++ b/docs/guide/global-computed.md
@@ -71,3 +71,11 @@ Value of the `<title>` label used for the current page.
 ## $description
 
 The content value of the `<meta name= "description" content= "...">` for the current page.
+
+## $withBase
+
+Helper method to generate correct path by prepending the `base` path configured in `.vitepress/config.js`. It's useful when you want to link to [public files with base path](./assets#public-files).
+
+```html
+<img :src="$withBase('/foo.png')" alt="foo">
+```


### PR DESCRIPTION
Port from https://vuepress.vuejs.org/guide/assets.html bringing the docs for vite from https://github.com/vitejs/vite#asset-url-handling

Removed $withBase global:

> But this is brittle if you ever decide to change the `base`. To help with that, VitePress provides a built-in helper `$withBase` (injected onto Vue’s prototype) that generates the correct path:
> 
> ```vue
> <img :src="$withBase('/foo.png')" alt="foo">
> ```
> 
> Note you can use the above syntax not only in theme components, but in your Markdown files as well.
> 
> Also, if a `base` is set, it’s automatically prepended to all asset URLs in `.vitepress/config.js` options.

I think we should provide this global in vitepress.