### PR TITLE
fix: render document with standards mode

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -78,7 +78,8 @@ export function createVitePressPlugin(
           if (req.url!.endsWith('.html')) {
             res.statusCode = 200
             res.end(
-              `<div id="app"></div>\n` +
+              `<!DOCTYPE html>\n` +
+                `<div id="app"></div>\n` +
                 `<script type="module" src="/@fs/${APP_PATH}/index.js"></script>`
             )
             return


### PR DESCRIPTION
This PR fixes the document rendering mode when running `docs-dev` script.

When `<!DOCTYPE html>` is not specified, the browser will use Quirks Mode to render the document, which will cause some third-party libraries to generate wrong logic, such as popperjs.

> In Firefox, select *View Page Info* from the context menu, and look for *Render Mode*.