### PR TITLE
fix: missing alt attribute on images even if provided

### DIFF
--- a/src/node/markdown/plugins/image.ts
+++ b/src/node/markdown/plugins/image.ts
@@ -11,7 +11,7 @@ export const imagePlugin = (md: MarkdownIt) => {
       token.attrSet('src', './' + url)
     }
 
-    if (token.attrIndex('alt') && token.children !== null) {
+    if (token.attrIndex('alt') && token.children != null) {
       token.attrs![token.attrIndex('alt')][1] = self.renderInlineAsText(
         token.children,
         options,

--- a/src/node/markdown/plugins/image.ts
+++ b/src/node/markdown/plugins/image.ts
@@ -10,6 +10,15 @@ export const imagePlugin = (md: MarkdownIt) => {
     if (url && !EXTERNAL_URL_RE.test(url) && !/^\.?\//.test(url)) {
       token.attrSet('src', './' + url)
     }
+
+    if (token.attrIndex('alt') && token.children !== null) {
+      token.attrs![token.attrIndex('alt')][1] = self.renderInlineAsText(
+        token.children,
+        options,
+        env
+      )
+    }
+
     return self.renderToken(tokens, idx, options)
   }
 }


### PR DESCRIPTION
Follow up: #679 

Fix for the `next-theme`