### PR TITLE
feat(next): use algolia button text from theme config

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -76,7 +76,7 @@ function load() {
               stroke-linejoin="round"
             />
           </svg>
-          <span class="DocSearch-Button-Placeholder">Search</span>
+          <span class="DocSearch-Button-Placeholder">{{ theme.algolia?.buttonText || 'Search' }}</span>
         </span>
         <span class="DocSearch-Button-Keys">
           <kbd class="DocSearch-Button-Key" ref="metaKey">Meta</kbd>

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -191,6 +191,7 @@ export namespace DefaultTheme {
     searchParameters?: any
     disableUserPersonalization?: boolean
     initialQuery?: string
+    buttonText?: string
   }
 
   // carbon ads ----------------------------------------------------------------


### PR DESCRIPTION
fixes: #713 

Anyway, I used `buttonText` in this PR for simplicity.