### PR TITLE
feat(theme): add team page feature

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -87,7 +87,8 @@ function sidebarGuide() {
         { text: 'Edit Link', link: '/guide/theme-edit-link' },
         { text: 'Last Updated', link: '/guide/theme-last-updated' },
         { text: 'Layout', link: '/guide/theme-layout' },
-        { text: 'Homepage', link: '/guide/theme-homepage' },
+        { text: 'Home Page', link: '/guide/theme-home-page' },
+        { text: 'Team Page', link: '/guide/theme-team-page' },
         { text: 'Footer', link: '/guide/theme-footer' },
         { text: 'Search', link: '/guide/theme-search' },
         { text: 'Carbon Ads', link: '/guide/theme-carbon-ads' }

--- a/docs/guide/migration-from-vitepress-0.md
+++ b/docs/guide/migration-from-vitepress-0.md
@@ -19,5 +19,5 @@ If you're coming from VitePress 0.x version, there're several breaking changes d
 
 ## Frontmatter Config
 
-- `home: true` option has changed to `layout: home`. Also, many Homepage related settings have been modified to provide additional features. See [Homepage guide](./theme-homepage) for details.
+- `home: true` option has changed to `layout: home`. Also, many Homepage related settings have been modified to provide additional features. See [Home Page guide](./theme-home-page) for details.
 - `footer` option is moved to [`themeConfig.footer`](../config/theme-configs#footer).

--- a/docs/guide/theme-home-page.md
+++ b/docs/guide/theme-home-page.md
@@ -1,4 +1,4 @@
-# Homepage
+# Home Page
 
 VitePress default theme provides a homepage layout, which you can also see used on [the homepage of this site](../). You may use it on any of your pages by specifying `layout: home` in the [frontmatter](./frontmatter).
 

--- a/docs/guide/theme-introduction.md
+++ b/docs/guide/theme-introduction.md
@@ -8,16 +8,17 @@ VitePress comes with its default theme providing many features out of the box. L
 - [Edit Link](./theme-edit-link)
 - [Last Updated](./theme-last-updated)
 - [Layout](./theme-layout)
-- [Homepage](./theme-homepage)
+- [Home Page](./theme-home-page)
+- [Team Page](./theme-team-page)
 - [Footer](./theme-footer)
 - [Search](./theme-search)
 - [Carbon Ads](./theme-carbon-ads)
 
-If you don't find the features you're looking for, or you would rather create your own theme, you may customize VitePress to fit your requirements.
+If you don't find the features you're looking for, or you would rather create your own theme, you may customize VitePress to fit your requirements. In the following sections, we'll go through each way of customizing the VitePress theme.
 
 ## Using a Custom Theme
 
-You can enable a custom theme by adding the `.vitepress/theme/index.js` file (the "theme entry file").
+You can enable a custom theme by adding the `.vitepress/theme/index.js` or `.vitepress/theme/index.ts` file (the "theme entry file").
 
 ```
 .
@@ -53,6 +54,7 @@ The theme entry file should export the theme as its default export:
 import Layout from './Layout.vue'
 
 export default {
+  // root component to wrap each page
   Layout,
 
   // this is a Vue 3 functional component

--- a/docs/guide/theme-layout.md
+++ b/docs/guide/theme-layout.md
@@ -35,4 +35,4 @@ Note that even in this layout, sidebar will still show up if the page has a matc
 
 ## Home Layout
 
-Option `home` will generate templated "Homepage". In this layout, you can set extra options such as `hero` and `features` to customize the content further. Please visit [Theme: Home Page](./theme-homepage) for more details.
+Option `home` will generate templated "Homepage". In this layout, you can set extra options such as `hero` and `features` to customize the content further. Please visit [Theme: Home Page](./theme-home-page) for more details.

--- a/docs/guide/theme-team-page.md
+++ b/docs/guide/theme-team-page.md
@@ -1,0 +1,255 @@
+<script setup>
+import { VPTeamMembers } from 'vitepress/theme'
+
+const members = [
+  {
+    avatar: 'https://github.com/yyx990803.png',
+    name: 'Evan You',
+    title: 'Creator',
+    links: [
+      { icon: 'github', link: 'https://github.com/yyx990803' },
+      { icon: 'twitter', link: 'https://twitter.com/youyuxi' }
+    ]
+  },
+  {
+    avatar: 'https://github.com/kiaking.png',
+    name: 'Kia King Ishii',
+    title: 'Developer',
+    links: [
+      { icon: 'github', link: 'https://github.com/kiaking' },
+      { icon: 'twitter', link: 'https://twitter.com/KiaKing85' }
+    ]
+  }
+]
+</script>
+
+# Team Page
+
+If you would like to introduce your team, you may use Team components to construct the Team Page. There're 2 ways of using these components. One is to embbed it in doc page, and another is to create a full Team Page.
+
+## Show team members in a page
+
+You may use `<VPTeamMembers>` component exposed from `vitepress/theme` to display a list of team members on any page.
+
+```html
+<script setup>
+import { VPTeamMembers } from 'vitepress/theme'
+
+const members = [
+  {
+    avatar: 'https://www.github.com/yyx990803.png',
+    name: 'Evan You',
+    title: 'Creator',
+    links: [
+      { icon: 'github', link: 'https://github.com/yyx990803' },
+      { icon: 'twitter', link: 'https://twitter.com/youyuxi' }
+    ]
+  },
+  ...
+]
+</script>
+
+# Our Team
+
+Say hello to our awesome team.
+
+<VPTeamMembers size="small" :members="members" />
+```
+
+The above will display a team member in card looking element. It should display something similar to below.
+
+<VPTeamMembers size="small" :members="members" />
+
+`<VPTeamMembers>` component comes in 2 different sizes, `small` and `medium`. While it boiles down to your preference, usually `small` size should fit better when used in doc page. Also, you may add more properties to each member such as adding "description" or "sponsor" button. Learn more about it in [`<VPTeamMembers>`](#vpteammembers).
+
+Embbeding team members in doc page is good for small size team where having dedicated full team page might be too much, or introducing partial members as a refference to documenation context.
+
+If you have large number of members, or simply would like to have more space to show team members, consider [creating a full team page](#create-a-full-team-page).
+
+## Create a full Team Page
+
+Instead of adding team members to doc page, you may also create a full Team Page, similar to how you can create a custom [Home Page](./theme-home-page).
+
+To create a team page, first, create a new md file. The file name doesn't matter, but here lets call it `team.md`. In this file, set frontmatter option `layout: page`, and then you may compose your page structure using `TeamPage` components.
+
+```html
+---
+layout: page
+---
+<script setup>
+import {
+  VPTeamPage,
+  VPTeamPageTitle,
+  VPTeamMembers
+} from 'vitepress/theme'
+
+const members = [
+  {
+    avatar: 'https://www.github.com/yyx990803.png',
+    name: 'Evan You',
+    title: 'Creator',
+    links: [
+      { icon: 'github', link: 'https://github.com/yyx990803' },
+      { icon: 'twitter', link: 'https://twitter.com/youyuxi' }
+    ]
+  },
+  ...
+]
+</script>
+
+<VPTeamPage>
+  <VPTeamPageTitle>
+    <template #title>
+      Our Team
+    </template>
+    <template #lead>
+      The development of VitePress is guided by an international
+      team, some of whom have chosen to be featured below.
+    </template>
+  </VPTeamPageTitle>
+  <VPTeamMembers
+    :members="members"
+  />
+</VPTeamPage>
+```
+
+When creating a full team page, remember to wrap all components with `<VPTeamPage>` component. This component will ensure all nested team related components get the proper layout structure like spacings.
+
+`<VPPageTitle>` component adds the page title section. The title being `<h1>` heading. Use `#title` and `#lead` slot to document about your team.
+
+`<VPMembers>` works as same as when used in a doc page. It will display list of members.
+
+### Add sections to divide team members
+
+You may add "sections" to the team page. For example, you may have different types of team members such as Core Team Members and Community Partners. You can devide these members into sections to better explain the roles of each group.
+
+To do so, add `<VPTeamPageSection>` component to the `team.md` file we created previously.
+
+```html
+---
+layout: page
+---
+<script setup>
+import {
+  VPTeamPage,
+  VPTeamPageTitle,
+  VPTeamMembers,
+  VPTeamPageSection
+} from 'vitepress/theme'
+
+const coreMembers = [...]
+const partners = [...]
+</script>
+
+<VPTeamPage>
+  <VPTeamPageTitle>
+    <template #title>Our Team</template>
+    <template #lead>...</template>
+  </VPTeamPageTitle>
+  <VPTeamMembers size="medium" :members="coreMembers" />
+  <VPTeamPageSection>
+    <template #title>Partners</template>
+    <template #lead>...</template>
+    <template #members>
+      <VPTeamMembers size="small" :members="partners" />
+    </template>
+  </VPTeamPageSection>
+</VPTeamPage>
+```
+
+The `<VPTeamPageSection>` component can have `#title` and `#lead` slot similar to `VPTeamPageTitle` component, and also `#members` slot for displaying team members.
+
+Remember to put in `<VPTeamMembers>` component within `#members` slot.
+
+## `<VPTeamMembers>`
+
+The `<VPTeamMembers>` component displays a given list of members.
+
+```html
+<VPTeamMembers
+  size="medium"
+  :members="[
+    { avatar: '...', name: '...' },
+    { avatar: '...', name: '...' },
+    ...
+  ]"
+/>
+```
+
+```ts
+interface Props {
+  // Size of each members. Defaults to `medium`.
+  size?: 'small' | 'meidum'
+
+  // List of members to display.
+  members: TeamMember[]
+}
+
+interface TeamMember {
+  // Avatar image for the member.
+  avatar: string
+
+  // Name of the member.
+  name: string
+
+  // Title to be shown below member's name.
+  // e.g. Developer, Software Engineer, etc.
+  title?: string
+
+  // Organization that the member belongs.
+  org?: string
+
+  // URL for the organization.
+  orgLink?: string
+
+  // Description for the member.
+  desc?: string
+
+  // Social links. e.g. GitHub, Twitter, etc. You may pass in
+  // the Social Links object here.
+  // See: https://vitepress.vuejs.org/config/theme-configs.html#sociallinks
+  links?: SocialLink[]
+
+  // URL for the sponsor page for the member.
+  sponsor?: string
+}
+```
+
+## `<VPTeamPage>`
+
+The root component when creating a full team page. It only accepts a single slot. It's will style all passed in team related components.
+
+## `<VPTeamPageTitle>`
+
+Adds "title" section of the page. Best use at the very beginning under `<VPTeamPage>`. It accepts `#title` and `#lead` slot.
+
+```html
+<VPTeamPage>
+  <VPTeamPageTitle>
+    <template #title>
+      Our Team
+    </template>
+    <template #lead>
+      The development of VitePress is guided by an international
+      team, some of whom have chosen to be featured below.
+    </template>
+  </VPTeamPageTitle>
+</VPTeamPage>
+```
+
+## `<VPTeamPageSection>`
+
+Creates a "section" with in team page. It accepts `#title`, `#lead`, and `#members` slot. You may add as many sections as you like inside `<VPTeamPage>`.
+
+```html
+<VPTeamPage>
+  ...
+  <VPTeamPageSection>
+    <template #title>Partners</template>
+    <template #lead>Lorem ipsum...</template>
+    <template #members>
+      <VPTeamMembers :members="data" />
+    </template>
+  </VPTeamPageSection>
+</VPTeamPage>
+```

--- a/src/client/theme-default/components/VPTeamMembers.vue
+++ b/src/client/theme-default/components/VPTeamMembers.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DefaultTheme } from '..'
+import VPTeamMembersItem from './VPTeamMembersItem.vue'
+
+const props = defineProps<{
+  size?: 'small' | 'medium'
+  members: DefaultTheme.TeamMember[]
+}>()
+
+const classes = computed(() => [
+  props.size ?? 'medium',
+  `count-${props.members.length}`
+])
+</script>
+
+<template>
+  <div class="VPTeamMembers" :class="classes">
+    <div class="container">
+      <div v-for="member in members" :key="member.name" class="item">
+        <VPTeamMembersItem :size="size" :member="member" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.VPTeamMembers.small .container {
+  grid-template-columns: repeat(auto-fit, minmax(224px, 1fr));
+}
+
+.VPTeamMembers.small.count-1 .container { max-width: 276px; }
+.VPTeamMembers.small.count-2 .container { max-width: calc(276px * 2 + 24px); }
+.VPTeamMembers.small.count-3 .container { max-width: calc(276px * 3 + 24px * 2); }
+
+.VPTeamMembers.medium .container {
+  grid-template-columns: repeat(auto-fit, minmax(256px, 1fr));
+}
+
+@media (min-width: 375px) {
+  .VPTeamMembers.medium .container {
+    grid-template-columns: repeat(auto-fit, minmax(288px, 1fr));
+  }
+}
+
+.VPTeamMembers.medium.count-1 .container { max-width: 368px; }
+.VPTeamMembers.medium.count-2 .container { max-width: calc(368px * 2 + 24px); }
+
+.container {
+  display: grid;
+  gap: 24px;
+  margin: 0 auto;
+  max-width: 1152px;
+}
+</style>

--- a/src/client/theme-default/components/VPTeamMembersItem.vue
+++ b/src/client/theme-default/components/VPTeamMembersItem.vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import type { DefaultTheme } from '..'
+import VPIconHeart from './icons/VPIconHeart.vue'
+import VPLink from './VPLink.vue'
+import VPSocialLinks from './VPSocialLinks.vue'
+
+defineProps<{
+  size?: 'small' | 'medium'
+  member: DefaultTheme.TeamMember
+}>()
+</script>
+
+<template>
+  <article class="VPTeamMembersItem" :class="[size ?? 'medium']">
+    <div class="profile">
+      <figure class="avatar">
+        <img class="avatar-img" :src="member.avatar" :alt="member.name">
+      </figure>
+      <div class="data">
+        <h1 class="name">
+          {{ member.name }}
+        </h1>
+        <p v-if="member.title || member.org" class="affiliation">
+          <span v-if="member.title" class="title">
+            {{ member.title }}
+          </span>
+          <span v-if="member.title && member.org" class="at">
+            @
+          </span>
+          <VPLink v-if="member.org" class="org" :class="{ link: member.orgLink }" :href="member.orgLink" no-icon>
+            {{ member.org }}
+          </VPLink>
+        </p>
+        <p v-if="member.desc" class="desc">
+          {{ member.desc }}
+        </p>
+        <div v-if="member.links" class="links">
+          <VPSocialLinks :links="member.links" />
+        </div>
+      </div>
+    </div>
+    <div v-if="member.sponsor" class="sponsor">
+      <VPLink class="sponsor-link" :href="member.sponsor" no-icon>
+        <VPIconHeart class="sponsor-icon" /> Sponsor
+      </VPLink>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.VPTeamMembersItem {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-radius: 12px;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.VPTeamMembersItem.small .profile {
+  padding: 32px;
+}
+
+.VPTeamMembersItem.small .data {
+  padding-top: 20px;
+}
+
+.VPTeamMembersItem.small .avatar {
+  width: 64px;
+  height: 64px;
+}
+
+.VPTeamMembersItem.small .name {
+  line-height: 24px;
+  font-size: 16px;
+}
+
+.VPTeamMembersItem.small .affiliation {
+  padding-top: 4px;
+  line-height: 20px;
+  font-size: 14px;
+}
+
+.VPTeamMembersItem.small .desc {
+  padding-top: 12px;
+  line-height: 20px;
+  font-size: 14px;
+}
+
+.VPTeamMembersItem.small .links {
+  margin: 0 -16px -20px;
+  padding: 10px 0 0;
+}
+
+.VPTeamMembersItem.medium .profile {
+  padding: 48px 32px;
+}
+
+.VPTeamMembersItem.medium .data {
+  padding-top: 24px;
+  text-align: center;
+}
+
+.VPTeamMembersItem.medium .avatar {
+  width: 96px;
+  height: 96px;
+}
+
+.VPTeamMembersItem.medium .name {
+  letter-spacing: 0.15px;
+  line-height: 28px;
+  font-size: 20px;
+}
+
+.VPTeamMembersItem.medium .affiliation {
+  padding-top: 4px;
+  font-size: 16px;
+}
+
+.VPTeamMembersItem.medium .desc {
+  padding-top: 16px;
+  max-width: 288px;
+  font-size: 16px;
+}
+
+.VPTeamMembersItem.medium .links {
+  margin: 0 -16px -12px;
+  padding: 16px 12px 0;
+}
+
+.profile {
+  flex-grow: 1;
+  background-color: var(--vp-c-bg-soft);
+}
+
+.data {
+  text-align: center;
+}
+
+.avatar {
+  position: relative;
+  flex-shrink: 0;
+  margin: 0 auto;
+  border-radius: 50%;
+  box-shadow: var(--vp-shadow-3);
+}
+
+.avatar-img {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.name {
+  margin:  0;
+  font-weight: 600;
+}
+
+.affiliation {
+  margin:  0;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+}
+
+.org.link {
+  color: var(--vp-c-text-2);
+  transition: color 0.25s;
+}
+
+.org.link:hover {
+  color: var(--vp-c-brand);
+}
+
+.desc {
+  margin: 0 auto;
+}
+
+.links {
+  display: flex;
+  justify-content: center;
+  height: 56px;
+}
+
+.sponsor-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-sponsor);
+  background-color: var(--vp-c-bg-soft);
+  transition: color 0.25s, background-color 0.25s;
+}
+
+.sponsor-link:hover,
+.sponsor-link:focus {
+  outline: none;
+  color: var(--vp-c-text-dark-1);
+  background-color: var(--vp-c-sponsor);
+}
+
+.sponsor-icon {
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+</style>

--- a/src/client/theme-default/components/VPTeamPage.vue
+++ b/src/client/theme-default/components/VPTeamPage.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="VPTeamPage">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.VPTeamPage {
+  padding-bottom: 96px;
+}
+
+@media (min-width: 768px) {
+  .VPTeamPage {
+    padding-bottom: 128px;
+  }
+}
+
+:slotted(.VPTeamPageSection + .VPTeamPageSection),
+:slotted(.VPTeamMembers + .VPTeamPageSection) {
+  margin-top: 64px;
+}
+
+:slotted(.VPTeamMembers + .VPTeamMembers) {
+  margin-top: 24px;
+}
+
+@media (min-width: 768px) {
+  :slotted(.VPTeamPageTitle + .VPTeamPageSection) {
+    margin-top: 16px;
+  }
+
+  :slotted(.VPTeamPageSection + .VPTeamPageSection),
+  :slotted(.VPTeamMembers + .VPTeamPageSection) {
+    margin-top: 96px;
+  }
+}
+
+:slotted(.VPTeamMembers) {
+  padding: 0 24px;
+}
+
+@media (min-width: 768px) {
+  :slotted(.VPTeamMembers) {
+    padding: 0 48px;
+  }
+}
+
+@media (min-width: 960px) {
+  :slotted(.VPTeamMembers) {
+    padding: 0 64px;
+  }
+}
+</style>

--- a/src/client/theme-default/components/VPTeamPageSection.vue
+++ b/src/client/theme-default/components/VPTeamPageSection.vue
@@ -1,0 +1,77 @@
+<template>
+  <section class="VPTeamPageSection">
+    <div class="title">
+      <div class="title-line" />
+      <h2 v-if="$slots.title" class="title-text">
+        <slot name="title" />
+      </h2>
+    </div>
+    <p v-if="$slots.lead" class="lead">
+      <slot name="lead" />
+    </p>
+    <div v-if="$slots.members" class="members">
+      <slot name="members" />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.VPTeamPageSection {
+  padding: 0 32px;
+}
+
+@media (min-width: 768px) {
+  .VPTeamPageSection {
+    padding: 0 48px;
+  }
+}
+
+@media (min-width: 960px) {
+  .VPTeamPageSection {
+    padding: 0 64px;
+  }
+}
+
+.title {
+  position: relative;
+  margin: 0 auto;
+  max-width: 1152px;
+  text-align: center;
+  color: var(--vp-c-text-2);
+}
+
+.title-line {
+  position: absolute;
+  top: 16px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background-color: var(--vp-c-divider-light);
+}
+
+.title-text {
+  position: relative;
+  display: inline-block;
+  padding: 0 24px;
+  letter-spacing: 0;
+  line-height: 32px;
+  font-size: 20px;
+  font-weight: 500;
+  background-color: var(--vp-c-bg);
+}
+
+.lead {
+  margin: 0 auto;
+  max-width: 480px;
+  padding-top: 12px;
+  text-align: center;
+  line-height: 24px;
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+}
+
+.members {
+  padding-top: 40px;
+}
+</style>

--- a/src/client/theme-default/components/VPTeamPageTitle.vue
+++ b/src/client/theme-default/components/VPTeamPageTitle.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="VPTeamPageTitle">
+    <h1 v-if="$slots.title" class="title">
+      <slot name="title" />
+    </h1>
+    <p v-if="$slots.lead" class="lead">
+      <slot name="lead" />
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.VPTeamPageTitle {
+  padding: 48px 32px;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .VPTeamPageTitle {
+    padding: 64px 48px 48px;
+  }
+}
+
+@media (min-width: 960px) {
+  .VPTeamPageTitle {
+    padding: 80px 64px 48px;
+  }
+}
+
+.title {
+  letter-spacing: 0;
+  line-height: 44px;
+  font-size: 36px;
+  font-weight: 500;
+}
+
+@media (min-width: 768px) {
+  .title {
+    letter-spacing: -0.5px;
+    line-height: 56px;
+    font-size: 48px;
+  }
+}
+
+.lead {
+  margin: 0 auto;
+  max-width: 512px;
+  padding-top: 12px;
+  line-height: 24px;
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+}
+
+@media (min-width: 768px) {
+  .lead {
+    max-width: 592px;
+    letter-spacing: 0.15px;
+    line-height: 28px;
+    font-size: 20px;
+  }
+}
+</style>

--- a/src/client/theme-default/index.ts
+++ b/src/client/theme-default/index.ts
@@ -15,6 +15,10 @@ export { default as VPHomeHero } from './components/VPHomeHero.vue'
 export { default as VPHomeFeatures } from './components/VPHomeFeatures.vue'
 export { default as VPHomeSponsors } from './components/VPHomeSponsors.vue'
 export { default as VPDocAsideSponsors } from './components/VPDocAsideSponsors.vue'
+export { default as VPTeamPage } from './components/VPTeamPage.vue'
+export { default as VPTeamPageTitle } from './components/VPTeamPageTitle.vue'
+export { default as VPTeamPageSection } from './components/VPTeamPageSection.vue'
+export { default as VPTeamMembers } from './components/VPTeamMembers.vue'
 
 const theme: Theme = {
   Layout,

--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -20,7 +20,7 @@
 }
 
 .vp-doc h2 {
-  margin: 48px 0 0;
+  margin: 48px 0 16px;
   border-top: 1px solid var(--vp-c-divider-light);
   padding-top: 24px;
   letter-spacing: -0.02em;
@@ -461,3 +461,26 @@
 .vp-doc [class~='language-tsx']:before        { content: 'tsx'; }
 .vp-doc [class~='language-vue']:before        { content: 'vue'; }
 .vp-doc [class~='language-yaml']:before       { content: 'yaml'; }
+
+/**
+ * Component: Team
+ * -------------------------------------------------------------------------- */
+
+.vp-doc .VPTeamMembers {
+  margin-top: 24px;
+}
+
+.vp-doc .VPTeamMembers.small.count-1 .container {
+  margin: 0 !important;
+  max-width: calc((100% - 24px) / 2) !important;
+}
+
+.vp-doc .VPTeamMembers.small.count-2 .container,
+.vp-doc .VPTeamMembers.small.count-3 .container {
+  max-width: 100% !important;
+}
+
+.vp-doc .VPTeamMembers.medium.count-1 .container {
+  margin: 0 !important;
+  max-width: calc((100% - 24px) / 2) !important;
+}

--- a/theme.d.ts
+++ b/theme.d.ts
@@ -5,6 +5,10 @@ export const VPHomeHero = ComponentOptions
 export const VPHomeFeatures = ComponentOptions
 export const VPHomeSponsors = ComponentOptions
 export const VPDocAsideSponsors = ComponentOptions
+export const VPTeamPage = ComponentOptions
+export const VPTeamPageTitle = ComponentOptions
+export const VPTeamPageSection = ComponentOptions
+export const VPTeamMembers = ComponentOptions
 
 declare const theme: {
   Layout: ComponentOptions

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -175,6 +175,19 @@ export namespace DefaultTheme {
     copyright?: string
   }
 
+  // team ----------------------------------------------------------------------
+
+  export interface TeamMember {
+    avatar: string
+    name: string
+    title?: string
+    org?: string
+    orgLink?: string
+    desc?: string
+    links?: SocialLink[]
+    sponsor?: string
+  }
+
   // locales -------------------------------------------------------------------
 
   export interface LocaleLinks {


### PR DESCRIPTION
This PR adds a new "Team Page" feature. [See more details in docs](https://deploy-preview-828--vitepress-docs.netlify.app/guide/theme-team-page.html).

```html
---
layout: page
---
<script setup>
import {
  VPTeamPage,
  VPTeamPageTitle,
  VPTeamMembers
} from 'vitepress/theme'

const members = [
  {
    avatar: 'https://www.github.com/yyx990803.png',
    name: 'Evan You',
    title: 'Creator',
    links: [
      { icon: 'github', link: 'https://github.com/yyx990803' },
      { icon: 'twitter', link: 'https://twitter.com/youyuxi' }
    ]
  },
  ...
]
</script>

<VPTeamPage>
  <VPTeamPageTitle>
    <template #title>Our Team</template>
    <template #lead>Lorem ipsum...</template>
  </VPTeamPageTitle>
  <VPTeamMembers :members="members" />
</VPTeamPage>
```

<img width="1392" alt="Screen_Shot_2022-06-17_at_0 23 51" src="https://user-images.githubusercontent.com/3753672/174771163-6133db95-65f8-4e0e-a39b-9d12d77f5c1d.png">

<img width="1392" alt="Screen_Shot_2022-06-17_at_0 23 29" src="https://user-images.githubusercontent.com/3753672/174771186-cee46d9f-e2db-43ec-9fc8-b239d9409da4.png">

### Why not frontmatter but component composition?

Because composing components are way more flexible.

### Why not props for `title` and `lead` but instead slots?

Because it's way more flexible to add custom styles or even links inside a lead text.