### PR TITLE
fix: skip external URLs in `withBase`

### DIFF
--- a/src/client/app/utils.ts
+++ b/src/client/app/utils.ts
@@ -1,5 +1,5 @@
 import { siteDataRef } from './data'
-import { inBrowser } from '../shared'
+import { inBrowser, EXTERNAL_URL_RE } from '../shared'
 
 export { inBrowser }
 
@@ -11,7 +11,9 @@ export function joinPath(base: string, path: string): string {
 }
 
 export function withBase(path: string) {
-  return joinPath(siteDataRef.value.base, path)
+  return EXTERNAL_URL_RE.test(path)
+    ? path
+    : joinPath(siteDataRef.value.base, path)
 }
 
 /**

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -8,6 +8,8 @@ export type {
   Header
 } from '../../types/shared'
 
+export const EXTERNAL_URL_RE = /^https?:/i
+
 export const inBrowser = typeof window !== 'undefined'
 
 function findMatchRoot(route: string, roots: string[]) {


### PR DESCRIPTION
## Reason
I found that `withBase` will add path for all path, if I want to use some web resource. It's no need. So I add some path check for some url

## More
I have no idea for that there is necessary to check all `path` which is been  wrapped `withBase`.