### PR TITLE
fix: should not parse JSON-LD script in head (fix #538)

### DIFF
--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -182,7 +182,7 @@ function renderHead(head: HeadConfig[]): Promise<string> {
     head.map(async ([tag, attrs = {}, innerHTML = '']) => {
       const openTag = `<${tag}${renderAttrs(attrs)}>`
       if (tag !== 'link' && tag !== 'meta') {
-        if (tag === 'script') {
+        if (tag === 'script' && attrs.type !== 'application/ld+json') {
           innerHTML = (
             await transformWithEsbuild(innerHTML, 'inline-script.js', {
               minify: true


### PR DESCRIPTION
JSON-LD contains JSON format code so it should not be transformed by esbuild which will raise an error.

references
- https://json-ld.org/
- https://json-ld.org/spec/latest/json-ld/