### PR TITLE
docs: add workaround for missing peer dependencies

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,6 +28,39 @@ Add VitePress and Vue as dev dependencies for the project.
 $ yarn add --dev vitepress vue
 ```
 
+::: details Getting missing peer deps warnings?
+`@docsearch/js` has certain issues with its peer dependencies. If you see some commands failing due to them, you can try this workaround for now:
+
+On Yarn v2/v3, add this inside your rc file (`.yarnrc.yml` by default):
+
+```yaml
+packageExtensions:
+  '@docsearch/react@*':
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      'react':
+        optional: true
+      'react-dom':
+        optional: true
+```
+
+On PNPM, add this in your `package.json`:
+
+```json
+"pnpm": {
+  "peerDependencyRules": {
+    "ignoreMissing": [
+      "@types/react",
+      "react",
+      "react-dom"
+    ]
+  }
+}
+```
+
+:::
+
 Create your first document.
 
 ```bash


### PR DESCRIPTION
Let's just add this in docs for now. I don't think there is anything we can do till https://github.com/algolia/docsearch/issues/1272 gets fixed.