### PR TITLE
fix(next): sidebar link base duplicated

### DIFF
--- a/src/client/theme-default/components/VPSidebarLink.vue
+++ b/src/client/theme-default/components/VPSidebarLink.vue
@@ -17,7 +17,7 @@ const closeSideBar = inject('close-sidebar') as () => void
 <template>
   <VPLink
     :class="{ active: isActive(page.relativePath, item.link) }"
-    :href="normalizeLink(item.link)"
+    :href="item.link"
     @click="closeSideBar"
   >
     <span class="link-text">{{ item.text }}</span>


### PR DESCRIPTION
`VPLink` component already use `normalizeLink` which prepends the base.