### PR TITLE
fix: sidebar 'auto' not working (#178)

### DIFF
--- a/__tests__/client/theme-default/support/sideBar.spec.ts
+++ b/__tests__/client/theme-default/support/sideBar.spec.ts
@@ -1,9 +1,19 @@
 import {
+  isSideBarEmpty,
   getSideBarConfig,
   getFlatSideBarLinks
 } from 'client/theme-default/support/sideBar'
 
 describe('client/theme-default/support/sideBar', () => {
+  it('checks if the given sidebar is empty', () => {
+    expect(isSideBarEmpty(undefined)).toBe(true)
+    expect(isSideBarEmpty(false)).toBe(true)
+    expect(isSideBarEmpty([])).toBe(true)
+
+    expect(isSideBarEmpty('auto')).toBe(false)
+    expect(isSideBarEmpty([{ text: 'a', link: '/a' }])).toBe(false)
+  })
+
   it('gets the correct sidebar items', () => {
     expect(getSideBarConfig(false, '')).toEqual(false)
     expect(getSideBarConfig('auto', '')).toEqual('auto')

--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -135,7 +135,7 @@ const showSidebar = computed(() => {
 
   const { themeConfig } = siteRouteData.value
 
-  return !isSideBarEmpty(getSideBarConfig(themeConfig.sidebar))
+  return !isSideBarEmpty(getSideBarConfig(themeConfig.sidebar, route.path))
 })
 
 const toggleSidebar = (to?: boolean) => {

--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -74,6 +74,7 @@ import {
   usePageData,
   useSiteDataByRoute
 } from 'vitepress'
+import { isSideBarEmpty, getSideBarConfig } from './support/sideBar'
 import type { DefaultTheme } from './config'
 
 // components
@@ -127,14 +128,14 @@ const openSideBar = ref(false)
 
 const showSidebar = computed(() => {
   const { frontmatter } = route.data
+
+  if (frontmatter.home || frontmatter.sidebar === false) {
+    return false
+  }
+
   const { themeConfig } = siteRouteData.value
-  return (
-    !frontmatter.home &&
-    frontmatter.sidebar !== false &&
-    ((typeof themeConfig.sidebar === 'object' &&
-      Object.keys(themeConfig.sidebar).length != 0) ||
-      (Array.isArray(themeConfig.sidebar) && themeConfig.sidebar.length != 0))
-  )
+
+  return !isSideBarEmpty(getSideBarConfig(themeConfig.sidebar))
 })
 
 const toggleSidebar = (to?: boolean) => {

--- a/src/client/theme-default/support/sideBar.ts
+++ b/src/client/theme-default/support/sideBar.ts
@@ -13,6 +13,10 @@ export function isSideBarGroup(
   return (item as DefaultTheme.SideBarGroup).children !== undefined
 }
 
+export function isSideBarEmpty(sidebar?: DefaultTheme.SideBarConfig): boolean {
+  return isArray(sidebar) ? sidebar.length === 0 : !sidebar
+}
+
 /**
  * Get the `SideBarConfig` from sidebar option. This method will ensure to get
  * correct sidebar config from `MultiSideBarConfig` with various path


### PR DESCRIPTION
fix #178 

Sidebar gets hidden because `auto` was treated as empty. Added helper function to check if the sidebar is empty or not, and refactored a bit on checking logic for better readability 👀 

This adds a breaking change where undefined sidebar now resolves to `auto` where currently it's treated as `false`. Though VuePress treats undefined sidebar as `auto` so this is how it should have been 😓 