### PR TITLE
feat(type): make LocaleLinks text nullable

### DIFF
--- a/src/client/theme-default/components/VPNavBarExtra.vue
+++ b/src/client/theme-default/components/VPNavBarExtra.vue
@@ -11,7 +11,7 @@ const { site, theme } = useData()
 <template>
   <VPFlyout class="VPNavBarExtra" label="extra navigation">
     <div v-if="theme.localeLinks" class="group">
-      <p class="trans-title">{{ theme.localeLinks.text }}</p>
+      <p v-if="theme.localeLinks.text" class="trans-title">{{ theme.localeLinks.text }}</p>
 
       <template v-for="locale in theme.localeLinks.items" :key="locale.link">
         <VPMenuLink :item="locale" />

--- a/src/client/theme-default/components/VPNavBarTranslations.vue
+++ b/src/client/theme-default/components/VPNavBarTranslations.vue
@@ -14,7 +14,7 @@ const { theme } = useData()
     :icon="VPIconLanguages"
   >
     <div class="items">
-      <p class="title">{{ theme.localeLinks.text }}</p>
+      <p v-if="theme.localeLinks.text" class="title">{{ theme.localeLinks.text }}</p>
 
       <template v-for="locale in theme.localeLinks.items" :key="locale.link">
         <VPMenuLink :item="locale" />

--- a/src/client/theme-default/components/VPNavScreenTranslations.vue
+++ b/src/client/theme-default/components/VPNavScreenTranslations.vue
@@ -17,7 +17,7 @@ function toggle() {
   <div v-if="theme.localeLinks" class="VPNavScreenTranslations" :class="{ open: isOpen }">
     <button class="title" @click="toggle">
       <VPIconLanguages class="icon lang" />
-      {{ theme.localeLinks.text }}
+      {{ theme.localeLinks?.text }}
       <VPIconChevronDown class="icon chevron" />
     </button>
 

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -220,7 +220,7 @@ export namespace DefaultTheme {
   // locales -------------------------------------------------------------------
 
   export interface LocaleLinks {
-    text: string
+    text?: string
     items: LocaleLink[]
   }
 


### PR DESCRIPTION
Signed-off-by: Sepush <sepush@outlook.com>

We don't want the text in localeLinks.
Make it nullable so we can config localeLinks in the following way.
![image](https://user-images.githubusercontent.com/39197136/178133862-282b5678-689c-4377-b585-c802b0d37dda.png)
![image](https://user-images.githubusercontent.com/39197136/178133903-72b7eb77-972f-42cb-9a26-e10616d4f0cb.png)
