### PR TITLE
style: make img center in nav-bar-title

### DIFF
--- a/src/client/theme-default/components/NavBarTitle.vue
+++ b/src/client/theme-default/components/NavBarTitle.vue
@@ -24,6 +24,9 @@ const { site, theme, localePath } = useData()
   font-size: 1.3rem;
   font-weight: 600;
   color: var(--c-text);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .nav-bar-title:hover {


### PR DESCRIPTION
Before: logo with text

![image](https://user-images.githubusercontent.com/25154432/131386087-b586173b-808a-4413-b6c5-e4db881c94e4.png)

After:

![image](https://user-images.githubusercontent.com/25154432/131386113-7198142a-7a49-4f99-b387-ee044ecd4e06.png)
