### PR TITLE
fix: allow disabling `markdown-it-attrs`

### DIFF
--- a/docs/config/app-configs.md
+++ b/docs/config/app-configs.md
@@ -119,6 +119,7 @@ interface MarkdownOptions extends MarkdownIt.Options {
     leftDelimiter?: string
     rightDelimiter?: string
     allowedAttributes?: string[]
+    disable?: boolean
   }
 
   // markdown-it-table-of-contents cplugin options

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -29,6 +29,7 @@ export interface MarkdownOptions extends MarkdownIt.Options {
     leftDelimiter?: string
     rightDelimiter?: string
     allowedAttributes?: string[]
+    disable?: boolean
   }
   theme?: Theme
   // https://github.com/Oktavilla/markdown-it-table-of-contents
@@ -80,13 +81,17 @@ export const createMarkdownRenderer = async (
       },
       base
     )
-    // 3rd party plugins
-    .use(attrs, options.attrs)
-    .use(anchor, {
-      slugify,
-      permalink: anchor.permalink.ariaHidden({}),
-      ...options.anchor
-    })
+
+  // 3rd party plugins
+  if (!options.attrs?.disable) {
+    md.use(attrs, options.attrs)
+  }
+
+  md.use(anchor, {
+    slugify,
+    permalink: anchor.permalink.ariaHidden({}),
+    ...options.anchor
+  })
     .use(toc, {
       slugify,
       includeLevel: [2, 3],

--- a/src/node/markdown/plugins/highlightLines.ts
+++ b/src/node/markdown/plugins/highlightLines.ts
@@ -10,20 +10,23 @@ export const highlightLinePlugin = (md: MarkdownIt) => {
     const [tokens, idx, options] = args
     const token = tokens[idx]
 
-    // due to use of markdown-it-attrs, the {0} syntax would have been converted
-    // to attrs on the token
+    // due to use of markdown-it-attrs, the {0} syntax would have been
+    // converted to attrs on the token
     const attr = token.attrs && token.attrs[0]
+
     let lines = null
+
     if (!attr) {
       // markdown-it-attrs maybe disabled
-
       const rawInfo = token.info
+
       if (!rawInfo || !RE.test(rawInfo)) {
         return fence(...args)
       }
 
       const langName = rawInfo.replace(RE, '').trim()
-      // ensure the next plugin get the correct lang.
+
+      // ensure the next plugin get the correct lang
       token.info = langName
 
       lines = RE.exec(rawInfo)![1]
@@ -31,6 +34,7 @@ export const highlightLinePlugin = (md: MarkdownIt) => {
 
     if (!lines) {
       lines = attr![0]
+
       if (!lines || !/[\d,-]+/.test(lines)) {
         return fence(...args)
       }
@@ -45,6 +49,7 @@ export const highlightLinePlugin = (md: MarkdownIt) => {
       : token.content
 
     const rawCode = code.replace(wrapperRE, '')
+
     const highlightLinesCode = rawCode
       .split('\n')
       .map((split, index) => {


### PR DESCRIPTION
fixes #662
fixes #629

`markdown-it-attrs` can now be disabled using the following config:

```ts
import { defineConfig } from 'vitepress'

export default defineConfig({
  markdown: { attrs: { disable: true } },
})
```