### PR TITLE
feat: allow to use custom syntax highlighting themes

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -1,5 +1,5 @@
 import MarkdownIt from 'markdown-it'
-import { Theme } from 'shiki'
+import { Theme, IShikiTheme } from 'shiki'
 import { parseHeader } from '../utils/parseHeader'
 import { highlight } from './plugins/highlight'
 import { slugify } from './plugins/slugify'
@@ -19,7 +19,9 @@ import attrs from 'markdown-it-attrs'
 import emoji from 'markdown-it-emoji'
 import toc from 'markdown-it-toc-done-right'
 
-export type ThemeOptions = Theme | { light: Theme; dark: Theme }
+export type ThemeValue = Theme | IShikiTheme
+
+export type ThemeOptions = ThemeValue | { light: ThemeValue; dark: ThemeValue }
 
 export interface MarkdownOptions extends MarkdownIt.Options {
   lineNumbers?: boolean


### PR DESCRIPTION
Adds the ability to import custom themes for syntax highlighting.

```ts
import { loadTheme } from 'shiki'
import { join } from 'path'

export default async () => {
    let theme = await loadTheme(join(__dirname, './my-theme.json'))
    return defineConfig({
      title: 'VitePress',

      markdown: {
        theme,
      },
     // ...
  })
}
```

<img width="637" alt="Screenshot 2022-07-14 at 11 46 52 PM" src="https://user-images.githubusercontent.com/5698350/179082518-ffb64208-2992-4783-a308-004d2310742b.png">
