### PR TITLE
fix: scrollbar when using line highlight

### DIFF
--- a/src/client/theme-default/styles/code.css
+++ b/src/client/theme-default/styles/code.css
@@ -85,6 +85,7 @@ li > div[class*='language-'] {
   font-family: var(--code-font-family);
   font-size: var(--code-font-size);
   user-select: none;
+  overflow: hidden;
 }
 
 .highlight-lines .highlighted {


### PR DESCRIPTION
Hides spurious scrollbar in code blocks that appears when using line highlighting
https://vitepress.vuejs.org/guide/markdown.html#line-highlighting-in-code-blocks

![image](https://user-images.githubusercontent.com/583075/103701606-9b15e180-4fa6-11eb-9fd7-68b01dd2c53e.png)
