### PR TITLE
Wrong document link in 'guide/global-component.md'

### DIFF
--- a/docs/guide/global-component.md
+++ b/docs/guide/global-component.md
@@ -4,7 +4,7 @@ VitePress comes with few built-in component that can be used globally. You may u
 
 ## Content
 
-The `Content` component displays the rendered markdown contents. Useful [when creating your own theme](http://localhost:3000/guide/customization.html).
+The `Content` component displays the rendered markdown contents. Useful [when creating your own theme](https://vitepress.vuejs.org/guide/customization.html).
 
 ```vue
 <template>


### PR DESCRIPTION
close https://github.com/vuejs/vitepress/issues/270

`guide/global-component.md` here was wrong, so I fixed it.

Change before
`http://localhost:3000/guide/customization.html`
  
After change
`https://vitepress.vuejs.org/guide/customization.html`
