### PR TITLE
fix: allow user to add Vitepress configuration to ESM packages

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -20,4 +20,9 @@ module.exports = {
 }
 ```
 
+::: warning
+If your project uses [ES modules](https://nodejs.org/api/esm.html),
+name this file `.vitepress/config.cjs` instead.
+:::
+
 Check out the [Config Reference](/config/basics) for a full list of options.

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -111,20 +111,19 @@ export async function resolveConfig(
   return config
 }
 
-export async function resolveUserConfig(root: string) {
-  // load user config
-  const configPath = resolve(root, 'config.js')
-  const hasUserConfig = await fs.pathExists(configPath)
-  // always delete cache first before loading config
-  delete require.cache[configPath]
-  const userConfig: UserConfig = hasUserConfig ? require(configPath) : {}
-  if (hasUserConfig) {
-    debug(`loaded config at ${chalk.yellow(configPath)}`)
-  } else {
-    debug(`no config file found.`)
+export async function resolveUserConfig(root: string): Promise<UserConfig> {
+  for (const name of ['config.cjs', 'config.js']) {
+    // load user config
+    const configPath = resolve(root, name)
+    // always delete cache first before loading config
+    delete require.cache[configPath]
+    if (await fs.pathExists(configPath)) {
+      debug(`loaded config at ${chalk.yellow(configPath)}`)
+      return require(configPath)
+    }
   }
-
-  return userConfig
+  debug(`no config file found.`)
+  return {}
 }
 
 export async function resolveSiteData(


### PR DESCRIPTION
If users have a `type: module` entry in their `package.json`, they cannot use VitePress with a `config.js` file.

## Reproduction

1. Follow the [tutorial](https://vitepress.vuejs.org/guide/getting-started.html)
and also a `"type": "module"` entry to the `package.json` file, so that it 
becomes:

```json
{
  "name": "vitepress-starter",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "type": "module",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "vitepress": "^0.15.6"
  }
}
```

2. Then, adding a `docs/.vitepress/config.js` as suggested [here](https://vitepress.vuejs.org/guide/configuration.html)

3. This will result in a typical ERR_REQUIRE_ESM error:

```
❯ npx vitepress dev docs
vitepress v0.15.6
vite v2.3.7
failed to start server. error:
 Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/capitaomorte/Source/Javascript/vitepress-starter/docs/.vitepress/config.js
require() of ES modules is not supported.
require() of /home/capitaomorte/Source/Javascript/vitepress-starter/docs/.vitepress/config.js from /home/capitaomorte/Source/Javascript/vitepress/dist/node/config.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename /home/capitaomorte/Source/Javascript/vitepress-starter/docs/.vitepress/config.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /home/capitaomorte/Source/Javascript/vitepress-starter/package.json.

    at new NodeError (node:internal/errors:278:15)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1125:13)
    at Module.load (node:internal/modules/cjs/loader:973:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Module.require (node:internal/modules/cjs/loader:997:19)
    at require (node:internal/modules/cjs/helpers:92:18)
    at resolveUserConfig (/home/capitaomorte/Source/Javascript/vitepress/dist/node/config.js:57:40)
    at async Object.resolveConfig (/home/capitaomorte/Source/Javascript/vitepress/dist/node/config.js:17:24)
    at async Object.createServer (/home/capitaomorte/Source/Javascript/vitepress/dist/node/server.js:8:20) {
  code: 'ERR_REQUIRE_ESM'

```

## Proposed fix

This change makes it so that `config.cjs` is searched before `config.js`.  Node's 'require' function allows files with such extensions to be loaded even from within an ES module project.