### PR TITLE
fix: use useData() instead of $site

### DIFF
--- a/src/client/theme-default/NotFound.vue
+++ b/src/client/theme-default/NotFound.vue
@@ -2,11 +2,14 @@
   <div class="theme">
     <h1>404</h1>
     <blockquote>{{ getMsg() }}</blockquote>
-    <a :href="$site.base" aria-label="go to home">Take me home.</a>
+    <a :href="site.base" aria-label="go to home">Take me home.</a>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useData } from 'vitepress'
+
+const { site } = useData()
 const msgs = [
   `There's nothing here.`,
   `How did we get here?`,


### PR DESCRIPTION
All global mixin properties (e.g. $site) except $frontmatter are removed. Always use useData() to retrieve VitePress data in Vue components.