### PR TITLE
fix(nav): display nav if locales are present

### DIFF
--- a/src/client/theme-default/components/NavLinks.vue
+++ b/src/client/theme-default/components/NavLinks.vue
@@ -9,7 +9,7 @@ import NavDropdownLink from './NavDropdownLink.vue'
 const { theme } = useData()
 const localeLinks = useLocaleLinks()
 const repo = useRepo()
-const show = computed(() => theme.value.value || repo.value)
+const show = computed(() => theme.value.nav || repo.value || localeLinks.value)
 </script>
 
 <template>


### PR DESCRIPTION
This PR fix how the NavBar is shown. Right now, a `themeConfig.repo` key is mandatory to display the NavBar, regardless `nav` or `locales` config are defined.