### PR TITLE
fix(theme): prevent docsearch button key from changing

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -14,7 +14,7 @@ const { theme } = useData()
 // hit the hotkey to invoke it.
 const loaded = ref(false)
 
-const metaKey = ref()
+const metaKey = ref(`'Meta'`)
 
 onMounted(() => {
   if (!theme.value.algolia) {
@@ -22,9 +22,9 @@ onMounted(() => {
   }
 
   // meta key detect (same logic as in @docsearch/js)
-  metaKey.value.textContent = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)
-    ? '⌘'
-    : 'Ctrl'
+  metaKey.value = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)
+    ? `'⌘'`
+    : `'Ctrl'`
 
   const handleSearchHotKey = (e: KeyboardEvent) => {
     if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
@@ -79,7 +79,7 @@ function load() {
           <span class="DocSearch-Button-Placeholder">{{ theme.algolia?.buttonText || 'Search' }}</span>
         </span>
         <span class="DocSearch-Button-Keys">
-          <kbd class="DocSearch-Button-Key" ref="metaKey">Meta</kbd>
+          <kbd class="DocSearch-Button-Key"></kbd>
           <kbd class="DocSearch-Button-Key">K</kbd>
         </span>
       </button>
@@ -253,6 +253,23 @@ function load() {
   border-radius: 0 4px 4px 0;
   padding-left: 2px;
   padding-right: 6px;
+}
+
+.DocSearch-Button .DocSearch-Button-Key:first-child {
+  font-size: 1px;
+  letter-spacing: -1px;
+  color: transparent;
+}
+
+.DocSearch-Button .DocSearch-Button-Key:first-child:after {
+  content: v-bind(metaKey);
+  font-size: 12px;
+  letter-spacing: normal;
+  color: var(--docsearch-muted-color);
+}
+
+.DocSearch-Button .DocSearch-Button-Key:first-child > * {
+  display: none;
 }
 
 .dark .DocSearch-Footer {


### PR DESCRIPTION
fixes #909
closes #982

On Mac:

Before loading: 
![image](https://user-images.githubusercontent.com/40380293/178972369-f2199c4b-9550-4fe3-acfd-75a23413494b.png)

After loading:
![image](https://user-images.githubusercontent.com/40380293/178972461-f99d1e8a-08d3-4551-9d7f-3b947a0a43e3.png)

On Windows:

Before loading:
![image](https://user-images.githubusercontent.com/40380293/178972549-cd2a7c4c-5f2c-4e27-8150-b6d5f13a5db0.png)

After loading:
![image](https://user-images.githubusercontent.com/40380293/178972597-5ea43a49-d053-48da-8d3d-298b45d68450.png)

