### PR TITLE
chore: handle undefined hmr

### DIFF
--- a/src/client/app/data.ts
+++ b/src/client/app/data.ts
@@ -31,8 +31,10 @@ export const siteDataRef: Ref<SiteData> = shallowRef(
 
 // hmr
 if (import.meta.hot) {
-  import.meta.hot!.accept('/@siteData', (m) => {
-    siteDataRef.value = m.default
+  import.meta.hot.accept('/@siteData', (m) => {
+    if (m) {
+      siteDataRef.value = m.default
+    }
   })
 }
 


### PR DESCRIPTION
Actually this PR does nothing when Vite is v2.

After Vite v3, `import.meta.hot.accept` is more accurately typed. (https://github.com/vitejs/vite/pull/8698/files)
This PR fixes the type error when Vite is upgraded to v3 which will fix vite-ecosystem-ci.
