### PR TITLE
fix: better nav types

### DIFF
--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -86,12 +86,14 @@ export namespace DefaultTheme {
     activeMatch?: string
   }
 
+  export type NavItemChildren = {
+    text?: string
+    items: NavItemWithLink[]
+  }
+
   export interface NavItemWithChildren {
     text?: string
-    items: {
-      text?: string
-      items: NavItemWithLink[]
-    }[]
+    items: (NavItemChildren | NavItemWithLink)[]
   }
 
   // sidebar -------------------------------------------------------------------

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -81,7 +81,10 @@ export namespace DefaultTheme {
 
   export interface NavItemWithChildren {
     text?: string
-    items: NavItem[]
+    items: {
+      text?: string
+      items: NavItemWithLink[]
+    }[]
   }
 
   // sidebar -------------------------------------------------------------------


### PR DESCRIPTION
Thanks for solving my problem before, but here I think a little change is needed.

`VPMenuGroup.vue` only one level of nesting is allowed：

```vue
<template>
  <div class="VPMenuGroup">
    <p v-if="text" class="title">{{ text }}</p>

    <template v-for="item in items">
      <VPMenuLink v-if="'link' in item" :item="item" />
    </template>
  </div>
</template>
```

But the type `items: NavItem[]` may be infinitely nested, the following Nav configuration code is allowed:

```typescript
nav: [
    {
        text: 'Dropdown Menu',
        items: [
            {
                // Title for the section.
                text: 'Section A Title',
                items: [
                    { text: 'Section A Item 1', link: '...' },
                    { text: 'Section A Item 2', link: '...' },
                ],
            },
            {
                // Title for the section.
                text: 'Section B Title',
                items: [
                    { text: 'Section B Item 1', link: '...' },
                    {
                        text: 'Section B Item 2',
                        items: [
                            {
                                // Title for the section.
                                text: 'Section C Title',
                                items: [
                                    { text: 'Section C Item 1', link: '...' },
                                    { text: 'Section C Item 2', link: '...' },
                                ],
                            },
                        ],
                    },
                ],
            },
        ],
    },
]
```

It passed the type check.