### PR TITLE
feat(build): allow ignoring dead links

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -64,6 +64,13 @@ export interface UserConfig<ThemeConfig = any> {
    * @experimental
    */
   mpa?: boolean
+
+  /**
+   * Don't fail builds due to dead links.
+   *
+   * @default false
+   */
+  ignoreDeadLinks?: boolean
 }
 
 export type RawConfigExports<ThemeConfig = any> =
@@ -74,7 +81,13 @@ export type RawConfigExports<ThemeConfig = any> =
 export interface SiteConfig<ThemeConfig = any>
   extends Pick<
     UserConfig,
-    'markdown' | 'vue' | 'vite' | 'shouldPreload' | 'mpa' | 'lastUpdated'
+    | 'markdown'
+    | 'vue'
+    | 'vite'
+    | 'shouldPreload'
+    | 'mpa'
+    | 'lastUpdated'
+    | 'ignoreDeadLinks'
   > {
   root: string
   srcDir: string
@@ -152,7 +165,8 @@ export async function resolveConfig(
     vue: userConfig.vue,
     vite: userConfig.vite,
     shouldPreload: userConfig.shouldPreload,
-    mpa: !!userConfig.mpa
+    mpa: !!userConfig.mpa,
+    ignoreDeadLinks: userConfig.ignoreDeadLinks
   }
 
   return config

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -46,7 +46,8 @@ export async function createVitePressPlugin(
     site,
     vue: userVuePluginOptions,
     vite: userViteConfig,
-    pages
+    pages,
+    ignoreDeadLinks
   } = siteConfig
 
   let markdownToVue: Awaited<ReturnType<typeof createMarkdownToVueRenderFn>>
@@ -153,7 +154,7 @@ export async function createVitePressPlugin(
     },
 
     renderStart() {
-      if (hasDeadLinks) {
+      if (hasDeadLinks && !ignoreDeadLinks) {
         throw new Error(`One or more pages contain dead links.`)
       }
     },


### PR DESCRIPTION
This PR introduces a new option `ignoreDeadLinks` in user config:

```js
// .vitepress/config.js

export default {
  ignoreDeadLinks: true // <-- this will still warn users on dead links but won't throw error
                        // default value is false, i.e. builds will fail on encountering dead links
}
```

Fixes #586.