### PR TITLE
docs: remove gh pages _assets warning (#124)

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -90,10 +90,6 @@ cd -
 You can also run the above script in your CI setup to enable automatic deployment on each push.
 :::
 
-::: warning
-GitHub pages have issues with the underscore in the dist `_assets` folder. To fix this an empty file name `.nojekyll` needs to be placed in the docs `public` directory. See [Bypassing Jekyll on GitHub Pages](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/).
-:::
-
 ### GitHub Pages and Travis CI
 
 1. Set the correct `base` in `docs/.vitepress/config.js`.


### PR DESCRIPTION
close #124 

See https://github.com/vuejs/vitepress/issues/124#issuecomment-765466780
Vite 2 defaults to `assets` for the assets dir instead of `_assets`, so this warning is no longer needed