### PR TITLE
fix: detect public folder for dead link

### DIFF
--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -56,7 +56,10 @@ export function createMarkdownToVueRenderFn(
             ? url.slice(1)
             : path.relative(root, path.resolve(dir, url))
         )
-        if (!pages.includes(resolved)) {
+        if (
+          !pages.includes(resolved) &&
+          !fs.existsSync(path.resolve(dir, 'public', `${resolved}.html`))
+        ) {
           console.warn(
             chalk.yellow(
               `\n(!) Found dead link ${chalk.cyan(

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -25,7 +25,11 @@ export function createMarkdownToVueRenderFn(
   const md = createMarkdownRenderer(root, options)
   pages = pages.map((p) => slash(p.replace(/\.md$/, '')))
 
-  return (src: string, file: string): MarkdownCompileResult => {
+  return (
+    src: string,
+    file: string,
+    publicDir: string
+  ): MarkdownCompileResult => {
     const relativePath = slash(path.relative(root, file))
 
     const cached = cache.get(src)
@@ -58,7 +62,7 @@ export function createMarkdownToVueRenderFn(
         )
         if (
           !pages.includes(resolved) &&
-          !fs.existsSync(path.resolve(dir, 'public', `${resolved}.html`))
+          !fs.existsSync(path.resolve(dir, publicDir, `${resolved}.html`))
         ) {
           console.warn(
             chalk.yellow(


### PR DESCRIPTION
For example:

```md
[test](/test.html)
```

It will check dead link automatically. `[test](/test.html)` need `docs/test.md`, otherwise it will fail to build.

But we also can place `test.html` in `docs/public`, `docs/public/test.html`.
So we can add a rule for it. Just check it too.

```ts
path.resolve(dir, 'public', `${resolved}.html`)
```