### PR TITLE
fix: append base to links

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -49,7 +49,8 @@ export type { Header }
 
 export const createMarkdownRenderer = (
   srcDir: string,
-  options: MarkdownOptions = {}
+  options: MarkdownOptions = {},
+  base: string
 ): MarkdownRenderer => {
   const md = MarkdownIt({
     html: true,
@@ -66,11 +67,15 @@ export const createMarkdownRenderer = (
     .use(hoistPlugin)
     .use(containerPlugin)
     .use(headingPlugin)
-    .use(linkPlugin, {
-      target: '_blank',
-      rel: 'noopener noreferrer',
-      ...options.externalLinks
-    })
+    .use(
+      linkPlugin,
+      {
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        ...options.externalLinks
+      },
+      base
+    )
     // 3rd party plugins
     .use(attrs, options.attrs)
     .use(anchor, {

--- a/src/node/markdown/plugins/link.ts
+++ b/src/node/markdown/plugins/link.ts
@@ -11,7 +11,8 @@ const indexRE = /(^|.*\/)index.md(#?.*)$/i
 
 export const linkPlugin = (
   md: MarkdownIt,
-  externalAttrs: Record<string, string>
+  externalAttrs: Record<string, string>,
+  base: string
 ) => {
   md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
     const token = tokens[idx]
@@ -75,6 +76,11 @@ export const linkPlugin = (
 
     // export it for existence check
     pushLink(url.replace(/\.html$/, ''))
+
+    // append base to internal (non-relative) urls
+    if (url.startsWith('/')) {
+      url = `${base}${url}`.replace(/\/+/g, '/')
+    }
 
     // markdown-it encodes the uri
     hrefAttr[1] = decodeURI(url)

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -25,9 +25,10 @@ export function createMarkdownToVueRenderFn(
   options: MarkdownOptions = {},
   pages: string[],
   userDefines: Record<string, any> | undefined,
-  isBuild = false
+  isBuild = false,
+  base: string
 ) {
-  const md = createMarkdownRenderer(srcDir, options)
+  const md = createMarkdownRenderer(srcDir, options, base)
   pages = pages.map((p) => slash(p.replace(/\.md$/, '')))
 
   const userDefineRegex = userDefines

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -84,7 +84,8 @@ export function createVitePressPlugin(
         markdown,
         pages,
         config.define,
-        config.command === 'build'
+        config.command === 'build',
+        config.base
       )
     },
 


### PR DESCRIPTION
fixes #252

As mentioned at https://github.com/vuejs/vitepress/issues/252#issuecomment-1000024504, relative links are still working. If you guys want to keep it that way only and map `/foo` to `scheme://path/foo` instead of `scheme://path/base/foo` then the current external URL testing needs to be changed as `/foo` may not point to valid internal link if `base` is set (ref: #458). If this is merged, then #458 can be closed as won't fix, i.e. `scheme://path` is required if linking to any external link (incl. links outside the base).