### PR TITLE
docs: change prefix to suffix

### DIFF
--- a/docs/config/basics.md
+++ b/docs/config/basics.md
@@ -33,7 +33,7 @@ module.exports = {
 - Type: `string`
 - Default: `VitePress`
 
-Title for the site. This will be the prefix for all page titles, and displayed in the navbar.
+Title for the site. This will be the suffix for all page titles, and displayed in the navbar.
 
 ```js
 module.exports = {


### PR DESCRIPTION
I think maybe `title | VitePress` is more like a suffix.