### PR TITLE
fix(code): code block highlight bug in ul

### DIFF
--- a/src/client/theme-default/styles/code.css
+++ b/src/client/theme-default/styles/code.css
@@ -26,6 +26,7 @@ div[class*='language-'] {
 li > div[class*='language-'] {
   border-radius: 6px 0 0 6px;
   margin: 1rem -1.5rem 1rem -1.25rem;
+  line-height: initial;
 }
 
 @media (min-width: 420px) {


### PR DESCRIPTION
If code block in ul element,it will inherit parent element style,then display error
![1628154598(1)](https://user-images.githubusercontent.com/15724316/128324398-e05ba954-9955-4733-a251-1a9a460db5d9.png)
