### PR TITLE
fix(hero): use `pre-wrap` for text and tagline

### DIFF
--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -115,6 +115,7 @@ defineProps<{
   line-height: 40px;
   font-size: 32px;
   font-weight: 700;
+  white-space: pre-wrap;
 }
 
 .VPHero.has-image .name,
@@ -161,6 +162,7 @@ defineProps<{
   line-height: 28px;
   font-size: 18px;
   font-weight: 500;
+  white-space: pre-wrap;
   color: var(--vp-c-text-2);
 }
 


### PR DESCRIPTION
This allows user to set manual line breaks, for example:

```yaml
---
hero:
  name: PWA
  text: Vite Plugin
  tagline: |
    Zero-config and framework-agnostic
    PWA Plugin for Vite
---
```
