### PR TITLE
feat: allow displaying fallback when ads are blocked

### DIFF
--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -133,7 +133,9 @@ const pageClasses = computed(() => {
               :key="'carbon' + page.relativePath"
               :code="theme.carbonAds.carbon"
               :placement="theme.carbonAds.placement"
-            />
+            >
+              <slot name="carbon-ads-blocked"></slot>
+            </CarbonAds>
           </div>
         </slot>
         <slot name="page-top" />

--- a/src/client/theme-default/components/CarbonAds.vue
+++ b/src/client/theme-default/components/CarbonAds.vue
@@ -7,17 +7,32 @@ const { code, placement } = defineProps<{
 }>()
 
 const el = ref()
+const isBlocked = ref(false)
 
 onMounted(() => {
+  const src = `//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+  fetch('https:' + src, {
+    method: 'HEAD',
+    mode: 'no-cors'
+  })
+    .then(() => {
+      isBlocked.value = false
+    })
+    .catch(() => {
+      isBlocked.value = true
+    })
+
   const s = document.createElement('script')
   s.id = '_carbonads_js'
-  s.src = `//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+  s.src = src
   el.value.appendChild(s)
 })
 </script>
 
 <template>
-  <div class="carbon-ads" ref="el" />
+  <div class="carbon-ads" ref="el">
+    <slot v-if="isBlocked" />
+  </div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
The idea behind this is to enable a way to remind developers to safelist docs in adblockers like in Nuxtjs or JSFiddle:

![Screen Shot 2021-08-04 at 17 58 34](https://user-images.githubusercontent.com/664177/128214123-5d15eeee-3d06-4094-93b3-f3f527fc0d65.png)

Currently, this exposes a slot named `carbon-ads-blocked` at the Layout level to let the user customize how this is displayed.