### PR TITLE
feat: allow external links in sidebar

### DIFF
--- a/src/client/theme-default/components/VPSidebarGroup.vue
+++ b/src/client/theme-default/components/VPSidebarGroup.vue
@@ -6,7 +6,7 @@ import VPIconMinusSquare from './icons/VPIconMinusSquare.vue'
 import VPSidebarLink from './VPSidebarLink.vue'
 
 const props = defineProps<{
-  text: string
+  text?: string
   items: DefaultTheme.SidebarItem[]
   collapsible?: boolean
   collapsed?: boolean
@@ -23,7 +23,12 @@ function toggle() {
 
 <template>
   <section class="VPSidebarGroup" :class="{ collapsible, collapsed }">
-    <div class="title" :role="collapsible ? 'button' : undefined" @click="toggle">
+    <div
+      v-if="text"
+      class="title"
+      :role="collapsible ? 'button' : undefined"
+      @click="toggle"
+    >
       <h2 class="title-text">{{ text }}</h2>
       <div class="action">
         <VPIconMinusSquare class="icon minus" />

--- a/src/client/theme-default/components/VPSidebarLink.vue
+++ b/src/client/theme-default/components/VPSidebarLink.vue
@@ -3,6 +3,7 @@ import { inject } from 'vue'
 import { useData } from 'vitepress'
 import { DefaultTheme } from '../config'
 import { isActive, normalizeLink } from '../support/utils'
+import VPLink from './VPLink.vue'
 
 defineProps<{
   item: DefaultTheme.SidebarItem
@@ -14,28 +15,36 @@ const closeSideBar = inject('close-sidebar') as () => void
 </script>
 
 <template>
-  <a
-    class="link"
+  <VPLink
     :class="{ active: isActive(page.relativePath, item.link) }"
     :href="normalizeLink(item.link)"
     @click="closeSideBar"
   >
-    <p class="link-text">{{ item.text }}</p>
-  </a>
+    <span class="link-text">{{ item.text }}</span>
+  </VPLink>
 </template>
 
 <style scoped>
+:deep(.icon) {
+  margin-top: -2px;
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
 .link {
   display: block;
   padding: 6px 0;
+  color: var(--vp-c-text-2);
+  transition: color 0.5s;
 }
 
-.link:hover .link-text {
+.link:hover {
   color: var(--vp-c-text-1);
   transition: color 0.25s;
 }
 
-.link.active .link-text {
+.link.active {
   color: var(--vp-c-brand);
   transition: color 0.25s;
 }
@@ -44,7 +53,5 @@ const closeSideBar = inject('close-sidebar') as () => void
   line-height: 20px;
   font-size: 14px;
   font-weight: 500;
-  color: var(--vp-c-text-2);
-  transition: color 0.5s;
 }
 </style>

--- a/src/client/theme-default/components/VPSidebarLink.vue
+++ b/src/client/theme-default/components/VPSidebarLink.vue
@@ -25,13 +25,6 @@ const closeSideBar = inject('close-sidebar') as () => void
 </template>
 
 <style scoped>
-:deep(.icon) {
-  margin-top: -2px;
-  width: 14px;
-  height: 14px;
-  fill: currentColor;
-}
-
 .link {
   display: block;
   padding: 6px 0;
@@ -41,12 +34,16 @@ const closeSideBar = inject('close-sidebar') as () => void
 
 .link:hover {
   color: var(--vp-c-text-1);
-  transition: color 0.25s;
 }
 
 .link.active {
   color: var(--vp-c-brand);
-  transition: color 0.25s;
+}
+
+.link :deep(.icon) {
+  width: 12px;
+  height: 12px;
+  fill: currentColor;
 }
 
 .link-text {

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -86,7 +86,7 @@ export namespace DefaultTheme {
   }
 
   export interface SidebarGroup {
-    text: string
+    text?: string
     items: SidebarItem[]
 
     /**


### PR DESCRIPTION
fixes: #205
closes: #481

Config:

```js
import { defineConfig } from 'vitepress'

export default defineConfig({
  themeConfig: {
    sidebar: [
      { items: [{ text: 'External Link', link: 'https://...' }] }
    ]
  }
})
```

Result:

![image](https://user-images.githubusercontent.com/40380293/170961008-655fa3bd-b47a-4e28-9c7e-679062081238.png)
