### PR TITLE
refactor: handle page data hmr in the same file

### DIFF
--- a/src/client/app/index.ts
+++ b/src/client/app/index.ts
@@ -15,7 +15,6 @@ import { usePrefetch } from './composables/preFetch'
 import { dataSymbol, initData } from './data'
 import { Content } from './components/Content'
 import { ClientOnly } from './components/ClientOnly'
-import { PageDataPayload } from '../shared'
 
 const NotFound = Theme.NotFound || (() => '404 Not Found')
 
@@ -45,8 +44,6 @@ const VitePressApp = {
 
 export function createApp() {
   const router = newRouter()
-
-  handleHMR(router)
 
   const app = newApp()
 
@@ -114,25 +111,6 @@ function newRouter(): Router {
 
     return import(/*@vite-ignore*/ pageFilePath)
   }, NotFound)
-}
-
-function handleHMR(router: Router): void {
-  // update route.data on HMR updates of active page
-  if (import.meta.hot) {
-    // hot reload pageData
-    import.meta.hot!.on('vitepress:pageData', (payload: PageDataPayload) => {
-      if (shouldHotReload(payload)) {
-        router.route.data = payload.pageData
-      }
-    })
-  }
-}
-
-function shouldHotReload(payload: PageDataPayload): boolean {
-  const payloadPath = payload.path.replace(/(\bindex)?\.md$/, '')
-  const locationPath = location.pathname.replace(/(\bindex)?\.html$/, '')
-
-  return payloadPath === locationPath
 }
 
 if (inBrowser) {


### PR DESCRIPTION
**Before**

We are loading page data in `router.ts`, but handling page data HMR in `index.ts`, which is bad for maintainability and readability.

**After**

Moving the page data HMR code into `router.ts` as well.