### PR TITLE
feat: $lang and $localePath globals (#166)

### DIFF
--- a/docs/guide/global-computed.md
+++ b/docs/guide/global-computed.md
@@ -64,6 +64,14 @@ Reference of `$page.frontmatter`.
 }
 ```
 
+## $lang
+
+The language of the current page. Default: `en-US`.
+
+## $localePath
+
+The locale path prefix for the current page. Default: `/`.
+
 ## $title
 
 Value of the `<title>` label used for the current page.
@@ -77,5 +85,5 @@ The content value of the `<meta name= "description" content= "...">` for the cur
 Helper method to generate correct path by prepending the `base` path configured in `.vitepress/config.js`. It's useful when you want to link to [public files with base path](./assets#public-files).
 
 ```html
-<img :src="$withBase('/foo.png')" alt="foo">
+<img :src="$withBase('/foo.png')" alt="foo" />
 ```

--- a/docs/guide/global-computed.md
+++ b/docs/guide/global-computed.md
@@ -85,5 +85,5 @@ The content value of the `<meta name= "description" content= "...">` for the cur
 Helper method to generate correct path by prepending the `base` path configured in `.vitepress/config.js`. It's useful when you want to link to [public files with base path](./assets#public-files).
 
 ```html
-<img :src="$withBase('/foo.png')" alt="foo" />
+<img :src="$withBase('/foo.png')" alt="foo">
 ```

--- a/src/client/app/mixin.ts
+++ b/src/client/app/mixin.ts
@@ -56,6 +56,24 @@ export function mixinGlobalComputed(
       }
     },
 
+    $lang: {
+      get() {
+        return siteByRoute.value.lang
+      }
+    },
+
+    $localePath: {
+      get() {
+        const { locales } = site.value
+        const { lang } = siteByRoute.value
+        return (
+          (locales &&
+            Object.keys(locales).find((lp) => locales[lp].lang === lang)) ||
+          '/'
+        )
+      }
+    },
+
     $withBase: {
       value(path: string) {
         return joinPath(site.value.base, path)

--- a/src/client/app/mixin.ts
+++ b/src/client/app/mixin.ts
@@ -42,6 +42,25 @@ export function mixinGlobalComputed(
       }
     },
 
+    $lang: {
+      get() {
+        return siteByRoute.value.lang
+      }
+    },
+
+    $localePath: {
+      get() {
+        const { locales } = site.value
+        const { lang } = siteByRoute.value
+
+        const path = Object.keys(locales).find(
+          (lp) => locales[lp].lang === lang
+        )
+
+        return (locales && path) || '/'
+      }
+    },
+
     $title: {
       get() {
         return page.value.title
@@ -53,24 +72,6 @@ export function mixinGlobalComputed(
     $description: {
       get() {
         return page.value.description || siteByRoute.value.description
-      }
-    },
-
-    $lang: {
-      get() {
-        return siteByRoute.value.lang
-      }
-    },
-
-    $localePath: {
-      get() {
-        const { locales } = site.value
-        const { lang } = siteByRoute.value
-        return (
-          (locales &&
-            Object.keys(locales).find((lp) => locales[lp].lang === lang)) ||
-          '/'
-        )
       }
     },
 


### PR DESCRIPTION
close #166 

As discussed in #166 

I now see that there several globals that [are exposed](https://github.com/vuejs/vuepress/blob/fbf5e5d99b40e3842a0a2566f9eb35e05863eab5/packages/%40vuepress/core/lib/node/ClientComputedMixin.js#L50) but are not documented.

`$localeConfig` and `$themeLocaleConfig` looks like they are parts of `$siteByRoute` in vitepress
There are also `$siteTitle`, `$canonicalUrl`

In my opinion, there is no need to add any of these four globals that are not documented.