### PR TITLE
docs: add including markdown content to guide

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -388,48 +388,47 @@ You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/co
 
 <!--lint enable strong-marker-->
 
-## Import & Embed markdown's content
+## Markdown File Inclusion
 
-When you need to combine multiple markdown content over a single markdown file, e.g.
+You can include a markdown file in another markdown file like this:
 
-```vue
-<script>
-import basics from './parts/basics.md'
-import reference from './parts/reference.md'
-</script>
+**Input**
 
+```md
 # Docs
 
 ## Basics
 
-{{ basics }}
-
-## API Reference
-
-{{ reference }}
+<!--@include: ./parts/basics.md-->
 ```
 
-Replace curly brackets with `@include`, 
-the pathname with the extension, 
-surrounded by `<!-- -->` sintax
+**Part file** (`parts/basics.md`)
 
-```vue
-<script>
-import basics from './parts/basics.md'
-import reference from './parts/reference.md'
-</script>
+```md
+Some getting started stuff.
 
+### Configuration
+
+Can be created using `.foorc.json`.
+```
+
+**Equivalent code**
+
+```md
 # Docs
 
 ## Basics
 
-< !--@include:./parts/basics.md--> 
+Some getting started stuff.
 
-## API Reference
+### Configuration
 
-< !--@include:./parts/reference.md-->
+Can be created using `.foorc.json`.
 ```
 
+::: warning
+Note that this does not throw errors if your file is not present. Hence, when using this feature make sure that the contents are being rendered as expected.
+:::
 
 ## Advanced Configuration
 

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -388,6 +388,49 @@ You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/co
 
 <!--lint enable strong-marker-->
 
+## Import & Embed markdown's content
+
+When you need to combine multiple markdown content over a single markdown file, e.g.
+
+```vue
+<script>
+import basics from './parts/basics.md'
+import reference from './parts/reference.md'
+</script>
+
+# Docs
+
+## Basics
+
+{{ basics }}
+
+## API Reference
+
+{{ reference }}
+```
+
+Replace curly brackets with `@include`, 
+the pathname with the extension, 
+surrounded by `<!-- -->` sintax
+
+```vue
+<script>
+import basics from './parts/basics.md'
+import reference from './parts/reference.md'
+</script>
+
+# Docs
+
+## Basics
+
+< !--@include:./parts/basics.md--> 
+
+## API Reference
+
+< !--@include:./parts/reference.md-->
+```
+
+
 ## Advanced Configuration
 
 VitePress uses [markdown-it](https://github.com/markdown-it/markdown-it) as the Markdown renderer. A lot of the extensions above are implemented via custom plugins. You can further customize the `markdown-it` instance using the `markdown` option in `.vitepress/config.js`:

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -54,11 +54,15 @@ export async function createMarkdownToVueRenderFn(
 
     // resolve includes
     let includes: string[] = []
-    src = src.replace(includesRE, (_, m1) => {
-      const includePath = path.join(dir, m1)
-      const content = fs.readFileSync(includePath, 'utf-8')
-      includes.push(slash(includePath))
-      return content
+    src = src.replace(includesRE, (m, m1) => {
+      try {
+        const includePath = path.join(dir, m1)
+        const content = fs.readFileSync(includePath, 'utf-8')
+        includes.push(slash(includePath))
+        return content
+      } catch (error) {
+        return m // silently ignore error if file is not present
+      }
     })
 
     const { content, data: frontmatter } = matter(src)


### PR DESCRIPTION
Add Import & Embed Markdown's Content.
More details about how it will look like, here #411 