### PR TITLE
workflow(next-theme): include `packageManager`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vitepress",
   "version": "1.0.0-draft.1",
+  "packageManager": "pnpm@7.0.1",
   "description": "Vite & Vue powered static site generator",
   "main": "dist/node/index.js",
   "typings": "types/index.d.ts",


### PR DESCRIPTION
The `pnpm` lock file is using `pnpm@7.0.1` (version 5.4)