### PR TITLE
fix(docs) - broken "custom theming" link target

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -71,7 +71,7 @@ VitePress comes with few built-in component that can be used globally. You may u
 
 ### `<Content/>`
 
-The `<Content/>` component displays the rendered markdown contents. Useful [when creating your own theme](https://vitepress.vuejs.org/guide/customization.html).
+The `<Content/>` component displays the rendered markdown contents. Useful [when creating your own theme](/guide/theming.html#using-a-custom-theme).
 
 ```vue
 <template>


### PR DESCRIPTION
Currently the link target is broken. (see https://vitepress.vuejs.org/guide/api.html#global-components). I guess the correct link should be referring to custom theming . I also changed the link target to a relative one.