### PR TITLE
fix: nav home title not having locale based link (#195)

### DIFF
--- a/src/client/theme-default/components/NavBarTitle.vue
+++ b/src/client/theme-default/components/NavBarTitle.vue
@@ -1,8 +1,8 @@
 <template>
   <a
     class="nav-bar-title"
-    :href="$site.base"
-    :aria-label="`${$site.title}, back to home`"
+    :href="$withBase($localePath)"
+    :aria-label="`${$siteByRoute.title}, back to home`"
   >
     <img
       v-if="$themeConfig.logo"


### PR DESCRIPTION
fix #195

Make "home link" at nav bars locale based.