### PR TITLE
Make serve url clickable

### DIFF
--- a/src/node/serve/serve.ts
+++ b/src/node/serve/serve.ts
@@ -30,6 +30,6 @@ export async function serve(options: ServeOptions = {}) {
     .use(compress, serve)
     .listen(port, (err: any) => {
       if (err) throw err
-      console.log(`Built site served at http://localhost:${port}.\n`)
+      console.log(`Built site served at http://localhost:${port}/\n`)
     })
 }


### PR DESCRIPTION
`vitepress serve` adds a `.` to the logged url, which makes the url non clickable on some terminal emulators.

Replaced `.` with `/` to match Vite server: https://github.com/vitejs/vite/blob/57c03435256b97857700e3df0e45e89fc324ed2c/packages/vite/src/node/server/index.ts#L522