### PR TITLE
fix: `base` option not working on dev mode (#181)

### DIFF
--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -10,6 +10,7 @@ export async function createServer(
 
   return createViteServer({
     root,
+    base: config.site.base,
     // logLevel: 'warn',
     plugins: createVitePressPlugin(root, config),
     server: serverOptions


### PR DESCRIPTION
fix #181

Now Vite natively supports `base` option, so all we need to do is pass the option down to the Vite server 💪 