### PR TITLE
refactor: reuse original markdown-it renderer rule

### DIFF
--- a/src/node/markdown/plugins/image.ts
+++ b/src/node/markdown/plugins/image.ts
@@ -4,21 +4,13 @@ import MarkdownIt from 'markdown-it'
 import { EXTERNAL_URL_RE } from '../../shared'
 
 export const imagePlugin = (md: MarkdownIt) => {
+  const imageRule = md.renderer.rules.image!
   md.renderer.rules.image = (tokens, idx, options, env, self) => {
     const token = tokens[idx]
     const url = token.attrGet('src')
     if (url && !EXTERNAL_URL_RE.test(url) && !/^\.?\//.test(url)) {
       token.attrSet('src', './' + url)
     }
-
-    if (token.attrIndex('alt') && token.children != null) {
-      token.attrs![token.attrIndex('alt')][1] = self.renderInlineAsText(
-        token.children,
-        options,
-        env
-      )
-    }
-
-    return self.renderToken(tokens, idx, options)
+    return imageRule(tokens, idx, options, env, self)
   }
 }


### PR DESCRIPTION
Related to #685. We don't need to fork the code from the default image renderer rule. Re-using it is safer.