### PR TITLE
fix: don't change url hash while scrolling

### DIFF
--- a/src/client/theme-default/composables/outline.ts
+++ b/src/client/theme-default/composables/outline.ts
@@ -120,7 +120,6 @@ export function useActiveAnchor(
       const [isActive, hash] = isAnchorActive(i, anchor, nextAnchor)
 
       if (isActive) {
-        history.replaceState(null, document.title, hash ? hash : ' ')
         activateLink(hash)
         return
       }


### PR DESCRIPTION
Temporary fixes #903 until we can figure out some method to change URL hash only when manually scrolled by user.