### PR TITLE
fix: prevent line numbers from being copied. Closes #884

### DIFF
--- a/src/client/theme-default/composables/copy-code.ts
+++ b/src/client/theme-default/composables/copy-code.ts
@@ -76,7 +76,18 @@ function handleElement(el: HTMLElement) {
       parent.classList.contains('language-sh') ||
       parent.classList.contains('language-bash')
 
-    let { innerText: text = '' } = parent
+    // Select the <code> element inside the whole code block.
+    // The <code> element is currently nested inside the <pre> tag.
+    const codeBlockBody = parent.querySelector(
+      'pre > code'
+    ) as HTMLElement | null
+
+    let text: string = '' // Give it a default value
+
+    // if the code block body is not null, then we can get the text from it
+    if (codeBlockBody) {
+      text = codeBlockBody?.innerText ?? ''
+    }
 
     if (isShell) {
       text = text.replace(/^ *\$ /gm, '')


### PR DESCRIPTION
There is currently an issue where having line numbers enabled in your markdown causes the `copy to clipboard` button to also add in those line numbers at the end. 

This PR now looks at the `<code>` tag to read the `innertext` contents. This skips the line numbers from being added to the copied text. 

Tested locally with `lineNumbers` both enabled and disabled. 