### PR TITLE
feat: home slot for customizing the entire homepage easily

### DIFF
--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -105,17 +105,22 @@ const pageClasses = computed(() => {
 
     <Content v-if="isCustomLayout" />
 
-    <Home v-else-if="enableHome">
-      <template #hero>
-        <slot name="home-hero" />
-      </template>
-      <template #features>
-        <slot name="home-features" />
-      </template>
-      <template #footer>
-        <slot name="home-footer" />
-      </template>
-    </Home>
+    <template v-else-if="enableHome">
+      <!-- A slot for customizing the entire homepage easily -->
+      <slot name="home">
+        <Home>
+          <template #hero>
+            <slot name="home-hero" />
+          </template>
+          <template #features>
+            <slot name="home-features" />
+          </template>
+          <template #footer>
+            <slot name="home-footer" />
+          </template>
+        </Home>
+      </slot>
+    </template>
 
     <Page v-else>
       <template #top>


### PR DESCRIPTION
## This PR adds a `slot` for the entire home page for easy customization

### Reason
- Currently when someone wants to just modify the `homepage` with custom style, it's not possible to extend. 
- The current `homepage slots` i.e. `home-hero`. `home-features`, `home-footer` only allow customizing specific parts.

### How this addition helps
__Currently__
```vue
<script setup lang="ts">
import Layout from 'vitepress/dist/client/theme-default/Layout.vue';
</script>

<template>
  <Layout>
    <template #home-hero>
      <p>My custom hero data</p>
    </template>
    <template #home-features>
      <p>My custom feature data</p>
    </template>
    <template #home-footer>
      <p>My custom footer data</p>
    </template>
  </Layout>
</template>
```
__In this pr__
```vue
<script setup lang="ts">
import Home from './components/Home.vue';
import Layout from 'vitepress/dist/client/theme-default/Layout.vue';
</script>

<template>
  <Layout>
    <template #home>
      <Home />
    </template>
  </Layout>
</template>
```
This will add more flexibility to vitepress while customizing the default `Homepage`