### PR TITLE
fix(theme): header blur incomplete

### DIFF
--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -28,6 +28,7 @@ provide('close-screen', closeScreen)
 @media (min-width: 960px) {
   .VPNav {
     position: fixed;
+    backdrop-filter: saturate(50%) blur(8px);
   }
 }
 </style>

--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
 import { provide } from 'vue'
+import { useData } from 'vitepress'
 import { useNav } from '../composables/nav'
 import VPNavBar from './VPNavBar.vue'
 import VPNavScreen from './VPNavScreen.vue'
+import { useSidebar } from '../composables/sidebar'
 
+const { frontmatter } = useData()
+const { hasSidebar } = useSidebar()
 const { isScreenOpen, closeScreen, toggleScreen } = useNav()
 
 provide('close-screen', closeScreen)
 </script>
 
 <template>
-  <header class="VPNav">
+  <header class="VPNav" :class="{ 'no-sidebar' : !hasSidebar }">
     <VPNavBar :is-screen-open="isScreenOpen" @toggle-screen="toggleScreen" />
     <VPNavScreen :open="isScreenOpen" />
   </header>
@@ -28,6 +32,11 @@ provide('close-screen', closeScreen)
 @media (min-width: 960px) {
   .VPNav {
     position: fixed;
+  }
+}
+
+@media (min-width: 960px) {
+  .no-sidebar {
     backdrop-filter: saturate(50%) blur(8px);
   }
 }

--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -2,6 +2,7 @@
 import { provide } from 'vue'
 import { useSidebar } from '../composables/sidebar'
 import { useNav } from '../composables/nav'
+import { useSidebar } from '../composables/sidebar'
 import VPNavBar from './VPNavBar.vue'
 import VPNavScreen from './VPNavScreen.vue'
 
@@ -31,10 +32,8 @@ provide('close-screen', closeScreen)
   .VPNav {
     position: fixed;
   }
-}
 
-@media (min-width: 960px) {
-  .no-sidebar {
+  .VPNav.no-sidebar {
     backdrop-filter: saturate(50%) blur(8px);
   }
 }

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { useSidebar } from '../composables/sidebar'
 import VPNavBarTitle from './VPNavBarTitle.vue'
 import VPNavBarSearch from './VPNavBarSearch.vue'
 import VPNavBarMenu from './VPNavBarMenu.vue'
@@ -7,7 +8,6 @@ import VPNavBarAppearance from './VPNavBarAppearance.vue'
 import VPNavBarSocialLinks from './VPNavBarSocialLinks.vue'
 import VPNavBarExtra from './VPNavBarExtra.vue'
 import VPNavBarHamburger from './VPNavBarHamburger.vue'
-import { useSidebar } from '../composables/sidebar'
 
 const { hasSidebar } = useSidebar()
 
@@ -21,11 +21,11 @@ defineEmits<{
 </script>
 
 <template>
-  <div class="VPNavBar">
+  <div class="VPNavBar" :class="{ 'has-sidebar' : hasSidebar }">
     <div class="container">
       <VPNavBarTitle />
 
-      <div class="content" :class="{ 'has-sidebar' : hasSidebar }">
+      <div class="content">
         <VPNavBarSearch class="search" />
         <VPNavBarMenu class="menu" />
         <VPNavBarTranslations class="translations" />
@@ -63,6 +63,10 @@ defineEmits<{
     height: var(--vp-nav-height-desktop);
     border-bottom: 0;
   }
+
+  .VPNavBar.has-sidebar .content {
+    backdrop-filter: saturate(50%) blur(8px);
+  }
 }
 
 .container {
@@ -77,12 +81,6 @@ defineEmits<{
   justify-content: flex-end;
   align-items: center;
   flex-grow: 1;
-}
-
-@media (min-width: 960px) {
-  .has-sidebar {
-    backdrop-filter: saturate(50%) blur(8px);
-  }
 }
 
 .menu + .translations::before,

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -76,12 +76,6 @@ defineEmits<{
   flex-grow: 1;
 }
 
-@media (min-width: 960px) {
-  .content {
-    backdrop-filter: saturate(50%) blur(8px);
-  }
-}
-
 .menu + .translations::before,
 .menu + .appearance::before,
 .menu + .social-links::before,

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -7,6 +7,9 @@ import VPNavBarAppearance from './VPNavBarAppearance.vue'
 import VPNavBarSocialLinks from './VPNavBarSocialLinks.vue'
 import VPNavBarExtra from './VPNavBarExtra.vue'
 import VPNavBarHamburger from './VPNavBarHamburger.vue'
+import { useSidebar } from '../composables/sidebar'
+
+const { hasSidebar } = useSidebar()
 
 defineProps<{
   isScreenOpen: boolean
@@ -22,7 +25,7 @@ defineEmits<{
     <div class="container">
       <VPNavBarTitle />
 
-      <div class="content">
+      <div class="content" :class="{ 'has-sidebar' : hasSidebar }">
         <VPNavBarSearch class="search" />
         <VPNavBarMenu class="menu" />
         <VPNavBarTranslations class="translations" />
@@ -74,6 +77,12 @@ defineEmits<{
   justify-content: flex-end;
   align-items: center;
   flex-grow: 1;
+}
+
+@media (min-width: 960px) {
+  .has-sidebar {
+    backdrop-filter: saturate(50%) blur(8px);
+  }
 }
 
 .menu + .translations::before,


### PR DESCRIPTION
 The `content` class doesn't occupy 100% of the width, so the header's blur is not complete and appears abrupt.