### PR TITLE
fix: ESM SSR

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -60,12 +60,7 @@ export function createRouter(
     const targetLoc = new URL(href, fakeHost)
     const pendingPath = (latestPendingPath = targetLoc.pathname)
     try {
-      let page = loadPageModule(pendingPath)
-      // only await if it returns a Promise - this allows sync resolution
-      // on initial render in SSR.
-      if ('then' in page && typeof page.then === 'function') {
-        page = await page
-      }
+      let page = await loadPageModule(pendingPath)
       if (latestPendingPath === pendingPath) {
         latestPendingPath = null
 

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -25,7 +25,7 @@ export async function renderPage(
   const { app, router } = createApp()
   const routePath = `/${page.replace(/\.md$/, '')}`
   const siteData = resolveSiteDataByRoute(config.site, routePath)
-  router.go(routePath)
+  await router.go(routePath)
 
   // lazy require server-renderer for production build
   // prioritize project root over vitepress' own dep


### PR DESCRIPTION
@brc-dd

Now SSR uses ESM. So dynamic import is used instead of `require`.
This means it now requires `await`.

refs https://github.com/vitejs/vite/issues/8759
