### PR TITLE
fix: remove `configureServer()` hack and use Vite 3 instead

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -162,10 +162,9 @@ export function createVitePressPlugin(
       // serve our index.html after vite history fallback
       return () => {
         server.middlewares.use((req, res, next) => {
-          if (req.url!.endsWith('.html')) {
-            res.statusCode = 200
-            res.setHeader('Content-Type', 'text/html')
-            res.end(`
+          res.statusCode = 200
+          res.setHeader('Content-Type', 'text/html')
+          res.end(`
 <!DOCTYPE html>
 <html>
   <head>
@@ -179,9 +178,6 @@ export function createVitePressPlugin(
     <script type="module" src="/@fs/${APP_PATH}/index.js"></script>
   </body>
 </html>`)
-            return
-          }
-          next()
         })
       }
     },


### PR DESCRIPTION
This PR removes a hack that was needed to inject the Vitepress middleware. After we merge https://github.com/vitejs/vite/pull/8217 we won't need that hack anymore.

This is a draft to show how to make Vitepress work with https://github.com/vitejs/vite/pull/8217.

We can merge this PR after merging https://github.com/vitejs/vite/pull/8217.