### PR TITLE
feat(theme): support external links in sidebar

### DIFF
--- a/src/client/theme-default/components/SideBarLink.ts
+++ b/src/client/theme-default/components/SideBarLink.ts
@@ -2,7 +2,8 @@ import { FunctionalComponent, h, VNode } from 'vue'
 import { useRoute, useData } from 'vitepress'
 import { Header } from '../../shared'
 import { DefaultTheme } from '../config'
-import { joinUrl, isActive } from '../utils'
+import { joinUrl, isActive, isExternal as isExternalCheck } from '../utils'
+import OutboundLink from './icons/OutboundLink.vue'
 
 interface HeaderWithChildren extends Header {
   children?: Header[]
@@ -19,7 +20,8 @@ export const SideBarLink: FunctionalComponent<{
 
   const headers = route.data.headers
   const text = props.item.text
-  const link = resolveLink(site.value.base, props.item.link)
+  const isExternal = props.item.link && isExternalCheck(props.item.link)
+  const link = isExternal ? props.item.link : resolveLink(site.value.base, props.item.link)
   const children = (props.item as DefaultTheme.SideBarGroup).children
   const active = isActive(route, props.item.link)
   const childItems =
@@ -32,9 +34,16 @@ export const SideBarLink: FunctionalComponent<{
       link ? 'a' : 'p',
       {
         class: { 'sidebar-link-item': true, active },
-        href: link
-      },
-      text
+        href: link,
+        target: isExternal ? `_blank` : null,
+        rel: isExternal ? `noopener noreferrer` : null
+      }, isExternal
+      ? [
+        text,
+        ' ',
+        h(OutboundLink),
+      ]
+      : text
     ),
     childItems
   ])


### PR DESCRIPTION
This adds support for external links in sidebar of default theme. It adds the same icon to the links that's already being used in the nav bar.

Example rendered from https://github.com/FrodeI/vitepress-examples/tree/main/external-sidebar-links:
![image](https://user-images.githubusercontent.com/6661206/147883969-27a02afb-02ac-4e68-abc4-f998dfc9c7fc.png)

close #205