### PR TITLE
docs: edge comment about details

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -140,7 +140,7 @@ This is a dangerous warning
 :::
 
 ::: details
-This is a details block, which does not work in Internet Explorer or Edge.
+This is a details block, which does not work in Internet Explorer or Edge (before version 98)
 :::
 ```
 

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -140,7 +140,7 @@ This is a dangerous warning
 :::
 
 ::: details
-This is a details block, which does not work in Internet Explorer or Edge (before version 98)
+This is a details block, which does not work in Internet Explorer or old versions of Edge.
 :::
 ```
 


### PR DESCRIPTION
Edge after the switch to using chromium engine (version 98) does support details block