### PR TITLE
fix: add config.js markdown.config return file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 node_modules
 TODOs.md
 .vscode
+.idea

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -94,9 +94,9 @@ export const createMarkdownRenderer = (
 
   // wrap render so that we can return both the html and extracted data.
   const render = md.render
-  const wrappedRender: MarkdownRenderer['render'] = (src) => {
+  const wrappedRender: MarkdownRenderer['render'] = (src,env={}) => {
     ;(md as any).__data = {}
-    const html = render.call(md, src)
+    const html = render.call(md, src,env)
     return {
       html,
       data: (md as any).__data

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -65,7 +65,7 @@ export function createMarkdownToVueRenderFn(
     })
 
     const { content, data: frontmatter } = matter(src)
-    let { html, data } = md.render(content)
+    let { html, data } = md.render(content,{file})
 
     if (isBuild) {
       // avoid env variables being replaced by vite


### PR DESCRIPTION
[#351 ](https://github.com/vuejs/vitepress/issues/351)

config.ts

```ts
import { defineConfig } from "vitepress"
import MarkdownIt from "markdown-it"
export default defineConfig({
    title:"test outFile",
    markdown:{
        config:(md:MarkdownIt)=>{
            // get file path
            md.renderer.rules.html_block = function (tokens, idx, options, env, self) {
                console.log(env);// {file:"xxx.md"}
            }
        }
    }
})
```