### PR TITLE
fix: align $title with vuepress (#158)

### DIFF
--- a/src/client/app/mixin.ts
+++ b/src/client/app/mixin.ts
@@ -44,7 +44,9 @@ export function mixinGlobalComputed(
 
     $title: {
       get() {
-        return page.value.title || siteByRoute.value.title
+        return page.value.title
+          ? page.value.title + ' | ' + siteByRoute.value.title
+          : siteByRoute.value.title
       }
     },
 


### PR DESCRIPTION
Fixes #158 

@kiaking I tried to do the localized `pageData.title` change but looks like it is more involved than I thought. I do not have the siteDataByRoute when pageData is created https://github.com/vuejs/vitepress/blob/master/src/node/markdownToVue.ts#L42
I still think that it would be good that do it, but I'll leave this one to someone else to check.
The PR only fixes the bug and aligns $site with the docs and vuepress.