### PR TITLE
fix: L4 toc style

### DIFF
--- a/src/client/theme-default/styles/sidebar-links.css
+++ b/src/client/theme-default/styles/sidebar-links.css
@@ -105,3 +105,22 @@ a.sidebar-link-item.active {
   font-size: 0.9rem;
   font-weight: 400;
 }
+
+.sidebar
+> .sidebar-links
+> .sidebar-link
+> .sidebar-links
+> .sidebar-link
+> .sidebar-links
+> .sidebar-link
+> .sidebar-links
+> .sidebar-link
+> .sidebar-links
+> .sidebar-link
+> .sidebar-link-item {
+  display: block;
+  padding: 0.3rem 1.5rem 0.3rem 5rem;
+  line-height: 1.4;
+  font-size: 0.8rem;
+  font-weight: 400;
+}


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/5960988/141975692-4e1e55b9-5d63-47ac-adcb-5d46d9271d38.png)

after:

![image](https://user-images.githubusercontent.com/5960988/141975705-52ec2cb6-62b5-42c6-ac03-ab2a3ddb294f.png)


my sidebar config is like: 


```js
    sidebar: {
      '/': [
        {
          text: 'Usage',
          children: [
            { text: 'Getting Started', link: '/usage/getting-started' },
            {
              text: 'i18n',
              link: '/usage/i18n',
            },
          ],
        },
        {
          text: 'Components',
          children: [
            {
              text: 'Basic',
              collapsable: false,
              children: [
                { text: 'Button', link: '/components/btn' },
                { text: 'Button Group', link: '/components/btn-group' },
                { text: 'Collapse', link: '/components/collapse' },
              ],
            },
            ...
          ],
        },
      ],
    },
```