### PR TITLE
fix: ERR_REQUIRE_ESM error when project type is set to module

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs from 'fs-extra'
 import { defineConfig, mergeConfig, Plugin, ResolvedConfig } from 'vite'
 import { SiteConfig, resolveSiteData } from './config'
 import {
@@ -275,6 +276,15 @@ export function createVitePressPlugin(
 
         // overwrite src so vue plugin can handle the HMR
         ctx.read = () => vueSrc
+      }
+    },
+
+    writeBundle(_options) {
+      if (ssr && _options.dir && _options.format === 'cjs') {
+        fs.writeFileSync(
+          path.join(_options.dir, 'package.json'),
+          JSON.stringify({ type: 'commonjs' })
+        )
       }
     }
   }


### PR DESCRIPTION
There is currently a bug when building Vitepress in a project with its type set to `module` in the `package.json` file. The temporary directory for the SSR build is bundled in CJS format with `.js` extension. In a project whose type is set to `module`, these files are considered ESM and cannot be `required()`, see [this reproduction repository](https://github.com/titouanmathis/vitepress-type-module-reproduction) to test the bug.

I was able to fix the issue by adding a `package.json` file in the temporary directory with type set to `commonjs`.