### PR TITLE
fix: return proper html in dev mode

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -79,8 +79,10 @@ export function createVitePressPlugin(
           if (req.url!.endsWith('.html')) {
             res.statusCode = 200
             res.end(
-              `<div id="app"></div>\n` +
-                `<script type="module" src="/@fs/${APP_PATH}/index.js"></script>`
+              '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>' +
+                '<div id="app"></div>' +
+                `<script type="module" src="/@fs/${APP_PATH}/index.js"></script>` +
+              '</body></html>'
             )
             return
           }


### PR DESCRIPTION
Adds doctype to avoid quirks mode, supersedes #207.
Adds charset, fixes Safari issues with non-ascii characters,
closes #218, closes https://github.com/vitejs/docs-cn/issues/8