### PR TITLE
fix: override target and rel links attribute in config

### DIFF
--- a/src/client/theme-default/composables/navLink.ts
+++ b/src/client/theme-default/composables/navLink.ts
@@ -28,8 +28,8 @@ export function useNavLink(item: Ref<DefaultTheme.NavItemWithLink>) {
         isExternal
       },
       href: isExternal ? item.value.link : withBase(item.value.link),
-      target: item.value.target || isExternal ? `_blank` : null,
-      rel: item.value.rel || isExternal ? `noopener noreferrer` : null,
+      target: item.value.target || (isExternal ? `_blank` : null),
+      rel: item.value.rel || (isExternal ? `noopener noreferrer` : null),
       'aria-label': item.value.ariaLabel
     }
   })


### PR DESCRIPTION
The condition was overridden by the `isExternal` boolean