### PR TITLE
style(theme): <code> need not a inline-bg-color in <pre>

### DIFF
--- a/src/client/theme-default/styles/code.css
+++ b/src/client/theme-default/styles/code.css
@@ -55,6 +55,7 @@ li > div[class*='language-'] {
   -moz-hyphens: none;
   -ms-hyphens: none;
   hyphens: none;
+  background: transparent;
 }
 
 [class*='language-'] pre {
@@ -62,7 +63,6 @@ li > div[class*='language-'] {
   z-index: 1;
   margin: 0;
   padding: 1.25rem 1.5rem;
-  background: transparent;
   overflow-x: auto;
 }
 


### PR DESCRIPTION
**--code-inline-bg-color** as a custom color variable.  both used by code backgrourd and markdown **strong** tag .
when I change **--code-inline-bg-color** lightly. it show **obvious** in code block.

![](https://i.bmp.ovh/imgs/2021/09/30a3f2d79d0945cb.png)

  