### PR TITLE
fix: navigate to 404, the page will be blank

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -20,22 +20,13 @@ export const RouterSymbol: InjectionKey<Router> = Symbol()
 // matter and is only passed to support same-host hrefs.
 const fakeHost = `http://a.com`
 
-const getDefaultPageData = (): PageData => ({
-  relativePath: '',
-  title: '',
-  description: '',
-  headers: [],
-  frontmatter: {},
-  lastUpdated: 0
-})
-
 const getDefaultRoute = (): Route => ({
   path: '/',
   component: null,
   // this will be set upon initial page load, which is before
   // the app is mounted, so it's guaranteed to be available in
-  // components
-  data: getDefaultPageData()
+  // components. We just need enough data for 404 pages to render.
+  data: { frontmatter: {} } as any
 })
 
 interface PageModule {

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -20,13 +20,22 @@ export const RouterSymbol: InjectionKey<Router> = Symbol()
 // matter and is only passed to support same-host hrefs.
 const fakeHost = `http://a.com`
 
+const getDefaultPageData = (): PageData => ({
+  relativePath: '',
+  title: '',
+  description: '',
+  headers: [],
+  frontmatter: {},
+  lastUpdated: 0
+})
+
 const getDefaultRoute = (): Route => ({
   path: '/',
   component: null,
   // this will be set upon initial page load, which is before
   // the app is mounted, so it's guaranteed to be available in
   // components
-  data: null as any
+  data: getDefaultPageData()
 })
 
 interface PageModule {


### PR DESCRIPTION
## bug description
when I navigate 404, the page will be blank
![error](https://user-images.githubusercontent.com/44056372/137356983-02a01d5a-35a0-4bd0-acd2-919b2ec0fb22.png)
.
## reason
because when navigate to 404, the `route.data` will be null. However, `route.data` used many times
![reason](https://user-images.githubusercontent.com/44056372/137357297-a45aa46e-9e86-48ce-b6a2-00eca33169c7.png)
We tried to get the property on `null`. So it throws an error. 

## solution
we can set `route.data` a default PageDate value to avoid getting the property on `null`.

## finally
![success](https://user-images.githubusercontent.com/44056372/137357743-84e0a9b0-d9f6-41ec-ab00-a0214534c9be.png)

