### PR TITLE
docs: using vue in markdown guide

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -53,6 +53,7 @@ function getGuideSidebar() {
         { text: 'Configuration', link: '/guide/configuration' },
         { text: 'Asset Handling', link: '/guide/assets' },
         { text: 'Markdown Extensions', link: '/guide/markdown' },
+        { text: 'Using Vue in Markdown', link: '/guide/using-vue' },
         { text: 'Deploying', link: '/guide/deploy' }
       ]
     },

--- a/docs/components/ComponentInHeader.vue
+++ b/docs/components/ComponentInHeader.vue
@@ -1,0 +1,3 @@
+<template>
+  <span>&#x26A1;</span>
+</template>

--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -11,7 +11,7 @@ You can develop your custom theme by adding the `.vitepress/theme/index.js` file
 │  │  └─ config.js
 │  └─ index.md
 └─ package.json
-````
+```
 
 In `.vitepress/theme/index.js`, you must export theme object and register your own theme layout. Let's say you have your own `Layout` component like this.
 

--- a/docs/guide/global-component.md
+++ b/docs/guide/global-component.md
@@ -26,3 +26,8 @@ If you are using or demoing components that are not SSR-friendly (for example, c
   <NonSSRFriendlyComponent />
 </ClientOnly>
 ```
+
+## OutboundLink
+
+The indicator `OutboundLink` is used to denote external links. In VitePress, this component has been followed by every external link.
+

