### PR TITLE
fix(plugin): set content-type header for serving index.html

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -164,6 +164,7 @@ export function createVitePressPlugin(
         server.middlewares.use((req, res, next) => {
           if (req.url!.endsWith('.html')) {
             res.statusCode = 200
+            res.setHeader('Content-Type', 'text/html')
             res.end(`
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
This is a small PR that sets the `Content-Type` for serving the `index.html`. I think it's good practice to set this header and I ran into an issue with WebContainer where we expected this header to be present. I have fixed this on our end but I also wanted to make sure that the `index.html` is served with the correct `Content-Type` header.