### PR TITLE
fix(edit-link): let frontmatter overwrite global editLink

### DIFF
--- a/src/client/theme-default/composables/editLink.ts
+++ b/src/client/theme-default/composables/editLink.ts
@@ -16,7 +16,10 @@ export function useEditLink() {
       editLinks
     } = theme.value
 
-    const showEditLink = frontmatter.value.editLink || editLinks
+    const showEditLink =
+      frontmatter.value.editLink !== undefined
+        ? frontmatter.value.editLink
+        : editLinks
     const { relativePath } = page.value
 
     if (!showEditLink || !relativePath || !repo) {

--- a/src/client/theme-default/composables/editLink.ts
+++ b/src/client/theme-default/composables/editLink.ts
@@ -17,7 +17,7 @@ export function useEditLink() {
     } = theme.value
 
     const showEditLink =
-      frontmatter.value.editLink !== undefined
+      frontmatter.value.editLink != null
         ? frontmatter.value.editLink
         : editLinks
     const { relativePath } = page.value


### PR DESCRIPTION
Allows overwriting the `editLinks` setting via the frontmatter `editLink` property.

Closes #334