### PR TITLE
fix: port fixes to parseHeader utils from vuepress

### DIFF
--- a/__tests__/node/utils/deeplyParseHeader.spec.ts
+++ b/__tests__/node/utils/deeplyParseHeader.spec.ts
@@ -1,0 +1,33 @@
+import { deeplyParseHeader } from 'node/utils/parseHeader'
+
+test('deeplyParseHeader', () => {
+  const asserts: Record<string, string> = {
+    // Remove tail html
+    '# `H1` <Comp></Comp>': '# H1',
+    '# *H1* <Comp/>': '# H1',
+
+    // Reserve code-wrapped tail html
+    '# `H1` `<Comp></Comp>`': '# H1 <Comp></Comp>',
+    '# *H1* `<Comp/>`': '# H1 <Comp/>',
+
+    // Remove leading html
+    '# <Comp></Comp> `H1`': '#  H1',
+    '# <Comp/> *H1*': '#  H1',
+
+    // Reserve code-wrapped leading html
+    '# `<Comp></Comp>` `H1`': '# <Comp></Comp> H1',
+    '# `<Comp/>` *H1*': '# <Comp/> H1',
+
+    // Remove middle html
+    '# `H1` <Comp></Comp> `H2`': '# H1  H2',
+    '# `H1` <Comp/> `H2`': '# H1  H2',
+
+    // Reserve middle html
+    '# `H1` `<Comp></Comp>` `H2`': '# H1 <Comp></Comp> H2',
+    '# `H1` `<Comp/>` `H2`': '# H1 <Comp/> H2'
+  }
+
+  Object.keys(asserts).forEach((input) => {
+    expect(deeplyParseHeader(input)).toBe(asserts[input])
+  })
+})

--- a/__tests__/node/utils/parseHeader.spec.ts
+++ b/__tests__/node/utils/parseHeader.spec.ts
@@ -1,0 +1,38 @@
+import { parseHeader } from 'node/utils/parseHeader'
+
+describe('parseHeader', () => {
+  test('should unescape html', () => {
+    const input = `&lt;div :id=&quot;&#39;app&#39;&quot;&gt;`
+    expect(parseHeader(input)).toBe(`<div :id="'app'">`)
+  })
+
+  test('should remove markdown tokens correctly', () => {
+    const asserts: Record<string, string> = {
+      // vuepress #238
+      '[vue](vuejs.org)': 'vue',
+      '`vue`': 'vue',
+      '*vue*': 'vue',
+      '**vue**': 'vue',
+      '***vue***': 'vue',
+      _vue_: 'vue',
+      '\\_vue\\_': '_vue_',
+      '\\*vue\\*': '*vue*',
+      '\\!vue\\!': '!vue!',
+
+      // vuepress #2688
+      '[vue](vuejs.org) / [vue](vuejs.org)': 'vue / vue',
+      '[\\<ins>](vuejs.org)': '<ins>',
+
+      // vuepress #564 For multiple markdown tokens
+      '`a` and `b`': 'a and b',
+      '***bold and italic***': 'bold and italic',
+      '**bold** and *italic*': 'bold and italic',
+
+      // escaping \$
+      '\\$vue': '$vue'
+    }
+    Object.keys(asserts).forEach((input) => {
+      expect(parseHeader(input)).toBe(asserts[input])
+    })
+  })
+})

