### PR TITLE
fix(utils): add logic for image links

### DIFF
--- a/src/client/app/utils.ts
+++ b/src/client/app/utils.ts
@@ -6,6 +6,7 @@ export { inBrowser }
  * Join two paths by resolving the slash collision.
  */
 export function joinPath(base: string, path: string): string {
+  if (path.charAt(0) !== '/') return path
   return `${base}${path}`.replace(/\/+/g, '/')
 }
 


### PR DESCRIPTION
### Description：
$withBase make 'base' before my img link
<img width="1109" alt="截屏2021-04-18_下午3_31_15" src="https://user-images.githubusercontent.com/34104179/115138431-b17c1080-a05e-11eb-855f-3ea3e75f2aeb.png">

### Solution
use VuePress Logic：
<img width="1255" alt="截屏2021-04-18_下午4_00_50" src="https://user-images.githubusercontent.com/34104179/115138562-92ca4980-a05f-11eb-973f-0b29d0869f92.png">

### Result
<img width="1264" alt="截屏2021-04-18 下午4 03 40" src="https://user-images.githubusercontent.com/34104179/115138581-ac6b9100-a05f-11eb-8b4a-bd059e8f653c.png">

