### PR TITLE
fix(theme): fix blockquote overflow (with many code childs)

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -235,6 +235,8 @@
 }
 
 .vp-doc :not(pre) > code {
+  display: inline-block;
+  line-height: initial;
   border-radius: 4px;
   padding: 3px 6px;
   color: var(--vp-c-text-code);


### PR DESCRIPTION
Hi

This is a fix for the blockquote overflow with many code elements: 👇
![bug-overflow](https://user-images.githubusercontent.com/6343314/175789746-038c8827-1078-4dde-bc66-23835f66d66e.PNG)
The result after the fix: :tada:
![fix-overflow](https://user-images.githubusercontent.com/6343314/175789773-a29ab436-5e7f-44e7-b494-76b90ed60ef7.PNG)

You can see the problem directlty in [my docs](https://dxf.vercel.app/guide/tables.html#style-record), or use this markdown snippet:

```md
> `Element example`, `Element example`, `Element example`, `Element example`, `Element example`, `Element example`, `Element example`, `Element example`, 
```

Thank you for this amazing project I like it.