### PR TITLE
fix(theme): make code blocks horizontally scrollable

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -107,6 +107,10 @@ samp {
   font-family: var(--vp-font-family-mono);
 }
 
+pre {
+  overflow-x: auto;
+}
+
 img,
 svg,
 video,


### PR DESCRIPTION
See [my proof of concept](https://stackblitz.com/edit/node-ggaugv?file=docs%2Findex.md).

When there is a [code block](https://www.markdownguide.org/basic-syntax#code-blocks) containing a long line, the block overflows horizontally. My change sets `pre`'s `overflow-x` to `auto` to make code blocks horizontally scrollable.