### PR TITLE
fix(theme): make last updated time reactive

### DIFF
--- a/src/client/theme-default/components/VPDocFooterLastUpdated.vue
+++ b/src/client/theme-default/components/VPDocFooterLastUpdated.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { ref, watchEffect, onMounted } from 'vue'
+import { ref, computed, watchEffect, onMounted } from 'vue'
 import { useData } from 'vitepress'
 
 const { theme, page } = useData()
 
-const date = new Date(page.value.lastUpdated!)
-const isoDatetime = date.toISOString()
+const date = computed(() => new Date(page.value.lastUpdated!))
+const isoDatetime = computed(() => date.value.toISOString())
 const datetime = ref('')
 
 // set time on mounted hook because the locale string might be different
@@ -13,7 +13,7 @@ const datetime = ref('')
 // calculated at build time
 onMounted(() => {
   watchEffect(() => {
-    datetime.value = date.toLocaleString(window.navigator.language)
+    datetime.value = date.value.toLocaleString(window.navigator.language)
   })
 })
 </script>


### PR DESCRIPTION
The last updated time should be a computed value based on `page-data`.

This PR fixes:

When you go through pages on [VitePress Docs](https://vitepress.vuejs.org/), `last updated time` stays the same.`The time` we saw on each page used the `updated time` of the first landed page, then it never changes.
But if you refresh on a specific page, you can see the right `last updated time`.