### PR TITLE
feat: support user-provided vite plugins

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -273,5 +273,5 @@ export function createVitePressPlugin(
     }
   }
 
-  return [vitePressPlugin, vuePlugin]
+  return [vitePressPlugin, vuePlugin, ...(userViteConfig.plugins || [])]
 }


### PR DESCRIPTION
Currently plugins defined in `.vitepress/config.js` are ignored, e.g.
```js
module.exports = {
  vite: {
    plugins: [
      myPlugin() // doesn't work
    ]
  }
}
```

Therefore, `userViteConfig.plugins` is appended to `createVitePressPlugin` result to support custom vite plugins