### PR TITLE
feat: add cjs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/node/index.js"
+      "import": "./dist/node/index.js",
+      "require": "./dist/node-cjs/index.cjs"
     },
     "./dist/client/*": "./dist/client/*"
   },
@@ -45,7 +46,7 @@
     "dev": "rimraf dist && run-s dev-shared dev-start",
     "dev-start": "run-p dev-client dev-node dev-watch",
     "dev-client": "tsc -w -p src/client",
-    "dev-node": "pnpm run build-node -w",
+    "dev-node": "DEV=true pnpm run build-node -w",
     "dev-shared": "node scripts/copyShared",
     "dev-watch": "node scripts/watchAndCopy",
     "build": "run-s build-prepare build-client build-node",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'rollup'
+import { RollupOptions, defineConfig } from 'rollup'
 import { promises as fs } from 'fs'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
@@ -11,68 +11,99 @@ import { resolve } from 'path'
 import { fileURLToPath } from 'url'
 import pkg from './package.json'
 
+const DEV = !!process.env.DEV
+const PROD = !DEV
+
 const ROOT = fileURLToPath(import.meta.url)
 const r = (p: string) => resolve(ROOT, '..', p)
 
-const external = [
-  ...Object.keys(pkg.dependencies),
-  'buffer',
-  'punycode'
+const external = [...Object.keys(pkg.dependencies), 'buffer', 'punycode']
+
+const plugins = [
+  alias({
+    entries: {
+      'readable-stream': 'stream'
+    }
+  }),
+  replace({
+    // polyfill broken browser check from bundled deps
+    'navigator.userAgentData': 'undefined',
+    'navigator.userAgent': 'undefined',
+    preventAssignment: true
+  }),
+  commonjs(),
+  nodeResolve(),
+  esbuild({ target: 'node14' }),
+  json()
 ]
 
-export default defineConfig([
-  {
-    input: [r('src/node/index.ts'), r('src/node/cli.ts')],
-    output: {
-      format: 'esm',
-      dir: r('dist/node')
-    },
-    external,
-    plugins: [
-      alias({
-        entries: {
-          'readable-stream': 'stream'
-        }
-      }),
-      replace({
-        // polyfill broken browser check from bundled deps
-        'navigator.userAgentData': 'undefined',
-        'navigator.userAgent': 'undefined',
-        preventAssignment: true
-      }),
-      commonjs(),
-      nodeResolve(),
-      esbuild({
-        target: 'node14'
-      }),
-      json()
-    ],
-    onwarn(warning, warn) {
-      if (warning.code !== 'EVAL') warn(warning)
-    }
+const esmBuild: RollupOptions = {
+  input: [r('src/node/index.ts'), r('src/node/cli.ts')],
+  output: {
+    format: 'esm',
+    entryFileNames: `[name].js`,
+    chunkFileNames: 'serve-[hash].js',
+    dir: r('dist/node')
   },
-  {
-    input: r('src/node/index.ts'),
-    output: {
-      format: 'esm',
-      file: 'dist/node/index.d.ts'
-    },
-    plugins: [dts()]
+  external,
+  plugins,
+  onwarn(warning, warn) {
+    if (warning.code !== 'EVAL') warn(warning)
+  }
+}
+
+const cjsBuild: RollupOptions = {
+  input: [r('src/node/index.ts'), r('src/node/cli.ts')],
+  output: {
+    format: 'cjs',
+    dir: r('dist/node-cjs'),
+    entryFileNames: `[name].cjs`,
+    chunkFileNames: 'serve-[hash].cjs'
   },
-  {
-    input: r('dist/client-types/index.d.ts'),
-    output: {
-      format: 'esm',
-      file: 'dist/client/index.d.ts'
-    },
-    plugins: [
-      dts(),
-      {
-        name: 'cleanup',
-        async closeBundle() {
+  external,
+  plugins,
+  onwarn(warning, warn) {
+    if (warning.code !== 'EVAL') warn(warning)
+  }
+}
+
+const nodeTypes: RollupOptions = {
+  input: r('src/node/index.ts'),
+  output: {
+    format: 'esm',
+    file: 'dist/node/index.d.ts'
+  },
+  plugins: [dts()]
+}
+
+const clientTypes: RollupOptions = {
+  input: r('dist/client-types/index.d.ts'),
+  output: {
+    format: 'esm',
+    file: 'dist/client/index.d.ts'
+  },
+  plugins: [
+    dts(),
+    {
+      name: 'cleanup',
+      async closeBundle() {
+        if (PROD) {
           await fs.rm(r('dist/client-types'), { recursive: true })
         }
       }
-    ]
-  }
-])
+    }
+  ]
+}
+
+const config = defineConfig([])
+
+config.push(esmBuild)
+
+if (PROD) {
+  config.push(cjsBuild)
+}
+
+config.push(nodeTypes)
+config.push(clientTypes)
+
+export default config


### PR DESCRIPTION
Add cjs bundle for the new esm build setting #659. Also handles missing `client-types` folder error in dev mode.