### PR TITLE
refactor: improve site data parsing

### DIFF
--- a/src/client/app/data.ts
+++ b/src/client/app/data.ts
@@ -1,6 +1,6 @@
 import { InjectionKey, Ref, shallowRef, readonly, computed, inject } from 'vue'
 import { Route } from './router'
-import serializedSiteData from '@siteData'
+import siteData from '@siteData'
 import {
   PageData,
   SiteData,
@@ -25,17 +25,14 @@ export interface VitePressData<T = any> {
 // site data is a singleton
 export type SiteDataRef<T = any> = Ref<SiteData<T>>
 
-export const siteDataRef: Ref<SiteData> = shallowRef(parse(serializedSiteData))
-
-function parse(data: string): SiteData {
-  const parsed = JSON.parse(data)
-  return (import.meta.env.DEV ? readonly(parsed) : parsed) as SiteData
-}
+export const siteDataRef: Ref<SiteData> = shallowRef(
+  import.meta.env.PROD ? siteData : readonly(siteData)
+)
 
 // hmr
 if (import.meta.hot) {
   import.meta.hot!.accept('/@siteData', (m) => {
-    siteDataRef.value = parse(m.default)
+    siteDataRef.value = m.default
   })
 }
 

--- a/src/client/shim.d.ts
+++ b/src/client/shim.d.ts
@@ -10,7 +10,8 @@ declare module '*.vue' {
 }
 
 declare module '@siteData' {
-  const data: string
+  import type { SiteData } from './shared'
+  const data: SiteData
   export default data
 }
 

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -126,7 +126,9 @@ export async function createVitePressPlugin(
         if (config.command === 'build') {
           data = { ...siteData, head: [] }
         }
-        return `export default ${JSON.stringify(JSON.stringify(data))}`
+        return `export default JSON.parse(${JSON.stringify(
+          JSON.stringify(data)
+        )})`
       }
     },
 


### PR DESCRIPTION
Put `JSON.parse()` in the codegen, avoiding calling `JSON.parse()` everywhere.