### PR TITLE
ESM instead of CommonJs

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -16,7 +16,7 @@ Without any configuration, the page is pretty minimal, and the user has no way t
 The essential file for configuring a VitePress site is `.vitepress/config.js`, which should export a JavaScript object:
 
 ```js
-module.exports = {
+export default {
   title: 'Hello VitePress',
   description: 'Just playing around.'
 }


### PR DESCRIPTION
Modified the CommonJs style export of `config.js` to the ESM style export.

Vite is all about advancement of tools. Why not reflect it in documents, by using ESM instead of CommonJs.