### PR TITLE
fix(md): avoid normalising markdown "mailto:" links

### DIFF
--- a/src/node/markdown/plugins/link.ts
+++ b/src/node/markdown/plugins/link.ts
@@ -23,7 +23,12 @@ export const linkPlugin = (
         Object.entries(externalAttrs).forEach(([key, val]) => {
           token.attrSet(key, val)
         })
-      } else if (!url.startsWith('#')) {
+      } else if (
+        // internal anchor links
+        !url.startsWith('#') &&
+        // mail links
+        !url.startsWith('mailto:')
+      ) {
         normalizeHref(hrefAttr)
       }
     }


### PR DESCRIPTION
The "mailto:" links were being normalised which resulted in them linking to a broken URL - not working.

![image](https://user-images.githubusercontent.com/5326365/101020165-2e33b400-35c2-11eb-9eca-c39fccd43807.png)

```md
## Email me

harlan@harlanzw.com

```