### PR TITLE
fix(theme): set search box min-width for >=751px

### DIFF
--- a/src/client/theme-default/components/AlgoliaSearchBox.vue
+++ b/src/client/theme-default/components/AlgoliaSearchBox.vue
@@ -145,7 +145,6 @@ function initialize(userOptions: any) {
 @media (min-width: 751px) {
   .algolia-search-box {
     min-width: 176.3px; /* avoid layout shift */
-    padding-left: 8px;
   }
 
   .algolia-search-box .DocSearch-Button-Placeholder {

--- a/src/client/theme-default/components/AlgoliaSearchBox.vue
+++ b/src/client/theme-default/components/AlgoliaSearchBox.vue
@@ -139,12 +139,12 @@ function initialize(userOptions: any) {
 @media (min-width: 720px) {
   .algolia-search-box {
     padding-left: 8px;
-    min-width: 176.3px; /* avoid layout shift */
   }
 }
 
 @media (min-width: 751px) {
   .algolia-search-box {
+    min-width: 176.3px; /* avoid layout shift */
     padding-left: 8px;
   }
 


### PR DESCRIPTION
### Description

This PR closes #250.

### Solution

```min-width: 176,3px``` was moved to ```@media (min-width: 751px) { ... }``` block (as @nico-bachner suggested in issue).

### Result
- 751px
![751](https://user-images.githubusercontent.com/55282960/115068855-3c98c180-9f0c-11eb-902d-5e8ff78bdd12.png)
- 750px
![750](https://user-images.githubusercontent.com/55282960/115068857-3e628500-9f0c-11eb-9907-e9d049bf56d2.png)
- 720px
![720](https://user-images.githubusercontent.com/55282960/115068856-3dc9ee80-9f0c-11eb-874f-3e73a60f8d00.png)