### PR TITLE
fix: search bar `CTRL K`

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -24,7 +24,7 @@ onMounted(() => {
   // meta key detect (same logic as in @docsearch/js)
   metaKey.value.textContent = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)
     ? '⌘'
-    : 'Ctrl'
+    : 'CTRL'
 
   const handleSearchHotKey = (e: KeyboardEvent) => {
     if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
@@ -54,7 +54,7 @@ function load() {
   <div v-if="theme.algolia" class="VPNavBarSearch">
     <VPAlgoliaSearchBox v-if="loaded" />
 
-    <div v-else id="docsearch" @click="load">
+    <div v-else id="docsearch-hack" @click="load">
       <button
         type="button"
         class="DocSearch DocSearch-Button"
@@ -79,7 +79,7 @@ function load() {
           <span class="DocSearch-Button-Placeholder">{{ theme.algolia?.buttonText || 'Search' }}</span>
         </span>
         <span class="DocSearch-Button-Keys">
-          <kbd class="DocSearch-Button-Key" ref="metaKey">Meta</kbd>
+          <kbd class="DocSearch-Button-Key DocSearch-Button-Key-Hack" ref="metaKey">Meta</kbd>
           <kbd class="DocSearch-Button-Key">K</kbd>
         </span>
       </button>
@@ -245,6 +245,14 @@ function load() {
   font-size: 12px;
   font-weight: 500;
   transition: color 0.5s, border-color 0.5s;
+}
+
+.DocSearch-Button .DocSearch-Button-Key.DocSearch-Button-Key-Hack {
+  line-height: 16px;
+  font-size: 9px;
+  padding-left: 4px;
+  margin-left: 2px;
+  font-weight: bolder;
 }
 
 .DocSearch-Button .DocSearch-Button-Key + .DocSearch-Button-Key {


### PR DESCRIPTION
The Algolia search is loaded lazy, and so, if the user don't use the search we don't download the Algolia stuff.

Algolia will configure its own search box, and so, on initial render the Algolia search is not stll there, we need to mimic the Algolia search (that's why there is an `v-if` and `v-else` in the VPNavbarSearch component).

The SVG is included by Algolia, shown once the search is activated first time.

For example, if I remove the `v-else`, this is the result with the changes in this PR (on the left the Algolia search and on the right the hack):

![Captura de pantalla 2022-07-14 004932](https://user-images.githubusercontent.com/6311119/178850660-128269ab-125c-412a-9f85-e8faefe73b74.png)


closes #909