### PR TITLE
feat: don't add .html to urls

### DIFF
--- a/docs/guide/migration-from-vitepress-0.md
+++ b/docs/guide/migration-from-vitepress-0.md
@@ -12,7 +12,7 @@ If you're coming from VitePress 0.x version, there're several breaking changes d
   - `children` key is now named `items`.
   - Top level item may not contain `link` at the moment. We're planning to bring it back.
 - `repo`, `repoLabel`, `docsDir`, `docsBranch`, `editLinks`, `editLinkText` are removed in favor of more flexible api.
-  - For adding GitHub link with icon to the nav, use [Social Links](./theme-nav.html#navigation-links) feature.
+  - For adding GitHub link with icon to the nav, use [Social Links](./theme-nav#navigation-links) feature.
   - For adding "Edit this page" feature, use [Edit Link](./theme-edit-link) feature.
 - `lastUpdated` option is now split into `config.lastUpdated` and `themeConfig.lastUpdatedText`.
 - `carbonAds.carbon` is changed to `carbonAds.code`.

--- a/docs/guide/theme-nav.md
+++ b/docs/guide/theme-nav.md
@@ -4,7 +4,7 @@ The Nav is the navigation bar displayed on top of the page. It contains the site
 
 ## Site Title and Logo
 
-By default, nav shows the title of the site refferencing [`config.title`](../config/app-configs.html#title) value. If you would like to change what's displayed on nav, you may define custom text in `themeConfig.siteTitle` option.
+By default, nav shows the title of the site refferencing [`config.title`](../config/app-configs#title) value. If you would like to change what's displayed on nav, you may define custom text in `themeConfig.siteTitle` option.
 
 ```js
 export default {

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -48,12 +48,6 @@ export function createRouter(
   const route = reactive(getDefaultRoute())
 
   function go(href: string = inBrowser ? location.href : '/') {
-    // ensure correct deep link so page refresh lands on correct files.
-    const url = new URL(href, fakeHost)
-    if (!url.pathname.endsWith('/') && !url.pathname.endsWith('.html')) {
-      url.pathname += '.html'
-      href = url.pathname + url.search + url.hash
-    }
     if (inBrowser) {
       // save scroll position before changing url
       history.replaceState({ scrollPosition: window.scrollY }, document.title)

--- a/src/client/app/utils.ts
+++ b/src/client/app/utils.ts
@@ -35,7 +35,8 @@ export function pathToFile(path: string): string {
     // /foo/bar.html -> ./foo_bar.md
     if (inBrowser) {
       const base = import.meta.env.BASE_URL
-      pagePath = pagePath.slice(base.length).replace(/\//g, '_') + '.md'
+      pagePath =
+        (pagePath.slice(base.length).replace(/\//g, '_') || 'index') + '.md'
       // client production build needs to account for page hash, which is
       // injected directly in the page's html
       const pageHash = __VP_HASH_MAP__[pagePath.toLowerCase()]

--- a/src/client/theme-default/support/utils.ts
+++ b/src/client/theme-default/support/utils.ts
@@ -79,7 +79,7 @@ export function normalizeLink(url: string): string {
   const normalizedPath =
     pathname.endsWith('/') || pathname.endsWith('.html')
       ? url
-      : `${pathname.replace(/(\.md)?$/, '.html')}${search}${hash}`
+      : `${pathname.replace(/(\.md)?$/, '')}${search}${hash}`
 
   return withBase(normalizedPath)
 }

--- a/src/node/markdown/plugins/link.ts
+++ b/src/node/markdown/plugins/link.ts
@@ -58,15 +58,7 @@ export const linkPlugin = (
       const [, path, hash] = indexMatch
       url = path + hash
     } else {
-      let cleanUrl = url.replace(/[?#].*$/, '')
-      // .md -> .html
-      if (cleanUrl.endsWith('.md')) {
-        cleanUrl = cleanUrl.replace(/\.md$/, '.html')
-      }
-      // ./foo -> ./foo.html
-      if (!cleanUrl.endsWith('.html') && !cleanUrl.endsWith('/')) {
-        cleanUrl += '.html'
-      }
+      const cleanUrl = url.replace(/[?#].*$/, '').replace(/\.md$/, '')
       const parsed = new URL(url, 'http://a.com')
       url = cleanUrl + parsed.search + parsed.hash
     }


### PR DESCRIPTION
Taking over #488.

The router will no longer force `.html` in urls. There is no change in the generated directory structure.
