### PR TITLE
fix(client router): tolerant invalid hash selector typo

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -185,7 +185,7 @@ function scrollTo(el: HTMLElement, hash: string, smooth = false) {
   let target: Element | null = null
 
   try {
-    target = el.classList.contains('.header-anchor')
+    target = el.classList.contains('header-anchor')
       ? el
       : document.querySelector(decodeURIComponent(hash))
   } catch (e) {


### PR DESCRIPTION
parameter of `element.classList.contains()`  should be a string without selector prefix `.`

```diff
- target = el.classList.contains('.header-anchor')
+ target = el.classList.contains('header-anchor')
      ? el
      : document.querySelector(decodeURIComponent(hash))
```