### PR TITLE
fix(next-theme): import and use `VPDoc` instead `VPContentDoc`

### DIFF
--- a/src/client/theme-default/components/VPContent.vue
+++ b/src/client/theme-default/components/VPContent.vue
@@ -4,7 +4,7 @@ import { useSidebar } from '../composables/sidebar'
 import NotFound from '../NotFound.vue'
 import VPPage from './VPPage.vue'
 import VPHome from './VPHome.vue'
-import VPContentDoc from './VPContentDoc.vue'
+import VPDoc from './VPDoc.vue'
 
 const route = useRoute()
 const { frontmatter } = useData()
@@ -20,7 +20,7 @@ const { hasSidebar } = useSidebar()
     <NotFound v-if="route.component === NotFound" />
     <VPPage v-else-if="frontmatter.layout === 'page'" />
     <VPHome v-else-if="frontmatter.layout === 'home'" />
-    <VPContentDoc v-else :class="{ 'has-sidebar': hasSidebar }" />
+    <VPDoc v-else :class="{ 'has-sidebar': hasSidebar }" />
   </div>
 </template>
 


### PR DESCRIPTION
When running `docs-dev` script I get the following error, it seems `VPContentDoc`  has been renamed to `VPDoc`:
```shell
> vitepress@1.0.0-draft.1 docs-dev F:\work\projects\quini\GitHub\vitepress
> node ./bin/vitepress dev docs                                               

vitepress v1.0.0-draft.1

  > Local: http://localhost:3000/
  > Network: use `--host` to expose
Failed to resolve import "./VPContentDoc.vue" from "dist\client\theme-default\components\VPContent.vue". Does the file exist?
21:37:43 [vite] Internal server error: Failed to resolve import "./VPContentDoc.vue" from "dist\client\theme-default\components\VPContent.vue". Does the file exist?
  Plugin: vite:import-analysis
  File: F:/work/projects/quini/GitHub/vitepress/dist/client/theme-default/components/VPContent.vue
  5  |  import VPPage from "./VPPage.vue";
  6  |  import VPHome from "./VPHome.vue";
  7  |  import VPContentDoc from "./VPContentDoc.vue";
     |                            ^
  8  |  const _sfc_main = /* @__PURE__ */ _defineComponent({
  9  |    setup(__props, { expose }) {
```