### PR TITLE
docs: fix typo introduced due to #523

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -19,7 +19,7 @@ Hi! We're really excited that you are interested in contributing to VitePress. B
 
 - It's OK to have multiple small commits as you work on the PR - GitHub can automatically squash them before merging.
 
-- Commit messages must follow the [commit message convention](./commit-convention) so that changelogs can be automatically generated.
+- Commit messages must follow the [commit message convention](./commit-convention.md) so that changelogs can be automatically generated.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ To check out docs, visit [vitepress.vuejs.org](https://vitepress.vuejs.org).
 
 ## Changelog
 
-Detailed changes for each release are documented in the [CHANGELOG](./CHANGELOG).
+Detailed changes for each release are documented in the [CHANGELOG](https://github.com/vuejs/vitepress/blob/main/CHANGELOG.md).
 
 ## Contribution
 
-Please make sure to read the [Contributing Guide](./.github/contributing) before making a pull request.
+Please make sure to read the [Contributing Guide](https://github.com/vuejs/vitepress/blob/main/.github/contributing.md) before making a pull request.
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](https://github.com/vuejs/vitepress/blob/main/LICENSE)
 
 Copyright (c) 2019-present, Yuxi (Evan) You


### PR DESCRIPTION
In #523, I accidently missed `.md` extension in some URLs that are being handled by GitHub. So they are currently giving 404. Also, I think that using complete URLs in readme is better, as some package search engines unlike NPM don't resolve relative links back to GitHub. Sorry for the inconvenience, I should have noticed this earlier.