### PR TITLE
fix: properly type vitepress/theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "bin",
     "dist",
     "types",
-    "client.d.ts"
+    "client.d.ts",
+    "theme.d.ts"
   ],
   "scripts": {
     "dev": "run-s dev-shared dev-start",

--- a/src/node/markdown/plugins/containers.ts
+++ b/src/node/markdown/plugins/containers.ts
@@ -33,7 +33,9 @@ function createContainer(klass: string, defaultTitle: string): ContainerArgs {
         const info = token.info.trim().slice(klass.length).trim()
         if (token.nesting === 1) {
           if (klass === 'details') {
-            return `<details class="${klass} custom-block">${info ? `<summary>${info}</summary>` : ''}\n`
+            return `<details class="${klass} custom-block">${
+              info ? `<summary>${info}</summary>` : ''
+            }\n`
           }
           return `<div class="${klass} custom-block"><p class="custom-block-title">${
             info || defaultTitle

--- a/src/node/serve/serve.ts
+++ b/src/node/serve/serve.ts
@@ -23,7 +23,7 @@ export interface ServeOptions {
 export async function serve(options: ServeOptions = {}) {
   const port = options.port !== undefined ? options.port : 5000
   const site = await resolveConfig(options.root, 'serve', 'production')
-  const base = trimChar(site?.site?.base ?? "", "/")
+  const base = trimChar(site?.site?.base ?? '', '/')
 
   const compress = compression()
   const serve = sirv(site.outDir, {

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -6,7 +6,7 @@ export type {
   HeadConfig,
   LocaleConfig,
   Header,
-  DefaultTheme,
+  DefaultTheme
 } from '../../types/shared'
 
 export const EXTERNAL_URL_RE = /^https?:/i

--- a/theme.d.ts
+++ b/theme.d.ts
@@ -1,3 +1,4 @@
 // so that users can do `import DefaultTheme from 'vitepress/theme'`
-import DefaultTheme from './dist/client/theme-default/index'
-export default DefaultTheme
+import { Theme } from 'vitepress'
+declare const theme: Theme
+export default theme


### PR DESCRIPTION
Earlier there was `import DefaultTheme from './dist/client/theme-default/index'` in `./theme.d.ts`. But since, `./dist/client/theme-default/index.d.ts` is not bundled, the type of `DefaultTheme` was `any`.

Changed content of `./theme.d.ts` based on what TSC generates in `./dist/temp/theme-default/index.d.ts` on running `pnpm tsc -p src/client --declaration --emitDeclarationOnly --outDir dist/temp` (first part of `build-types-client` script).

The other changes were done by `prettier` on running `pnpm lint`. And refer #489 for the changes in `package.json`.