### PR TITLE
fix: run ”yarn dev“ error in window OS

### DIFF
--- a/scripts/watchAndCopy.js
+++ b/scripts/watchAndCopy.js
@@ -1,18 +1,26 @@
 const fs = require('fs-extra')
 const chokidar = require('chokidar')
+const { normalizePath } = require('vite')
 
 function toClientAndNode(method, file) {
+  const normalize_file = normalizePath(file)
   if (method === 'copy') {
-    fs.copy(file, file.replace(/^src\/shared\//, 'src/node/'))
-    fs.copy(file, file.replace(/^src\/shared\//, 'src/client/'))
+    fs.copy(
+      normalize_file,
+      normalize_file.replace(/^src\/shared\//, 'src/node/')
+    )
+    fs.copy(
+      normalize_file,
+      normalize_file.replace(/^src\/shared\//, 'src/client/')
+    )
   } else if (method === 'remove') {
-    fs.remove(file.replace(/^src\/shared\//, 'src/node/'))
-    fs.remove(file.replace(/^src\/shared\//, 'src/client/'))
+    fs.remove(normalize_file.replace(/^src\/shared\//, 'src/node/'))
+    fs.remove(normalize_file.replace(/^src\/shared\//, 'src/client/'))
   }
 }
 
 function toDist(file) {
-  return file.replace(/^src\//, 'dist/')
+  return normalizePath(file).replace(/^src\//, 'dist/')
 }
 
 // copy shared files to the client and node directory whenever they change.


### PR DESCRIPTION
## Bug 
![error](https://user-images.githubusercontent.com/44056372/135107053-4e20c604-f089-47e7-ae61-85c1004785b7.png)
## Env
1. OS - window10 1909
2. Node - v14.17.0
3. yarn - 1.22.5
## Reproduction:
  try to run and execute "yarn dev" in windows
## Reason
  ![reason](https://user-images.githubusercontent.com/44056372/135109274-458b2551-801c-45b8-837b-ec82e6ba61ae.png)
## Solution
 we can use  “normalizePath” method from  vite to normalize file path 
