### PR TITLE
docs: add config.ts example

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,3 +1,5 @@
+import type { UserConfig } from 'vitepress'
+
 export default {
   lang: 'en-US',
   title: 'VitePress',
@@ -41,7 +43,7 @@ export default {
       '/': getGuideSidebar()
     }
   }
-}
+} as UserConfig
 
 function getGuideSidebar() {
   return [

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,6 @@
 import type { UserConfig } from 'vitepress'
 
-export default {
+const config: UserConfig = {
   lang: 'en-US',
   title: 'VitePress',
   description: 'Vite & Vue powered static site generator.',
@@ -43,7 +43,9 @@ export default {
       '/': getGuideSidebar()
     }
   }
-} as UserConfig
+}
+
+export default config
 
 function getGuideSidebar() {
   return [

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -14,10 +14,15 @@ Without any configuration, the page is pretty minimal, and the user has no way t
 The essential file for configuring a VitePress site is `.vitepress/config.js`, which should export a JavaScript object:
 
 ```js
-module.exports = {
+/**
+ * @type {import('vitepress').UserConfig}
+ */
+const config = {
   title: 'Hello VitePress',
   description: 'Just playing around.'
 }
+
+module.exports = config
 ```
 
 If you are using TypeScript, you can use `.vitepress/config.ts` instead to get better types hint for VitePress Config.
@@ -25,10 +30,12 @@ If you are using TypeScript, you can use `.vitepress/config.ts` instead to get b
 ```ts
 import type { UserConfig } from 'vitepress'
 
-export default {
+const config = {
   title: 'Hello VitePress',
   description: 'Just playing around.'
-} as UserConfig
+}
+
+export default config
 ```
 
 Check out the [Config Reference](/config/basics) for a full list of options.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -20,4 +20,15 @@ module.exports = {
 }
 ```
 
+If you are using TypeScript, you can use `.vitepress/config.ts` instead to get better types hint for VitePress Config.
+
+```ts
+import type { UserConfig } from 'vitepress'
+
+export default {
+  title: 'Hello VitePress',
+  description: 'Just playing around.'
+} as UserConfig
+```
+
 Check out the [Config Reference](/config/basics) for a full list of options.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -25,7 +25,7 @@ const config = {
 module.exports = config
 ```
 
-If you are using TypeScript, you can use `.vitepress/config.ts` instead to get better types hint for VitePress Config.
+If you are using TypeScript, you can use it in your config too by using the `.ts` extension instead of the `.js` one:
 
 ```ts
 import type { UserConfig } from 'vitepress'


### PR DESCRIPTION
Related to https://github.com/vuejs/vitepress/commit/d3b1521ebef831e0d0307b3b12e4fc1f6ce4721a.

I have been looking forward to this feature for a long time, and I think it would be better if it can also be written in the documentation.