### PR TITLE
fix(theme): color for info custom block

### DIFF
--- a/src/client/theme-default/styles/custom-blocks.css
+++ b/src/client/theme-default/styles/custom-blocks.css
@@ -15,6 +15,7 @@
 
 .custom-block.info {
   background-color: #f3f5f7;
+  color: var(--c-text-light-2);
   border-color: var(--c-text-light-2);
 }
 


### PR DESCRIPTION
Seen on Vitest docs:
On dark, info custom block is light, but the text color remains light (as the body color is light).

<img width="737" alt="Capture d’écran 2022-01-13 à 12 05 43" src="https://user-images.githubusercontent.com/2922851/149319018-53f83d2f-2089-4125-981d-131c81af1339.png">
https://vitest.dev/config/#globalsetup
