### PR TITLE
docs(config): DocSearch upgrade to v3 configuration

### DIFF
--- a/docs/config/algolia-search.md
+++ b/docs/config/algolia-search.md
@@ -1,11 +1,12 @@
 # Theme Config: Algolia Search
 
-The `themeConfig.algolia` option allows you to use [Algolia DocSearch](https://docsearch.algolia.com). To enable it, you need to provide at least apiKey and indexName:
+The `themeConfig.algolia` option allows you to use [Algolia DocSearch](https://docsearch.algolia.com). To enable it, you need to provide at least apiId, apiKey and indexName:
 
 ```js
 module.exports = {
   themeConfig: {
     algolia: {
+      apiId: 'your_api_id',
       apiKey: 'your_api_key',
       indexName: 'index_name'
     }
@@ -19,6 +20,7 @@ For more options, check out [Algolia DocSearch's documentation](https://docsearc
 module.exports = {
   themeConfig: {
     algolia: {
+      apiId: 'your_api_id',
       apiKey: 'your_api_key',
       indexName: 'index_name',
       searchParameters: {


### PR DESCRIPTION
The vitepress uses algolia [DocSearch v3](https://github.com/algolia/docsearch/). In this version, `appId` is now required.

See: [Migrating from DocSearch v2](https://docsearch.algolia.com/docs/migrating-from-v2).