### PR TITLE
fix: switch to h2 for feature headers

### DIFF
--- a/src/client/theme-default/components/VPBox.vue
+++ b/src/client/theme-default/components/VPBox.vue
@@ -9,7 +9,7 @@ defineProps<{
 <template>
   <article class="VPBox">
     <div v-if="icon" class="icon">{{ icon }}</div>
-    <h1 class="title">{{ title }}</h1>
+    <h2 class="title">{{ title }}</h2>
     <p class="details">{{ details }}</p>
   </article>
 </template>


### PR DESCRIPTION
Theoretically Google is smart enough to work with multiple h1 headers. But using h2 for hero features, I think, makes more sense.