### PR TITLE
docs: change Markdown TOC to correct package name

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -401,7 +401,7 @@ module.exports = {
     // options for markdown-it-anchor
     anchor: { permalink: false },
 
-    // options for markdown-it-toc
+    // options for markdown-it-table-of-contents
     toc: { includeLevel: [1, 2] },
 
     config: (md) => {


### PR DESCRIPTION
Change `markdown-it-toc` to `markdown-it-table-of-contents` in config comment. `markdown-it-table-of-content` is the right npm package.