### PR TITLE
docs: fix gitlab pages deploy syntax

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -141,8 +141,9 @@ deploy:
 3. Create a file called `.gitlab-ci.yml` in the root of your project with the content below. This will build and deploy your site whenever you make changes to your content:
 
 ```yaml
-image: node:10.22.0
+image: node:16.5.0
 pages:
+  stage: deploy
   cache:
     paths:
       - node_modules/
@@ -152,8 +153,8 @@ pages:
   artifacts:
     paths:
       - public
-  only:
-    - main
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
 ## Netlify


### PR DESCRIPTION
GitLab CI fails with this error when building the site using the `.gitlab-ci.yml` example in the [vitepress docs](https://vitepress.vuejs.org/guide/deploy.html#gitlab-pages-and-gitlab-ci).
`error vitepress@0.22.3: The engine "node" is incompatible with this module. Expected version ">=14.0.0". Got "10.22.0"`

This change will:
- Use a compatible node version
- Use a conditional rule instead of a hardcoded branch name
- Mark it as the deploy stage 

The last two changes are for consistency with a similar `.gitlab-ci.yml` example in the main vite docs:
- vitejs/vite#5909
- https://vitejs.dev/guide/static-deploy.html#gitlab-pages-and-gitlab-ci