### PR TITLE
docs: add migrating from vuepress guide

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -52,7 +52,11 @@ function getGuideSidebar() {
       children: [
         { text: 'Frontmatter', link: '/guide/frontmatter' },
         { text: 'Global Computed', link: '/guide/global-computed' },
-        { text: 'Customization', link: '/guide/customization' }
+        { text: 'Customization', link: '/guide/customization' },
+        {
+          text: 'Migrating from Vuepress',
+          link: '/guide/migrating-from-vuepress'
+        }
       ]
     }
   ]

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -54,8 +54,8 @@ function getGuideSidebar() {
         { text: 'Global Computed', link: '/guide/global-computed' },
         { text: 'Customization', link: '/guide/customization' },
         {
-          text: 'Migrating from Vuepress',
-          link: '/guide/migrating-from-vuepress'
+          text: 'Differences from Vuepress',
+          link: '/guide/differences-from-vuepress'
         }
       ]
     }

--- a/docs/guide/differences-from-vuepress.md
+++ b/docs/guide/differences-from-vuepress.md
@@ -1,33 +1,33 @@
-# Migrating from VuePress
+# Differences from VuePress
 
-VitePress follows VuePress config and default theme API where possible to ease the migration path. However, there are some features that are not present in VitePress because of differences in the [design goals](../index.md) of the two projects. VitePress aims to have bare minimal features for authoring docs and most features are pushed to the Themes, whereas VuePress has those features enabled by plugins.
+VitePress and VuePress have different [design goals](../index.md). Both projects share similar config naming conventions. VitePress aims to have the bare minimum features needed for authoring docs. Other features are pushed to Themes. On the other hand, VuePress has more features out-of-the-box or enabled by its ecosystem of plugins.
 
