### PR TITLE
refactor: improve page data parsing

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -28,7 +28,7 @@ const getDefaultRoute = (): Route => ({
 })
 
 interface PageModule {
-  __pageData: string
+  __pageData: PageData
   default: Component
 }
 
@@ -76,8 +76,8 @@ export function createRouter(
         route.path = inBrowser ? pendingPath : withBase(pendingPath)
         route.component = markRaw(comp)
         route.data = import.meta.env.PROD
-          ? markRaw(JSON.parse(__pageData))
-          : (readonly(JSON.parse(__pageData)) as PageData)
+          ? markRaw(__pageData)
+          : (readonly(__pageData) as PageData)
 
         if (inBrowser) {
           nextTick(() => {

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -60,7 +60,7 @@ export async function renderPage(
     const { __pageData } = await import(
       pathToFileURL(path.join(config.tempDir, pageServerJsFileName)).toString()
     )
-    pageData = JSON.parse(__pageData)
+    pageData = __pageData
   } catch (e) {
     if (page === '404.md') {
       hasCustom404 = false

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -169,9 +169,9 @@ const defaultExportRE = /((?:^|\n|;)\s*)export(\s*)default/
 const namedDefaultExportRE = /((?:^|\n|;)\s*)export(.+)as(\s*)default/
 
 function genPageDataCode(tags: string[], data: PageData) {
-  const code = `\nexport const __pageData = ${JSON.stringify(
+  const code = `\nexport const __pageData = JSON.parse(${JSON.stringify(
     JSON.stringify(data)
-  )}`
+  )})`
 
   const existingScriptIndex = tags.findIndex((tag) => {
     return (


### PR DESCRIPTION
Put `JSON.parse()` in the codegen, avoiding calling `JSON.parse()` everywhere.