### PR TITLE
fix: utf-8 character not working on safari in dev mode (#218)

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -78,11 +78,17 @@ export function createVitePressPlugin(
         server.middlewares.use((req, res, next) => {
           if (req.url!.endsWith('.html')) {
             res.statusCode = 200
-            res.end(
-              `<!DOCTYPE html>\n` +
-                `<div id="app"></div>\n` +
-                `<script type="module" src="/@fs/${APP_PATH}/index.js"></script>`
-            )
+            res.end(`
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/@fs/${APP_PATH}/index.js"></script>
+  </body>
+</html>`)
             return
           }
           next()


### PR DESCRIPTION
fix #218

This PR adds "charset" meta tag in dev mode as well to fix issue where utf-8 character not working in Safari. I've just went ahead and added `head` tag and `body` tag and so on as well.