--- a/__tests__/node/utils/removeNonCodeWrappedHTML.spec.ts
+++ b/__tests__/node/utils/removeNonCodeWrappedHTML.spec.ts
@@ -1,0 +1,56 @@
+import { removeNonCodeWrappedHTML } from 'node/utils/parseHeader'
+
+test('removeNonCodeWrappedHTML', () => {
+  const asserts: Record<string, string> = {
+    // Remove tail html
+    '# H1 <Comp></Comp>': '# H1 ',
+    '# H1<Comp></Comp>': '# H1',
+    '# H1 <Comp a="b"></Comp>': '# H1 ',
+    '# H1<Comp a="b"></Comp>': '# H1',
+    '# H1 <Comp/>': '# H1 ',
+    '# H1<Comp/>': '# H1',
+    '# H1 <Comp a="b"/>': '# H1 ',
+    '# H1<Comp a="b"/>': '# H1',
+
+    // Reserve code-wrapped tail html
+    '# H1 `<Comp></Comp>`': '# H1 `<Comp></Comp>`',
+    '# H1 `<Comp a="b"></Comp>`': '# H1 `<Comp a="b"></Comp>`',
+    '# H1 `<Comp/>`': '# H1 `<Comp/>`',
+    '# H1 `<Comp a="b"/>`': '# H1 `<Comp a="b"/>`',
+
+    // Remove leading html
+    '# <Comp></Comp> H1': '#  H1',
+    '# <Comp></Comp>H1': '# H1',
+    '# <Comp a="b"></Comp> H1': '#  H1',
+    '# <Comp a="b"></Comp>H1': '# H1',
+    '# <Comp/> H1': '#  H1',
+    '# <Comp/>H1': '# H1',
+    '# <Comp a="b"/> H1': '#  H1',
+    '# <Comp a="b"/>H1': '# H1',
+
+    // Reserve code-wrapped leading html
+    '# `<Comp></Comp>` H1': '# `<Comp></Comp>` H1',
+    '# `<Comp a="b"></Comp>` H1': '# `<Comp a="b"></Comp>` H1',
+    '# `<Comp/>` H1': '# `<Comp/>` H1',
+    '# `<Comp a="b"/>` H1': '# `<Comp a="b"/>` H1',
+
+    // Remove middle html
+    '# H1 <Comp></Comp> H2': '# H1  H2',
+    '# H1 <Comp a="b"></Comp> H2': '# H1  H2',
+    '# H1 <Comp/> H2': '# H1  H2',
+    '# H1 <Comp a="b"/> H2': '# H1  H2',
+
+    // Reserve code-wrapped middle html
+    '# H1 `<Comp></Comp>` H2': '# H1 `<Comp></Comp>` H2',
+    '# H1 `<Comp a="b"></Comp>` H2': '# H1 `<Comp a="b"></Comp>` H2',
+    '# H1 `<Comp/>` H2': '# H1 `<Comp/>` H2',
+    '# H1 `<Comp a="b"/>` H2': '# H1 `<Comp a="b"/>` H2',
+
+    // vuepress #2688
+    '# \\<ins>': '# \\<ins>'
+  }
+
+  Object.keys(asserts).forEach((input) => {
+    expect(removeNonCodeWrappedHTML(input)).toBe(asserts[input])
+  })
+})

--- a/src/node/utils/parseHeader.ts
+++ b/src/node/utils/parseHeader.ts
@@ -28,9 +28,9 @@ const unescapeHtml = (html: string) =>
 
 const removeMarkdownTokens = (str: string) =>
   String(str)
-    .replace(/\[(.*)\]\(.*\)/, '$1') // []()
+    .replace(/(\[(.[^\]]+)\]\((.[^)]+)\))/g, '$2') // []()
     .replace(/(`|\*{1,3}|_)(.*?[^\\])\1/g, '$2') // `{t}` | *{t}* | **{t}** | ***{t}*** | _{t}_
-    .replace(/(\\)(\*|_|`|\!)/g, '$2') // remove escape char '\'
+    .replace(/(\\)(\*|_|`|\!|<|\$)/g, '$2') // remove escape char '\'
 
 const trim = (str: string) => str.trim()
 
@@ -39,7 +39,7 @@ const trim = (str: string) => str.trim()
 // Input: "<a> b",   Output: "b"
 // Input: "`<a>` b", Output: "`<a>` b"
 export const removeNonCodeWrappedHTML = (str: string) => {
-  return String(str).replace(/(^|[^><`])<.*>([^><`]|$)/g, '$1$2')
+  return String(str).replace(/(^|[^><`\\])<.*>([^><`]|$)/g, '$1$2')
 }
 
 const compose = (...processors: ((str: string) => string)[]) => {


### PR DESCRIPTION
Ported tests from vuepress:
- [parseHeaders.spec.ts](https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/shared-utils/__tests__/parseHeaders.spec.ts)
- [deeplyParseHeaders.spec.ts](https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/shared-utils/__tests__/deeplyParseHeaders.spec.ts)
- [removeNonCodeWrappedHTML.spec.ts](https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/shared-utils/__tests__/removeNonCodeWrappedHTML.spec.ts)

Ported fixes and new tests from unmerged PRs to vuepress:
https://github.com/vuejs/vuepress/pull/2688
https://github.com/vuejs/vuepress/pull/2363

The only part not included from [2363](https://github.com/vuejs/vuepress/pull/2363) is support for mathjax and subscript, waiting for discussion about this in https://github.com/vuejs/vitepress/issues/155#issuecomment-736813361.

Fixes https://github.com/vuejs/vitepress/issues/155