### PR TITLE
feat: support custom content in home layout

### DIFF
--- a/src/client/theme-default/components/VPHome.vue
+++ b/src/client/theme-default/components/VPHome.vue
@@ -13,13 +13,7 @@ import VPHomeFeatures from './VPHomeFeatures.vue'
     <VPHomeFeatures />
     <slot name="home-features-after" />
 
-    <div class="content">
-      <div class="content-container">
-        <main class="main">
-          <Content class="vp-doc" />
-        </main>
-      </div>
-    </div>
+    <Content />
   </div>
 </template>
 

--- a/src/client/theme-default/components/VPHome.vue
+++ b/src/client/theme-default/components/VPHome.vue
@@ -1,13 +1,6 @@
 <script setup lang="ts">
 import VPHomeHero from './VPHomeHero.vue'
 import VPHomeFeatures from './VPHomeFeatures.vue'
-import { computed } from 'vue';
-import { useData } from 'vitepress';
-
-const { page } = useData()
-const pageName = computed(() => {
-  return page.value.relativePath.slice(0, page.value.relativePath.indexOf('/'))
-})
 </script>
 
 <template>
@@ -23,7 +16,7 @@ const pageName = computed(() => {
     <div class="content">
       <div class="content-container">
         <main class="main">
-          <Content class="vp-doc" :class="pageName" />
+          <Content class="vp-doc" />
         </main>
       </div>
     </div>

--- a/src/client/theme-default/components/VPHome.vue
+++ b/src/client/theme-default/components/VPHome.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import VPHomeHero from './VPHomeHero.vue'
 import VPHomeFeatures from './VPHomeFeatures.vue'
+import { computed } from 'vue';
+import { useData } from 'vitepress';
+
+const { page } = useData()
+const pageName = computed(() => {
+  return page.value.relativePath.slice(0, page.value.relativePath.indexOf('/'))
+})
 </script>
 
 <template>
@@ -12,6 +19,14 @@ import VPHomeFeatures from './VPHomeFeatures.vue'
     <slot name="home-features-before" />
     <VPHomeFeatures />
     <slot name="home-features-after" />
+
+    <div class="content">
+      <div class="content-container">
+        <main class="main">
+          <Content class="vp-doc" :class="pageName" />
+        </main>
+      </div>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Since v1, it's not possible to have custom content/components on the home page:

```md
---
layout: home
---

All the following content will be ignored
```

which was quite useful in v0.x to provide additional info on the home page.

This PR brings back the ability, but not so sure if it's a ideal solution