--- a/docs/guide/using-vue.md
+++ b/docs/guide/using-vue.md
@@ -1,0 +1,249 @@
+# Using Vue in Markdown
+
+## Browser API Access Restrictions
+
+Because VitePress applications are server-rendered in Node.js when generating static builds, any Vue usage must conform to the [universal code requirements](https://ssr.vuejs.org/en/universal.html). In short, make sure to only access Browser / DOM APIs in `beforeMount` or `mounted` hooks.
+
+If you are using or demoing components that are not SSR-friendly (for example, contain custom directives), you can wrap them inside the built-in `<ClientOnly>` component:
+
+``` md
+<ClientOnly>
+  <NonSSRFriendlyComponent/>
+</ClientOnly>
+```
+
+Note this does not fix components or libraries that access Browser APIs **on import**. To use code that assumes a browser environment on import, you need to dynamically import them in proper lifecycle hooks:
+
+``` vue
+<script>
+export default {
+  mounted () {
+    import('./lib-that-access-window-on-import').then(module => {
+      // use code
+    })
+  }
+}
+</script>
+```
+
+If your module `export default` a Vue component, you can register it dynamically:
+
+```vue
+<template>
+  <component v-if="dynamicComponent" :is="dynamicComponent"></component>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      dynamicComponent: null
+    }
+  },
+
+  mounted () {
+    import('./lib-that-access-window-on-import').then(module => {
+      this.dynamicComponent = module.default
+    })
+  }
+}
+</script>
+```
+
+**Also see:**
+
+- [Vue.js > Dynamic Components](https://v3.vuejs.org/guide/component-dynamic-async.html)
+
+
+## Templating
+
+### Interpolation
+
+Each Markdown file is first compiled into HTML and then passed on as a Vue component to the Vite process pipeline. This means you can use Vue-style interpolation in text:
+
+**Input**
+
+``` md
+{{ 1 + 1 }}
+```
+
+**Output**
+
+<div class="language-text"><pre><code>{{ 1 + 1 }}</code></pre></div>
+
+### Directives
+
+Directives also work:
+
+**Input**
+
+``` md
+<span v-for="i in 3">{{ i }} </span>
+```
+
+**Output**
+
+<div class="language-text"><pre><code><span v-for="i in 3">{{ i }} </span></code></pre></div>
+
+### Access to Site & Page Data
+
+The compiled component has access to the [site metadata and computed properties](./global-computed.md). For example:
+
+**Input**
+
+``` md
+{{ $page }}
+```
+
+**Output**
+
+``` json
+{
+  "path": "/using-vue.html",
+  "title": "Using Vue in Markdown",
+  "frontmatter": {}
+}
+```
+
+## Escaping
+
+By default, fenced code blocks are automatically wrapped with `v-pre`. To display raw mustaches or Vue-specific syntax inside inline code snippets or plain text, you need to wrap a paragraph with the `v-pre` custom container:
+
+**Input**
+
+``` md
+::: v-pre
+`{{ This will be displayed as-is }}`
+:::
+```
+
+**Output**
+
+::: v-pre
+`{{ This will be displayed as-is }}`
+:::
+
+## Using Components
+
+When you need to have more flexibility, VitePress allows you to extend your authoring toolbox with your own Vue Components.
+
+### Importing components in markdown
+
+If your components are going to be used in only a few places, the recommended way to use them is to importing the components in the file where it is used. 
+
+```md
+# Docs
+
+This is a .md using a custom component
+
+<CustomComponent />
+
+## More docs
+
+...
+
+<script setup>
+import CustomComponent from '../components/CustomComponent.vue'
+</script>
+```
+
+### Registering global components in the theme
+
+If the components are going to be used across several pages in the docs, they can be registered globally in the theme (or as part of extending the default VitePress theme). Check out the [Customization Guide](./customization.md) for more information.
+
+In `.vitepress/theme/index.js`, the `enhanceApp` function receives the Vue `app` instance so you can [register components](https://v3.vuejs.org/guide/component-registration.html#component-registration) as you would do in a regular Vue application.
+
+```js
+import DefaultTheme from 'vitepress/theme'
+
+export default {
+  ...DefaultTheme,
+  enhanceApp({ app }) {
+    app.component('VueClickAwayExample', VueClickAwayExample)
+  }
+}
+```
+
+Later in your markdown files, the component can be interleaved between the content
+
+```md
+# Vue Click Away
+
+<VueClickAwayExample />
+```
+
+::: warning IMPORTANT
+Make sure a custom component’s name either contains a hyphen or is in PascalCase. Otherwise, it will be treated as an inline element and wrapped inside a `<p>` tag, which will lead to hydration mismatch because `<p>` does not allow block elements to be placed inside it.
+:::
+
+### Using Components In Headers <ComponentInHeader />
+
+You can use Vue components in the headers, but note the difference between the following syntaxes:
+
+| Markdown | Output HTML | Parsed Header |
+|--------|-------------|----------------|
+| <pre v-pre><code> # text &lt;Tag/&gt; </code></pre> | `<h1>text <Tag/></h1>` | `text` |
+| <pre v-pre><code> # text \`&lt;Tag/&gt;\` </code></pre> | `<h1>text <code>&lt;Tag/&gt;</code></h1>` | `text <Tag/>` |
+
+The HTML wrapped by `<code>` will be displayed as-is; only the HTML that is **not** wrapped will be parsed by Vue.
+
+::: tip
+The output HTML is accomplished by [markdown-it](https://github.com/markdown-it/markdown-it), while the parsed headers are handled by VitePress (and used for both the sidebar and document title).
+:::
+
+## Using CSS Pre-processors
+
+VitePress has [built-in support](https://vitejs.dev/guide/features.html#css-pre-processors) for CSS pre-processors: `.scss`, `.sass`, `.less`, `.styl` and `.stylus` files. There is no need to install Vite-specific plugins for them, but the corresponding pre-processor itself must be installed:
+
+```
+# .scss and .sass
+npm install -D sass
+
+# .less
+npm install -D less
+
+# .styl and .stylus
+npm install -D stylus
+```
+
+Then you can use the following in Markdown and theme components:
+
+``` vue
+<style lang="sass">
+.title
+  font-size: 20px
+</style>
+```
+
+## Script & Style Hoisting
+
+Sometimes you may need to apply some JavaScript or CSS only to the current page. In those cases, you can directly write root-level `<script>` or `<style>` blocks in the Markdown file. These will be hoisted out of the compiled HTML and used as the `<script>` and `<style>` blocks for the resulting Vue single-file component:
+
+<p class="demo" :class="$style.example"></p>
+
+<style module>
+.example {
+  color: #41b883;
+}
+</style>
+
+<script>
+import ComponentInHeader from '../components/ComponentInHeader.vue'
+
+export default {
+  props: ['slot-key'],
+  components: { ComponentInHeader },
+  mounted () {
+    document.querySelector(`.${this.$style.example}`)
+      .textContent = 'This is rendered by inline script and styled by inline CSS'
+  }
+}
+</script>
+
+## Built-In Components
+
+VitePress provides Built-In Vue Components like `ClientOnly` and `OutboundLink`, check out the [Global Component Guide](./global-component.md) for more information.
+
+**Also see:**
+
+- [Using Components In Headers](#using-components-in-headers)


### PR DESCRIPTION
This is a port of the [VuePress Using Vue in Markdown Guide](https://vuepress.vuejs.org/guide/using-vue.html)

The main difference is that there is no support for auto registering components. We can add that section if the feature gets implemented in VitePress. Instead of that, there is a section that showcases how to register components globally and how to import them in .md files.

@kiaking I respected the order of VuePress sections in the guide, but IMO it would be better to start by showing how to register and import the documents, and leave the first section about ClientOnly for the end (sort of advanced). But maybe it was pushed to the top because people were having issues with this in particular and they wanted to highlighted it. What do you think? (it can also be done later, better to have the guide up for now)

Notes:
Removed the comment about the page Vue component not having private data that I didn't understood.
I did not include a section about using `pug` for templates, because I am unsure about how it works, we can add that later also.
