### PR TITLE
fix: ads display

### DIFF
--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -179,6 +179,7 @@ const pageClasses = computed(() => {
   #ads-container {
     /* Avoid layout shift */
     height: 105px;
+    margin: 1.75rem 0;
   }
 }
 

--- a/src/client/theme-default/components/CarbonAds.vue
+++ b/src/client/theme-default/components/CarbonAds.vue
@@ -22,7 +22,6 @@ onMounted(() => {
 
 <style scoped>
 .carbon-ads {
-  padding: 1.75rem 0 0;
   border-radius: 4px;
   margin: 0 auto;
   max-width: 280px;

--- a/src/client/theme-default/components/Page.vue
+++ b/src/client/theme-default/components/Page.vue
@@ -47,4 +47,11 @@ import NextAndPrevLinks from './NextAndPrevLinks.vue'
 .content {
   padding-bottom: 1.5rem;
 }
+
+@media (max-width: 420px) {
+  .content {
+    /* fix carbon ads display */
+    clear: both;
+  }
+}
 </style>


### PR DESCRIPTION
In mobile:

- better spacing around the ad at the top
- Fix the layout shift due to float


Old:

![Screen Shot 2021-02-10 at 09 41 50](https://user-images.githubusercontent.com/664177/107485557-37be3700-6b84-11eb-9b7f-fc0f117da991.png)

Fixed:

![Screen Shot 2021-02-10 at 09 43 26](https://user-images.githubusercontent.com/664177/107485722-6dfbb680-6b84-11eb-8588-b9913dac32b0.png)

https://deploy-preview-230--vitepress-docs.netlify.app/