### PR TITLE
fix(types): `@` symbol not resolving on build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@docsearch/css": "^1.0.0-alpha.28",
     "@docsearch/js": "^1.0.0-alpha.28",
+    "@types/markdown-it": "^10.0.2",
     "@vitejs/plugin-vue": "^1.1.4",
     "@vue/compiler-sfc": "^3.0.5",
     "@vue/server-renderer": "^3.0.5",
@@ -97,7 +98,6 @@
     "@types/koa": "^2.11.7",
     "@types/koa-static": "^4.0.1",
     "@types/lru-cache": "^5.1.0",
-    "@types/markdown-it": "^10.0.2",
     "@types/node": "^14.14.25",
     "@types/postcss-load-config": "^2.0.1",
     "chokidar": "^3.5.1",

--- a/src/client/app/composables/pageData.ts
+++ b/src/client/app/composables/pageData.ts
@@ -1,5 +1,5 @@
 import { Ref, computed } from 'vue'
-import { PageData } from '/@types/shared'
+import { PageData } from '../../../../types/shared'
 import { Route, useRoute } from '../router'
 
 export type PageDataRef = Ref<PageData>

--- a/src/client/app/composables/siteData.ts
+++ b/src/client/app/composables/siteData.ts
@@ -1,5 +1,5 @@
 import serialized from '@siteData'
-import { SiteData } from '/@types/shared'
+import { SiteData } from '../../../../types/shared'
 import { Ref, ref, readonly } from 'vue'
 
 export type SiteDataRef<T = any> = Ref<SiteData<T>>

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,4 +1,4 @@
-import { SiteData } from '/@types/shared'
+import { SiteData } from '../../../types/shared'
 
 const inBrowser = typeof window !== 'undefined'
 

--- a/src/shared/tsconfig.json
+++ b/src/shared/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "/@types/*": ["../../types/*"]
-    }
+    "baseUrl": "."
   },
   "include": [
     ".",


### PR DESCRIPTION
We have `paths` option set at `tsconfig.json`, however, this path is not resolved during the bundle time and bundled files will contain things like `import {...} from '/@types` as is. Currently, it is not causing major issue because these imports are only importing types.

But when we try to create custom theme that imports for example `useSiteData`, it throws type error because it can't find `/@types`.

This PR replace import path alias to the actual relative path to resolve the issue.

We might should remove all aliases except `vitepress`, but in this PR, I'm just removing the paths that actually causing issue at the moment.