### PR TITLE
fix: build fails without css chunks (#209)

### DIFF
--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -55,7 +55,7 @@ export async function renderPage(
 
   const stylesheetLink = cssChunk
     ? `<link rel="stylesheet" href="${siteData.base}${cssChunk.fileName}">`
-    : ``
+    : ''
 
   const html = `
 <!DOCTYPE html>

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -53,6 +53,10 @@ export async function renderPage(
     })
     .join('\n    ')
 
+  const stylesheetLink = cssChunk
+    ? `<link rel="stylesheet" href="${siteData.base}${cssChunk.fileName}">`
+    : ``
+
   const html = `
 <!DOCTYPE html>
 <html lang="${siteData.lang}">
@@ -65,7 +69,7 @@ export async function renderPage(
     <meta name="description" content="${
       pageData.description || siteData.description
     }">
-    <link rel="stylesheet" href="${siteData.base}${cssChunk.fileName}">
+    ${stylesheetLink}
     ${preloadLinks}
     ${renderHead(siteData.head)}
     ${renderHead(frontmatterHead && filterOutHeadDescription(frontmatterHead))}


### PR DESCRIPTION
fixes https://github.com/vuejs/vitepress/issues/209

`renderPage` should probably be dissected to smaller, pure functions to make it testable.