### PR TITLE
fix: set tempDir outside package root

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -16,7 +16,7 @@ import {
   LocaleConfig,
   createLangDictionary
 } from './shared'
-import { resolveAliases, APP_PATH, DEFAULT_THEME_PATH } from './alias'
+import { resolveAliases, DEFAULT_THEME_PATH } from './alias'
 import { MarkdownOptions } from './markdown/markdown'
 import _debug from 'debug'
 
@@ -122,7 +122,7 @@ export async function resolveConfig(
     pages,
     configPath,
     outDir: resolve(root, 'dist'),
-    tempDir: path.resolve(APP_PATH, 'temp'),
+    tempDir: resolve(root, '.tmp'),
     markdown: userConfig.markdown,
     alias: resolveAliases(themeDir),
     vue: userConfig.vue,


### PR DESCRIPTION
package root can be read-only when install strategies like PnP are used, so the tempDir needs to be outside the vitepress package itself

close #435