### PR TITLE
fix: include emoji text in nav link to match toc

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -67,7 +67,6 @@ export const createMarkdownRenderer = (
     })
 
     // 3rd party plugins
-    .use(emoji)
     .use(anchor, {
       slugify,
       permalink: true,
@@ -82,6 +81,7 @@ export const createMarkdownRenderer = (
       format: parseHeader,
       ...options.toc
     })
+    .use(emoji)
 
   // apply user config
   if (options.config) {

--- a/src/node/markdown/plugins/slugify.ts
+++ b/src/node/markdown/plugins/slugify.ts
@@ -14,7 +14,7 @@ export const slugify = (str: string): string => {
       .replace(rSpecial, '-')
       // Remove continuos separators
       .replace(/\-{2,}/g, '-')
-      // Remove prefixing and trailing separtors
+      // Remove prefixing and trailing separators
       .replace(/^\-+|\-+$/g, '')
       // ensure it doesn't start with a number (#121)
       .replace(/^(\d)/, '_$1')


### PR DESCRIPTION
I moved the emoji plugin after anchor/toc to avoid a mismatch between nav link and toc generation. The bug can be seen by clicking the `Emoji` link in the rendered TOC here: https://vitepress.vuejs.org/guide/markdown.html#table-of-contents

The desired behavior might actually be to strip the emoji text from the nav link, but that's a (slightly) more complicated change and breaks existing links.