### PR TITLE
fix: dont' minimize non-javascript inline scripts

### DIFF
--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -182,7 +182,10 @@ function renderHead(head: HeadConfig[]): Promise<string> {
     head.map(async ([tag, attrs = {}, innerHTML = '']) => {
       const openTag = `<${tag}${renderAttrs(attrs)}>`
       if (tag !== 'link' && tag !== 'meta') {
-        if (tag === 'script') {
+        if (
+          tag === 'script' &&
+          (attrs.type === undefined || attrs.type.includes('javascript'))
+        ) {
           innerHTML = (
             await transformWithEsbuild(innerHTML, 'inline-script.js', {
               minify: true


### PR DESCRIPTION
Commit e61db62a1c49cb5f368a152221bfa60737dbbc6a introduced the minification of inline JavaScript.
Unfortunately this feature tries to minify the content of any `<script>` tag that is inserted into the `<head>`.
A `<script>` tag can contain not only JavaScript, but also JSON for example.
Therefore this won't work:

```js
module.exports = {
  head: [
    ['script', { type: 'application/ld+json' }, '{ "foo": "bar" }']
  ]
}
```

A detailed bug report can be found here: #538