### PR TITLE
fix: prefer `repo` above `docsRepo` for the navbar repo link

### DIFF
--- a/src/client/theme-default/composables/repo.ts
+++ b/src/client/theme-default/composables/repo.ts
@@ -12,7 +12,7 @@ export function useRepo() {
 
   return computed(() => {
     const theme = site.value.themeConfig as DefaultTheme.Config
-    const name = theme.docsRepo || theme.repo
+    const name = theme.repo || theme.docsRepo
 
     if (!name) {
       return null


### PR DESCRIPTION
fixes #457