### PR TITLE
fix: no-self-closing copy span tag

### DIFF
--- a/src/node/markdown/plugins/preWrapper.ts
+++ b/src/node/markdown/plugins/preWrapper.ts
@@ -15,6 +15,6 @@ export const preWrapperPlugin = (md: MarkdownIt) => {
     const [tokens, idx] = args
     const token = tokens[idx]
     const rawCode = fence(...args)
-    return `<div class="language-${token.info.trim()}"><span class="copy" />${rawCode}</div>`
+    return `<div class="language-${token.info.trim()}"><span class="copy"></span>${rawCode}</div>`
   }
 }


### PR DESCRIPTION
In Faker we are using the markdown renderer but it produces `<span class="copy" />` which renders as non-displayed element in chrome (hidden somehow). Maybe the `v-html` tag removes the self-close and thus embeds the content in there?!

<img src="https://user-images.githubusercontent.com/7195563/174477268-221b8cae-0f24-4de6-9713-581dfe65e4c6.png" width="300px"/>

Nevermind, I don't really know and care what the actual bug is, but the fix that works is to not use self-closing span tag
`<span class="copy"></span>`

When manually editing the html it looks like this (correct assumed version):

<img src="https://user-images.githubusercontent.com/7195563/174477430-2f82e624-6561-48be-8b5c-687eddcfd405.png" width="300px"/>

