### PR TITLE
fix(navbar): use css var for background-color

### DIFF
--- a/src/client/theme-default/components/NavBar.vue
+++ b/src/client/theme-default/components/NavBar.vue
@@ -36,7 +36,7 @@ defineEmit(['toggle'])
   border-bottom: 1px solid var(--c-divider);
   padding: 0.7rem 1.5rem 0.7rem 4rem;
   height: var(--header-height);
-  background-color: inherit;
+  background-color: var(--c-bg);
 }
 
 @media (min-width: 720px) {


### PR DESCRIPTION
The current background color of navigation bar in [VitePress](https://vitepress.vuejs.org/) becomes transparent after #256 
Fixed by using css variable `--c-bg`