-This is a list of changes and removed features compared to [VuePress v1.7.1](https://github.com/vuejs/vuepress/releases/tag/v1.7.1)
+::: tip
+If you are using VuePress, there is no need to migrate to VitePress. Both projects are going to continue to co-exist for the foreseeable future.
+:::
 
 ::: warning
-
-Note this is early WIP! Currently the focus is on making Vite stable and feature complete first. It is not recommended to use this for anything serious yet.
-
-Some of these differences may be gone before Vitepress 1.0 is released.
-
+Note this is early WIP! Currently, the focus is on making Vite stable and feature-complete first. It is not recommended to use this for anything serious yet.
 :::
+
+In case you decide to move your project to VitePress, this is a list of differences from [VuePress v1.7.1](https://github.com/vuejs/vuepress/releases/tag/v1.7.1) that you need to take into account.
 
 ## General
 
-- Removed
+- Missing
   - YAML and TOML are not supported formats for site config. Only javascript is supported for `.vitepress/config.js`
   - [Plugins](https://vuepress.vuejs.org/plugin/) support, features are implemented in themes
   - [permalink support](https://vuepress.vuejs.org/guide/permalinks.html)
   - `.vitepress/templates`
   - Components in `.vitepress/components` [are not auto registered as global components](https://vuepress.vuejs.org/)
-- Changed
-  - [Public files](https://vuepress.vuejs.org/guide/assets.html#public-files) that are directly copied to dist root moved from `.vitepress/public/` to `public/`
-  - [styling](https://vuepress.vuejs.org/config/#styling) `.vitepress/styles/index.styl` and `.vitepress/styles/palette.styl` changed to `.vitepress/style.styl`
-  - [App Level Enhancements](https://vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements) API, app enhancements moved from `.vitepress/enhanceApp.js` to `.vitepress/theme/index.js`.
+- Differences
+  - [Public files](https://vuepress.vuejs.org/guide/assets.html#public-files) that are directly copied to dist root moved from `.vitepress/public/` is `public/`
+  - [styling](https://vuepress.vuejs.org/config/#styling) `.vitepress/styles/index.styl` and `.vitepress/styles/palette.styl` is `.vitepress/style.styl`
+  - [App Level Enhancements](https://vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements) API, app enhancements `.vitepress/enhanceApp.js` is `.vitepress/theme/index.js`.
 
 ## Markdown
 
-- Removed
+- Missing
   - Support for [toml in frontmatter](https://vuepress.vuejs.org/guide/frontmatter.html#alternative-frontmatter-formats)
   - [details block](https://vuepress.vuejs.org/guide/markdown.html#custom-containers)
   - [markdown slots](https://vuepress.vuejs.org/guide/markdown-slot.html)
@@ -36,7 +36,7 @@ Some of these differences may be gone before Vitepress 1.0 is released.
 
 ## Site Config
 
-- Removed
+- Missing
   - `temp`
   - `dest`
   - [`theme` from a dependency](https://vuepress.vuejs.org/theme/using-a-theme.html#using-a-theme-from-a-dependency)
@@ -57,30 +57,30 @@ Some of these differences may be gone before Vitepress 1.0 is released.
 
 ## Default Theme Config
 
-- Removed
+- Missing
   - [`smoothScroll`](https://vuepress.vuejs.org/theme/default-theme-config.html#smooth-scrolling)
   - [`displayAllHeaders`](https://vuepress.vuejs.org/theme/default-theme-config.html#displaying-header-links-of-all-pages)
   - [`activeHeaderLinks`](https://vuepress.vuejs.org/theme/default-theme-config.html#active-header-links)
   - `sidebarDepth` and `initialOpenGroupIndex` for [sidebar groups](https://vuepress.vuejs.org/theme/default-theme-config.html#sidebar-groups)
-- Renamed
-  - `searchMaxSuggestions` to `search.maxSuggestions`
-  - `algolia` to `search.algolia`
-  - `searchPlaceholder` to `search.placeholder`
+- Differences
+  - `searchMaxSuggestions` is `search.maxSuggestions`
+  - `algolia` is `search.algolia`
+  - `searchPlaceholder` is `search.placeholder`
 
 # Default Theme
 
-- Removed
+- Missing
   - [`<code-group>` and `<code-block>`](https://vuepress.vuejs.org/theme/default-theme-config.html#code-groups-and-code-blocks)
 
 ## Computed Globals
 
-- Removed
+- Missing
   - `$lang`
   - `$localePath`
 
 ## Frontmatter Predefined Variables
 
-- Removed
+- Missing
   - `description`
   - [`meta`](https://vuepress.vuejs.org/guide/frontmatter.html#meta)
   - [`metaTitle`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
@@ -91,7 +91,7 @@ Some of these differences may be gone before Vitepress 1.0 is released.
 
 ## Frontmatter Default Theme Variables
 
-- Removed
+- Missing
   - `prev`, `next`
   - [`search`](https://vuepress.vuejs.org/guide/frontmatter.html#search)
   - [`tags`](https://vuepress.vuejs.org/guide/frontmatter.html#tags)
@@ -100,18 +100,18 @@ Some of these differences may be gone before Vitepress 1.0 is released.
 
 ## siteData
 
-- Removed
+- Missing
   - [`pages`](https://vuepress.vuejs.org/theme/writing-a-theme.html#site-and-page-metadata)
 
 ## pageData
 
-- Removed
+- Missing
   - `key`
   - `path`
   - `regularPath`
 
 ## Default Components
 
-- Removed
+- Missing
   - [`<ClientOnly>`](https://vuepress.vuejs.org/guide/using-vue.html#browser-api-access-restrictions)
   - [`<Badge>`](https://vuepress.vuejs.org/guide/using-vue.html#badge)

--- a/docs/guide/migrating-from-vuepress.md
+++ b/docs/guide/migrating-from-vuepress.md
@@ -1,6 +1,6 @@
 # Migrating from VuePress
 
-VitePress follows VuePress config and default theme API where possible to ease the migration path. There are although some features that are not present in vitepress because of differences in the [design goals](../index.md) of the two projects. VitePress aims to have bare minimal features for authoring docs and most features are pushed to the Themes, where else VuePress has those features enabled by plugins.
+VitePress follows VuePress config and default theme API where possible to ease the migration path. However, there are some features that are not present in VitePress because of differences in the [design goals](../index.md) of the two projects. VitePress aims to have bare minimal features for authoring docs and most features are pushed to the Themes, whereas VuePress has those features enabled by plugins.
 
 This is a list of changes and removed features compared to [VuePress v1.7.1](https://github.com/vuejs/vuepress/releases/tag/v1.7.1)
 
@@ -14,92 +14,104 @@ Some of these differences may be gone before Vitepress 1.0 is released.
 
 ## General
 
-- YAML and TOML are not supported formats for site config. Only javascript is supported for `.vitepress/config.js`
-- removed [Plugins](https://vuepress.vuejs.org/plugin/) support, features are implemented in themes
-- removed [permalink support](https://vuepress.vuejs.org/guide/permalinks.html)
-- Components in `.vitepress/components` [are not auto registered as global components](https://vuepress.vuejs.org/)
-- [Public files](https://vuepress.vuejs.org/guide/assets.html#public-files) that are directly copied to dist root moved from `.vitepress/public/` to `public/`
-- Changed [App Level Enhancements](https://vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements) API, app enhancements moved from `.vitepress/enhanceApp.js` to `.vitepress/theme/index.js`.
-- removed [styling](https://vuepress.vuejs.org/config/#styling) `.vitepress/styles/index.styl` and `.vitepress/styles/palette.styl`.
-- removed `.vitepress/templates`
+- Removed
+  - YAML and TOML are not supported formats for site config. Only javascript is supported for `.vitepress/config.js`
+  - [Plugins](https://vuepress.vuejs.org/plugin/) support, features are implemented in themes
+  - [permalink support](https://vuepress.vuejs.org/guide/permalinks.html)
+  - `.vitepress/templates`
+  - Components in `.vitepress/components` [are not auto registered as global components](https://vuepress.vuejs.org/)
+- Changed
+  - [Public files](https://vuepress.vuejs.org/guide/assets.html#public-files) that are directly copied to dist root moved from `.vitepress/public/` to `public/`
+  - [styling](https://vuepress.vuejs.org/config/#styling) `.vitepress/styles/index.styl` and `.vitepress/styles/palette.styl` changed to `.vitepress/style.styl`
+  - [App Level Enhancements](https://vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements) API, app enhancements moved from `.vitepress/enhanceApp.js` to `.vitepress/theme/index.js`.
 
 ## Markdown
 
-- removed support for [toml in frontmatter](https://vuepress.vuejs.org/guide/frontmatter.html#alternative-frontmatter-formats)
-- removed [details block](https://vuepress.vuejs.org/guide/markdown.html#custom-containers)
-- removed [markdown slots](https://vuepress.vuejs.org/guide/markdown-slot.html)
-  guide/using-vue.html#using-components).
-- removed `~` prefix to explicitly specify a url is a [webpack module request](https://vuepress.vuejs.org/guide/assets.html#relative-urls)
+- Removed
+  - Support for [toml in frontmatter](https://vuepress.vuejs.org/guide/frontmatter.html#alternative-frontmatter-formats)
+  - [details block](https://vuepress.vuejs.org/guide/markdown.html#custom-containers)
+  - [markdown slots](https://vuepress.vuejs.org/guide/markdown-slot.html)
+    guide/using-vue.html#using-components).
+  - `~` prefix to explicitly specify a url is a [webpack module request](https://vuepress.vuejs.org/guide/assets.html#relative-urls)
 
 ## Site Config
 
-- renamed `temp` to `tempDir`
-- renamed `dest` to `outDir`
-- removed [`theme` from a dependency](https://vuepress.vuejs.org/theme/using-a-theme.html#using-a-theme-from-a-dependency)
-- removed `permalink`
-- removed [`port`](https://vuepress.vuejs.org/config/#port)
-- removed [`shouldPrefetch`](https://vuepress.vuejs.org/config/#shouldprefetch)
-- removed [`cache`](https://vuepress.vuejs.org/config/#cache)
-- removed [`extraWatchFiles`](https://vuepress.vuejs.org/config/#extrawatchfiles)
-- removed [`patterns`](https://vuepress.vuejs.org/config/#patterns)
-- removed [`plugins`](https://vuepress.vuejs.org/config/#pluggable)
-- removed [`markdown.pageSuffix`](https://vuepress.vuejs.org/config/#markdown-pagesuffix)
-- removed [`markdown.slugify`](https://vuepress.vuejs.org/config/#markdown-slugify)
-- removed [`markdown.plugins`](https://vuepress.vuejs.org/config/#markdown-plugins)
-- removed [`markdown.extractHeaders`](https://vuepress.vuejs.org/config/#markdown-extractheaders)
-- renamed `markdown.extendMarkdown` to `markdown.config`
-- removed `configureWebpack`, `chainWebpack`, `postcss`, `Stylus`, `scss`, `Sass`, `less` configs
-- removed [`evergreen`](https://vuepress.vuejs.org/config/#evergreen)
+- Removed
+  - `temp`
+  - `dest`
+  - [`theme` from a dependency](https://vuepress.vuejs.org/theme/using-a-theme.html#using-a-theme-from-a-dependency)
+  - `permalink`
+  - [`port`](https://vuepress.vuejs.org/config/#port)
+  - [`shouldPrefetch`](https://vuepress.vuejs.org/config/#shouldprefetch)
+  - [`cache`](https://vuepress.vuejs.org/config/#cache)
+  - [`extraWatchFiles`](https://vuepress.vuejs.org/config/#extrawatchfiles)
+  - [`patterns`](https://vuepress.vuejs.org/config/#patterns)
+  - [`plugins`](https://vuepress.vuejs.org/config/#pluggable)
+  - [`markdown.pageSuffix`](https://vuepress.vuejs.org/config/#markdown-pagesuffix)
+  - [`markdown.slugify`](https://vuepress.vuejs.org/config/#markdown-slugify)
+  - [`markdown.plugins`](https://vuepress.vuejs.org/config/#markdown-plugins)
+  - [`markdown.extractHeaders`](https://vuepress.vuejs.org/config/#markdown-extractheaders)
+  - `markdown.extendMarkdown` to `markdown.config`
+  - `configureWebpack`, `chainWebpack`, `postcss`, `Stylus`, `scss`, `Sass`, `less` configs
+  - [`evergreen`](https://vuepress.vuejs.org/config/#evergreen)
 
 ## Default Theme Config
 
-- removed [`smoothScroll`](https://vuepress.vuejs.org/theme/default-theme-config.html#smooth-scrolling)
-- removed [`displayAllHeaders`](https://vuepress.vuejs.org/theme/default-theme-config.html#displaying-header-links-of-all-pages)
-- removed [`activeHeaderLinks`](https://vuepress.vuejs.org/theme/default-theme-config.html#active-header-links)
-- removed `sidebarDepth` and `initialOpenGroupIndex` for [sidebar groups](https://vuepress.vuejs.org/theme/default-theme-config.html#sidebar-groups)
-- renamed `searchMaxSuggestions` to `search.maxSuggestions`
-- renamed `algolia` to `search.algolia`
-- renamed `searchPlaceholder` to `search.placeholder`
+- Removed
+  - [`smoothScroll`](https://vuepress.vuejs.org/theme/default-theme-config.html#smooth-scrolling)
+  - [`displayAllHeaders`](https://vuepress.vuejs.org/theme/default-theme-config.html#displaying-header-links-of-all-pages)
+  - [`activeHeaderLinks`](https://vuepress.vuejs.org/theme/default-theme-config.html#active-header-links)
+  - `sidebarDepth` and `initialOpenGroupIndex` for [sidebar groups](https://vuepress.vuejs.org/theme/default-theme-config.html#sidebar-groups)
+- Renamed
+  - `searchMaxSuggestions` to `search.maxSuggestions`
+  - `algolia` to `search.algolia`
+  - `searchPlaceholder` to `search.placeholder`
 
 # Default Theme
 
-- removed [`<code-group>` and `<code-block>`](https://vuepress.vuejs.org/theme/default-theme-config.html#code-groups-and-code-blocks)
+- Removed
+  - [`<code-group>` and `<code-block>`](https://vuepress.vuejs.org/theme/default-theme-config.html#code-groups-and-code-blocks)
 
 ## Computed Globals
 
-- removed `$lang`
-- removed `$localePath`
+- Removed
+  - `$lang`
+  - `$localePath`
 
 ## Frontmatter Predefined Variables
 
-- removed `description`
-- removed `meta`
-- removed `lang`
-- removed [`layout`](https://vuepress.vuejs.org/guide/frontmatter.html#layout)
-- removed [`permalink`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
-- removed [`canonicalUrl`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
-- removed [`metaTitle`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
-- removed [`meta`](https://vuepress.vuejs.org/guide/frontmatter.html#meta)
+- Removed
+  - `description`
+  - [`meta`](https://vuepress.vuejs.org/guide/frontmatter.html#meta)
+  - [`metaTitle`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
+  - `lang`
+  - [`layout`](https://vuepress.vuejs.org/guide/frontmatter.html#layout)
+  - [`permalink`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
+  - [`canonicalUrl`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
 
 ## Frontmatter Default Theme Variables
 
-- removed `prev`, `next`,
-- removed [`search`](https://vuepress.vuejs.org/guide/frontmatter.html#search)
-- removed [`tags`](https://vuepress.vuejs.org/guide/frontmatter.html#tags)
-- removed [`pageClass`](https://vuepress.vuejs.org/theme/default-theme-config.html#custom-page-class)
-- removed [`layout`](https://vuepress.vuejs.org/theme/default-theme-config.html#custom-layout-for-specific-pages)
+- Removed
+  - `prev`, `next`
+  - [`search`](https://vuepress.vuejs.org/guide/frontmatter.html#search)
+  - [`tags`](https://vuepress.vuejs.org/guide/frontmatter.html#tags)
+  - [`pageClass`](https://vuepress.vuejs.org/theme/default-theme-config.html#custom-page-class)
+  - [`layout`](https://vuepress.vuejs.org/theme/default-theme-config.html#custom-layout-for-specific-pages)
 
 ## siteData
 
-- removed [`pages`](https://vuepress.vuejs.org/theme/writing-a-theme.html#site-and-page-metadata)
+- Removed
+  - [`pages`](https://vuepress.vuejs.org/theme/writing-a-theme.html#site-and-page-metadata)
 
 ## pageData
 
-- removed `key`
-- removed `path`
-- removed `regularPath`
+- Removed
+  - `key`
+  - `path`
+  - `regularPath`
 
 ## Default Components
 
-- removed [`<ClientOnly>`](https://vuepress.vuejs.org/guide/using-vue.html#browser-api-access-restrictions)
-- removed [`<Badge>`](https://vuepress.vuejs.org/guide/using-vue.html#badge)
+- Removed
+  - [`<ClientOnly>`](https://vuepress.vuejs.org/guide/using-vue.html#browser-api-access-restrictions)
+  - [`<Badge>`](https://vuepress.vuejs.org/guide/using-vue.html#badge)

--- a/docs/guide/migrating-from-vuepress.md
+++ b/docs/guide/migrating-from-vuepress.md
@@ -1,0 +1,105 @@
+# Migrating from VuePress
+
+VitePress follows VuePress config and default theme API where possible to ease the migration path. There are although some features that are not present in vitepress because of differences in the [design goals](../index.md) of the two projects. VitePress aims to have bare minimal features for authoring docs and most features are pushed to the Themes, where else VuePress has those features enabled by plugins.
+
+This is a list of changes and removed features compared to [VuePress v1.7.1](https://github.com/vuejs/vuepress/releases/tag/v1.7.1)
+
+::: warning
+
+Note this is early WIP! Currently the focus is on making Vite stable and feature complete first. It is not recommended to use this for anything serious yet.
+
+Some of these differences may be gone before Vitepress 1.0 is released.
+
+:::
+
+## General
+
+- YAML and TOML are not supported formats for site config. Only javascript is supported for `.vitepress/config.js`
+- removed [Plugins](https://vuepress.vuejs.org/plugin/) support, features are implemented in themes
+- removed [permalink support](https://vuepress.vuejs.org/guide/permalinks.html)
+- Components in `.vitepress/components` [are not auto registered as global components](https://vuepress.vuejs.org/)
+- [Public files](https://vuepress.vuejs.org/guide/assets.html#public-files) that are directly copied to dist root moved from `.vitepress/public/` to `public/`
+- Changed [App Level Enhancements](https://vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements) API, app enhancements moved from `.vitepress/enhanceApp.js` to `.vitepress/theme/index.js`.
+- removed [styling](https://vuepress.vuejs.org/config/#styling) `.vitepress/styles/index.styl` and `.vitepress/styles/palette.styl`.
+- removed `.vitepress/templates`
+
+## Markdown
+
+- removed support for [toml in frontmatter](https://vuepress.vuejs.org/guide/frontmatter.html#alternative-frontmatter-formats)
+- removed [details block](https://vuepress.vuejs.org/guide/markdown.html#custom-containers)
+- removed [markdown slots](https://vuepress.vuejs.org/guide/markdown-slot.html)
+  guide/using-vue.html#using-components).
+- removed `~` prefix to explicitly specify a url is a [webpack module request](https://vuepress.vuejs.org/guide/assets.html#relative-urls)
+
+## Site Config
+
+- renamed `temp` to `tempDir`
+- renamed `dest` to `outDir`
+- removed [`theme` from a dependency](https://vuepress.vuejs.org/theme/using-a-theme.html#using-a-theme-from-a-dependency)
+- removed `permalink`
+- removed [`port`](https://vuepress.vuejs.org/config/#port)
+- removed [`shouldPrefetch`](https://vuepress.vuejs.org/config/#shouldprefetch)
+- removed [`cache`](https://vuepress.vuejs.org/config/#cache)
+- removed [`extraWatchFiles`](https://vuepress.vuejs.org/config/#extrawatchfiles)
+- removed [`patterns`](https://vuepress.vuejs.org/config/#patterns)
+- removed [`plugins`](https://vuepress.vuejs.org/config/#pluggable)
+- removed [`markdown.pageSuffix`](https://vuepress.vuejs.org/config/#markdown-pagesuffix)
+- removed [`markdown.slugify`](https://vuepress.vuejs.org/config/#markdown-slugify)
+- removed [`markdown.plugins`](https://vuepress.vuejs.org/config/#markdown-plugins)
+- removed [`markdown.extractHeaders`](https://vuepress.vuejs.org/config/#markdown-extractheaders)
+- renamed `markdown.extendMarkdown` to `markdown.config`
+- removed `configureWebpack`, `chainWebpack`, `postcss`, `Stylus`, `scss`, `Sass`, `less` configs
+- removed [`evergreen`](https://vuepress.vuejs.org/config/#evergreen)
+
+## Default Theme Config
+
+- removed [`smoothScroll`](https://vuepress.vuejs.org/theme/default-theme-config.html#smooth-scrolling)
+- removed [`displayAllHeaders`](https://vuepress.vuejs.org/theme/default-theme-config.html#displaying-header-links-of-all-pages)
+- removed [`activeHeaderLinks`](https://vuepress.vuejs.org/theme/default-theme-config.html#active-header-links)
+- removed `sidebarDepth` and `initialOpenGroupIndex` for [sidebar groups](https://vuepress.vuejs.org/theme/default-theme-config.html#sidebar-groups)
+- renamed `searchMaxSuggestions` to `search.maxSuggestions`
+- renamed `algolia` to `search.algolia`
+- renamed `searchPlaceholder` to `search.placeholder`
+
+# Default Theme
+
+- removed [`<code-group>` and `<code-block>`](https://vuepress.vuejs.org/theme/default-theme-config.html#code-groups-and-code-blocks)
+
+## Computed Globals
+
+- removed `$lang`
+- removed `$localePath`
+
+## Frontmatter Predefined Variables
+
+- removed `description`
+- removed `meta`
+- removed `lang`
+- removed [`layout`](https://vuepress.vuejs.org/guide/frontmatter.html#layout)
+- removed [`permalink`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
+- removed [`canonicalUrl`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
+- removed [`metaTitle`](https://vuepress.vuejs.org/guide/frontmatter.html#predefined-variables)
+- removed [`meta`](https://vuepress.vuejs.org/guide/frontmatter.html#meta)
+
+## Frontmatter Default Theme Variables
+
+- removed `prev`, `next`,
+- removed [`search`](https://vuepress.vuejs.org/guide/frontmatter.html#search)
+- removed [`tags`](https://vuepress.vuejs.org/guide/frontmatter.html#tags)
+- removed [`pageClass`](https://vuepress.vuejs.org/theme/default-theme-config.html#custom-page-class)
+- removed [`layout`](https://vuepress.vuejs.org/theme/default-theme-config.html#custom-layout-for-specific-pages)
+
+## siteData
+
+- removed [`pages`](https://vuepress.vuejs.org/theme/writing-a-theme.html#site-and-page-metadata)
+
+## pageData
+
+- removed `key`
+- removed `path`
+- removed `regularPath`
+
+## Default Components
+
+- removed [`<ClientOnly>`](https://vuepress.vuejs.org/guide/using-vue.html#browser-api-access-restrictions)
+- removed [`<Badge>`](https://vuepress.vuejs.org/guide/using-vue.html#badge)


### PR DESCRIPTION
This is a review of current differences in features and config options between VuePress 1.7.1 and VitePress. I was creating these notes as part of porting the docs from VuePress and I think it is helpful that they are part of the formal documentation.

I added the warning from the readme about the WIP status so we do not give the wrong idea by publishing this guide.

At this point, apart from being useful for people that want to play with VitePress, I think it will be good to track the differences and see if the renamings have been done for a reason or can be aligned and if there are features that can be implemented to ease the migration path.

Before 1.0 is released, It would be interesting to _Upgrade Path_ explanations for each of the changes like it is done in https://vuepress.vuejs.org/miscellaneous/migration-guide.html. For the moment, as some of these differences may disappear, I do not think that it is worth adding.

This document should be fairly complete. This a list of things I did not know if Vitepress supports:
- [Multiple sidebars](https://vuepress.vuejs.org/theme/default-theme-config.html#multiple-sidebars)(https://vuepress.vuejs.org/theme/default-theme-config.html#multiple-sidebars)
- [content excerpt](https://vuepress.vuejs.org/theme/writing-a-theme.html#content-excerpt)
- [prepocessors](https://vuepress.vuejs.org/guide/using-vue.html#using-pre-processors)

It also needs to be reviewed if there are any differences in the [i18n support](https://vuepress.vuejs.org/guide/i18n.html)

