### PR TITLE
fix: invalid active props when `base` option is added

### DIFF
--- a/src/client/theme-default/composables/navLink.ts
+++ b/src/client/theme-default/composables/navLink.ts
@@ -15,7 +15,7 @@ export function useNavLink(item: Ref<DefaultTheme.NavItemWithLink>) {
     if (item.value.activeMatch) {
       active = new RegExp(item.value.activeMatch).test(routePath)
     } else {
-      const itemPath = normalizePath(withBase(item.value.link))
+      const itemPath = normalizePath(item.value.link)
       active =
         itemPath === '/'
           ? itemPath === routePath


### PR DESCRIPTION
When the `base` is configured in config.js, the navigation highlight will be invalid

```
 const routePath = normalizePath(`/${route.data.relativePath}`)
```
routePath is relativePath, It does not add `base`, but itemPath adds, which will cause the following comparison to fail, so that active is always `false`, and the navigation bar is not highlighted