### PR TITLE
fix(toc): encode string returned by parseHeader (#605)

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -95,7 +95,8 @@ export const createMarkdownRenderer = async (
     .use(toc, {
       slugify,
       level: [2, 3],
-      format: parseHeader,
+      format: (x: string, htmlencode: (s: string) => string) =>
+        htmlencode(parseHeader(x)),
       listType: 'ul',
       ...options.toc
     })


### PR DESCRIPTION
fixes: #605