### PR TITLE
feat: allow custom outline title (#689)

### DIFF
--- a/src/client/theme-default/components/VPDocAsideOutline.vue
+++ b/src/client/theme-default/components/VPDocAsideOutline.vue
@@ -7,7 +7,7 @@ import {
   useActiveAnchor
 } from '../composables/outline'
 
-const { page, frontmatter } = useData()
+const { page, frontmatter, theme } = useData()
 
 const { hasOutline } = useOutline()
 
@@ -32,7 +32,9 @@ function handleClick({ target: el }: Event) {
     <div class="content">
       <div class="outline-marker" ref="marker" />
 
-      <div class="outline-title">On this page</div>
+      <div class="outline-title">
+        {{ theme.outlineTitle || 'On this page' }}
+      </div>
 
       <nav aria-labelledby="doc-outline-aria-label">
         <span class="visually-hidden" id="doc-outline-aria-label">

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -14,6 +14,13 @@ export namespace DefaultTheme {
     siteTitle?: string | false
 
     /**
+     * Custom outline title in the aside component.
+     *
+     * @default 'On this page'
+     */
+    outlineTitle?: string
+
+    /**
      * The nav items.
      */
     nav?: NavItem[]


### PR DESCRIPTION
fixes: #689

Introduced `themeConfig.outlineTitle`. By default it will be "On this page".