### PR TITLE
feat(theme): support hiding aside component from frontmatter

### DIFF
--- a/docs/config/frontmatter-configs.md
+++ b/docs/config/frontmatter-configs.md
@@ -199,3 +199,18 @@ interface Feature {
   details: string
 }
 ```
+
+## rightsidebar
+
+- Type: `boolean`
+
+This option only take effect when `layout` is set to `page`.
+
+By default, the right aside will be shown, if you want to remove it, configure the option to `false`:
+
+```yaml
+---
+rightsidebar: false
+---
+```
+

--- a/docs/config/frontmatter-configs.md
+++ b/docs/config/frontmatter-configs.md
@@ -200,17 +200,15 @@ interface Feature {
 }
 ```
 
-## rightsidebar
+## aside
 
 - Type: `boolean`
+- Default: `true`
 
-This option only take effect when `layout` is set to `page`.
-
-By default, the right aside will be shown, if you want to remove it, configure the option to `false`:
+If you want the right aside component in `doc` layout not to be shown, set this option to `false`.
 
 ```yaml
 ---
-rightsidebar: false
+aside: false
 ---
 ```
-

--- a/src/client/theme-default/components/VPDoc.vue
+++ b/src/client/theme-default/components/VPDoc.vue
@@ -6,7 +6,7 @@ import VPDocAside from './VPDocAside.vue'
 import VPDocFooter from './VPDocFooter.vue'
 
 const route = useRoute()
-const { hasSidebar, hasRightSidebar } = useSidebar()
+const { hasSidebar, hasAside } = useSidebar()
 
 const pageName = computed(() =>
   route.path.replace(/[./]+/g, '_').replace(/_html$/, '')
@@ -14,9 +14,12 @@ const pageName = computed(() =>
 </script>
 
 <template>
-  <div class="VPDoc" :class="{ 'has-sidebar': hasSidebar }">
+  <div
+    class="VPDoc"
+    :class="{ 'has-sidebar': hasSidebar, 'has-aside': hasAside }"
+  >
     <div class="container">
-      <div v-if="hasRightSidebar" class="aside">
+      <div v-if="hasAside" class="aside">
         <div class="aside-curtain" />
         <div class="aside-container">
           <div class="aside-content">
@@ -33,7 +36,7 @@ const pageName = computed(() =>
       </div>
 
       <div class="content">
-        <div class="content-container" :class="{ 'has-right-sidebar': hasRightSidebar }">
+        <div class="content-container">
           <slot name="doc-before" />
 
           <main class="main">
@@ -172,7 +175,7 @@ const pageName = computed(() =>
   margin: 0 auto;
 }
 
-.content-container.has-right-sidebar {
+.VPDoc.has-aside .content-container {
   max-width: 688px;
 }
 </style>

--- a/src/client/theme-default/components/VPDoc.vue
+++ b/src/client/theme-default/components/VPDoc.vue
@@ -6,7 +6,7 @@ import VPDocAside from './VPDocAside.vue'
 import VPDocFooter from './VPDocFooter.vue'
 
 const route = useRoute()
-const { hasSidebar } = useSidebar()
+const { hasSidebar, hasRightSidebar } = useSidebar()
 
 const pageName = computed(() =>
   route.path.replace(/[./]+/g, '_').replace(/_html$/, '')
@@ -16,7 +16,7 @@ const pageName = computed(() =>
 <template>
   <div class="VPDoc" :class="{ 'has-sidebar': hasSidebar }">
     <div class="container">
-      <div class="aside">
+      <div v-if="hasRightSidebar" class="aside">
         <div class="aside-curtain" />
         <div class="aside-container">
           <div class="aside-content">
@@ -33,7 +33,7 @@ const pageName = computed(() =>
       </div>
 
       <div class="content">
-        <div class="content-container">
+        <div class="content-container" :class="{ 'has-right-sidebar': hasRightSidebar }">
           <slot name="doc-before" />
 
           <main class="main">
@@ -170,6 +170,9 @@ const pageName = computed(() =>
 
 .content-container {
   margin: 0 auto;
+}
+
+.content-container.has-right-sidebar {
   max-width: 688px;
 }
 </style>

--- a/src/client/theme-default/composables/sidebar.ts
+++ b/src/client/theme-default/composables/sidebar.ts
@@ -22,8 +22,11 @@ export function useSidebar() {
     )
   })
 
-  const hasRightSidebar = computed(() => {
-    if (frontmatter.value.layout !== 'home' && frontmatter.value.rightsidebar === false)
+  const hasAside = computed(() => {
+    if (
+      frontmatter.value.layout !== 'home' &&
+      frontmatter.value.aside === false
+    )
       return false
 
     return hasSidebar.value
@@ -45,7 +48,7 @@ export function useSidebar() {
     isOpen,
     sidebar,
     hasSidebar,
-    hasRightSidebar,
+    hasAside,
     open,
     close,
     toggle

--- a/src/client/theme-default/composables/sidebar.ts
+++ b/src/client/theme-default/composables/sidebar.ts
@@ -22,6 +22,13 @@ export function useSidebar() {
     )
   })
 
+  const hasRightSidebar = computed(() => {
+    if (frontmatter.value.layout !== 'home' && frontmatter.value.rightsidebar === false)
+      return false
+
+    return hasSidebar.value
+  })
+
   function open() {
     isOpen.value = true
   }
@@ -38,6 +45,7 @@ export function useSidebar() {
     isOpen,
     sidebar,
     hasSidebar,
+    hasRightSidebar,
     open,
     close,
     toggle


### PR DESCRIPTION
Sometime the space in the right sidebar is required, for example adding some app but we also need the left sidebar, since the sidebar is global we cannot remove the space on the right aside.

For example, in the `vite-plugin-pwa`  we're adding an application and we want some more space (the right sidebar is there but with empty content):
https://streamable.com/3wjtca

Using the why VitePress in the docs here, the result is this (removed in this PR, just for testing purposes):
https://streamable.com/5uklw5