### PR TITLE
fix: style pollution on custom theme

### DIFF
--- a/src/client/app/exports.ts
+++ b/src/client/app/exports.ts
@@ -24,6 +24,3 @@ import { ComponentOptions } from 'vue'
 import _Debug from './components/Debug.vue'
 const Debug = _Debug as ComponentOptions
 export { Debug }
-
-// default theme
-export { default as defaultTheme } from '/@default-theme/index'


### PR DESCRIPTION
When using a custom theme, the style from the default theme will be injected and polluting the custom theme (overrides) due to the styles import side effect from re-exporting the defaultTheme here:

https://github.com/vuejs/vitepress/blob/18d18d2eb15a569113ca68ccbb9ba52dfd46c80a/src/client/app/exports.ts#L29

Repro: https://codesandbox.io/s/vitepress-style-pollution-p5kvq?file=/index.md

This PR removed the redirecting as it does not seem to be used and users should always import the theme from `vitepress/dist/client/theme-default` explicitly.