### PR TITLE
feat: smooth scroll and prefs

### DIFF
--- a/src/client/theme-default/components/VPLink.vue
+++ b/src/client/theme-default/components/VPLink.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue'
 import { normalizeLink } from '../support/utils'
 import VPIconExternalLink from './icons/VPIconExternalLink.vue'
 import { EXTERNAL_URL_RE } from '../../shared'
-
 const props = defineProps<{
   href?: string
   noIcon?: boolean

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -5,6 +5,7 @@ import VPNavBarSearch from './VPNavBarSearch.vue'
 import VPNavBarMenu from './VPNavBarMenu.vue'
 import VPNavBarTranslations from './VPNavBarTranslations.vue'
 import VPNavBarAppearance from './VPNavBarAppearance.vue'
+import VPNavBarSmoothScroll from './VPNavBarSmoothScroll.vue'
 import VPNavBarSocialLinks from './VPNavBarSocialLinks.vue'
 import VPNavBarExtra from './VPNavBarExtra.vue'
 import VPNavBarHamburger from './VPNavBarHamburger.vue'
@@ -34,6 +35,7 @@ const { hasSidebar } = useSidebar()
         <VPNavBarMenu class="menu" />
         <VPNavBarTranslations class="translations" />
         <VPNavBarAppearance class="appearance" />
+        <VPNavBarSmoothScroll class="smooth-scroll" />
         <VPNavBarSocialLinks class="social-links" />
         <VPNavBarExtra class="extra" />
         <slot name="nav-bar-content-after" />
@@ -107,9 +109,13 @@ const { hasSidebar } = useSidebar()
 
 .menu + .translations::before,
 .menu + .appearance::before,
+.menu + .smooth-scroll::before,
 .menu + .social-links::before,
 .translations + .appearance::before,
-.appearance + .social-links::before {
+.translations + .smooth-scroll::before,
+.appearance + .smooth-scroll::before,
+.appearance + .social-links::before,
+.smooth-scroll + .social-links::before {
   margin-right: 8px;
   margin-left: 8px;
   width: 1px;
@@ -119,11 +125,16 @@ const { hasSidebar } = useSidebar()
 }
 
 .menu + .appearance::before,
-.translations + .appearance::before {
+.menu + .smooth-scroll::before,
+.translations + .appearance::before,
+.translations + .smooth-scroll::before,
+.appearance + .smooth-scroll::before {
   margin-right: 16px;
 }
 
-.appearance + .social-links::before {
+.appearance + .smooth-scroll::before,
+.appearance + .social-links::before,
+.smooth-scroll + .social-links::before {
   margin-left: 16px;
 }
 

--- a/src/client/theme-default/components/VPNavBarExtra.vue
+++ b/src/client/theme-default/components/VPNavBarExtra.vue
@@ -3,6 +3,7 @@ import { useData } from 'vitepress'
 import VPFlyout from './VPFlyout.vue'
 import VPMenuLink from './VPMenuLink.vue'
 import VPSwitchAppearance from './VPSwitchAppearance.vue'
+import VPSwitchSmoothScroll from "./VPSwitchSmoothScroll.vue";
 import VPSocialLinks from './VPSocialLinks.vue'
 
 const { site, theme } = useData()
@@ -23,6 +24,15 @@ const { site, theme } = useData()
         <p class="label">Appearance</p>
         <div class="appearance-action">
           <VPSwitchAppearance />
+        </div>
+      </div>
+    </div>
+
+    <div v-if="site.smoothScroll" class="group">
+      <div class="item smooth-scroll">
+        <p class="label">Smooth scroll</p>
+        <div class="smooth-scroll-action">
+          <VPSwitchSmoothScroll screen />
         </div>
       </div>
     </div>
@@ -62,17 +72,20 @@ const { site, theme } = useData()
 }
 
 .item.appearance,
+.item.smooth-scroll,
 .item.social-links {
   display: flex;
   align-items: center;
   padding: 0 12px;
 }
 
-.item.appearance {
+.item.appearance,
+.item.smooth-scroll {
   min-width: 176px;
 }
 
-.appearance-action {
+.appearance-action,
+.smooth-scroll-action {
   margin-right: -2px;
 }
 

--- a/src/client/theme-default/components/VPNavBarSmoothScroll.vue
+++ b/src/client/theme-default/components/VPNavBarSmoothScroll.vue
@@ -1,0 +1,25 @@
+<script lang="ts" setup>
+import { useData } from 'vitepress'
+import VPSwitchSmoothScroll from './VPSwitchSmoothScroll.vue'
+
+const { site } = useData()
+</script>
+
+<template>
+  <div v-if="site.smoothScroll" class="VPSwitchSmoothScroll">
+    <VPSwitchSmoothScroll />
+  </div>
+</template>
+
+<style scoped>
+.VPSwitchSmoothScroll {
+  display: none;
+}
+
+@media (min-width: 1280px) {
+  .VPSwitchSmoothScroll {
+    display: flex;
+    align-items: center;
+  }
+}
+</style>

--- a/src/client/theme-default/components/VPNavScreen.vue
+++ b/src/client/theme-default/components/VPNavScreen.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 import VPNavScreenMenu from './VPNavScreenMenu.vue'
 import VPNavScreenAppearance from './VPNavScreenAppearance.vue'
+import VPNavScreenSmoothScroll from './VPNavScreenSmoothScroll.vue'
 import VPNavScreenTranslations from './VPNavScreenTranslations.vue'
 import VPNavScreenSocialLinks from './VPNavScreenSocialLinks.vue'
 
@@ -33,6 +34,7 @@ function unlockBodyScroll() {
         <VPNavScreenMenu class="menu" />
         <VPNavScreenTranslations class="translations" />
         <VPNavScreenAppearance class="appearance" />
+        <VPNavScreenSmoothScroll class="smooth-scroll" />
         <VPNavScreenSocialLinks class="social-links" />
         <slot name="nav-screen-content-after" />
       </div>
@@ -88,7 +90,10 @@ function unlockBodyScroll() {
 
 .menu + .translations,
 .menu + .appearance,
-.translations + .appearance {
+.menu + .smooth-scroll,
+.translations + .appearance,
+.translations + .smooth-scroll,
+.appearance + .smooth-scroll {
   margin-top: 24px;
 }
 
@@ -96,7 +101,9 @@ function unlockBodyScroll() {
   margin-top: 16px;
 }
 
-.appearance + .social-links {
+.appearance + .smooth-scroll,
+.appearance + .social-links,
+.smooth-scroll + .social-links {
   margin-top: 16px;
 }
 </style>

--- a/src/client/theme-default/components/VPNavScreenSmoothScroll.vue
+++ b/src/client/theme-default/components/VPNavScreenSmoothScroll.vue
@@ -7,8 +7,8 @@ const { site } = useData()
 
 <template>
   <div v-if="site.smoothScroll" class="VPNavScreenSmoothScroll">
-    <p class="text">Smooth Scroll</p>
-    <VPSwitchSmoothScroll />
+    <p class="text">Smooth scroll</p>
+    <VPSwitchSmoothScroll screen />
   </div>
 </template>
 

--- a/src/client/theme-default/components/VPNavScreenSmoothScroll.vue
+++ b/src/client/theme-default/components/VPNavScreenSmoothScroll.vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup>
+import { useData } from 'vitepress'
+import VPSwitchSmoothScroll from './VPSwitchSmoothScroll.vue'
+
+const { site } = useData()
+</script>
+
+<template>
+  <div v-if="site.smoothScroll" class="VPNavScreenSmoothScroll">
+    <p class="text">Smooth Scroll</p>
+    <VPSwitchSmoothScroll />
+  </div>
+</template>
+
+<style scoped>
+.VPNavScreenSmoothScroll {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 8px;
+  padding: 12px 14px 12px 16px;
+  background-color: var(--vp-c-bg-soft);
+}
+
+.text {
+  line-height: 24px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+  transition: color 0.5s;
+}
+</style>

--- a/src/client/theme-default/components/VPSwitch.vue
+++ b/src/client/theme-default/components/VPSwitch.vue
@@ -37,6 +37,7 @@
   transition: background-color 0.25s, transform 0.25s;
 }
 
+
 .dark .check {
   background-color: var(--vp-c-black);
 }

--- a/src/client/theme-default/components/VPSwitch.vue
+++ b/src/client/theme-default/components/VPSwitch.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="VPSwitch" type="button" role="switch">
+  <button class="VPSwitch" type="button" role="switch" v-bind="$attrs">
     <span class="check">
       <span class="icon" v-if="$slots.default">
         <slot />

--- a/src/client/theme-default/components/VPSwitchAppearance.vue
+++ b/src/client/theme-default/components/VPSwitchAppearance.vue
@@ -3,6 +3,9 @@ import { APPEARANCE_KEY } from '../../shared'
 import VPSwitch from './VPSwitch.vue'
 import VPIconSun from './icons/VPIconSun.vue'
 import VPIconMoon from './icons/VPIconMoon.vue'
+import { ref } from "vue";
+
+const isDark = ref(false)
 
 const toggle = typeof localStorage !== 'undefined' ? useAppearance() : () => {}
 
@@ -12,20 +15,20 @@ function useAppearance() {
 
   let userPreference = localStorage.getItem(APPEARANCE_KEY) || 'auto'
 
-  let isDark = userPreference === 'auto'
+  isDark.value = userPreference === 'auto'
     ? query.matches
     : userPreference === 'dark'
 
   query.onchange = (e) => {
     if (userPreference === 'auto') {
-      setClass((isDark = e.matches))
+      setClass((isDark.value = e.matches))
     }
   }
 
   function toggle() {
-    setClass((isDark = !isDark))
+    setClass((isDark.value = !isDark.value))
 
-    userPreference = isDark
+    userPreference = isDark.value
       ? query.matches ? 'auto' : 'dark'
       : query.matches ? 'light' : 'auto'
 
@@ -44,6 +47,7 @@ function useAppearance() {
   <VPSwitch
     class="VPSwitchAppearance"
     aria-label="toggle dark mode"
+    :aria-checked="`${isDark}`"
     @click="toggle"
   >
     <VPIconSun class="sun" />

--- a/src/client/theme-default/components/VPSwitchSmoothScroll.vue
+++ b/src/client/theme-default/components/VPSwitchSmoothScroll.vue
@@ -1,53 +1,59 @@
 <script lang="ts" setup>
 import { SMOOTH_SCROLL_KEY } from '../../shared'
 import VPSwitch from './VPSwitch.vue'
-import VPIconSun from './icons/VPIconSun.vue'
-import VPIconMoon from './icons/VPIconMoon.vue'
+import VPIconSmoothScrollOn from './icons/VPIconSmoothScrollOn.vue'
+import VPIconSmoothScrollOff from './icons/VPIconSmoothScrollOff.vue'
+import { ref, watch } from 'vue';
+
+defineProps<{ screen?: boolean }>()
+
+const title = ref('Smooth Scroll')
+const isSmoothScroll = ref(false)
+
+watch(isSmoothScroll, (smoothScroll) => {
+  title.value = `Smooth scroll is ${smoothScroll ? 'on' : 'off'}`
+})
 
 const toggle = typeof localStorage !== 'undefined' ? useSmoothScroll() : () => {}
 
 function useSmoothScroll() {
-  const query = window.matchMedia('(prefers-reduced-motion: reduce)')
   const classList = document.documentElement.classList
 
-  let userPreference = localStorage.getItem(SMOOTH_SCROLL_KEY) || 'auto'
+  // reduce will be used only while the user don't click the switcher
+  let userPreference = localStorage.getItem(SMOOTH_SCROLL_KEY) || 'reduce'
 
-  let isSmoothScroll = userPreference === 'auto'
-    ? !query.matches
-    : userPreference === 'no-preference'
+  isSmoothScroll.value = userPreference === 'no-preference'
 
-  query.onchange = (e) => {
-    if (userPreference === 'auto') {
-      setClass((isSmoothScroll = !e.matches))
-    }
-  }
+  setClass(isSmoothScroll.value)
 
   function toggle() {
-    setClass((isSmoothScroll = !isSmoothScroll))
+    setClass((isSmoothScroll.value = !isSmoothScroll.value))
 
-    userPreference = isSmoothScroll
-      ? query.matches ? 'auto' : 'no-preference'
-      : 'no-preference'
+    userPreference = isSmoothScroll.value ? 'no-preference' : 'reduce'
 
     localStorage.setItem(SMOOTH_SCROLL_KEY, userPreference)
   }
 
   function setClass(smoothScroll: boolean): void {
-    classList[smoothScroll ? 'add' : 'remove']('no-preference')
+    classList.remove('smooth-scroll-on', 'smooth-scroll-off')
+    classList.add(smoothScroll ? 'smooth-scroll-on' : 'smooth-scroll-off')
   }
 
   return toggle
 }
+
 </script>
 
 <template>
   <VPSwitch
     class="VPSwitchSmoothScroll"
+    :title="title"
     aria-label="toggle smooth scroll mode"
+    :aria-checked="`${isSmoothScroll}`"
     @click="toggle"
   >
-    <VPIconSun class="reduce" />
-    <VPIconMoon class="no-preference" />
+    <VPIconSmoothScrollOff :title="title" :check="screen" class="reduce" />
+    <VPIconSmoothScrollOn :title="title" :check="screen" class="no-preference" />
   </VPSwitch>
 </template>
 
@@ -60,17 +66,15 @@ function useSmoothScroll() {
   opacity: 0;
 }
 
-.no-preference .reduce {
+.smooth-scroll-on .reduce {
   opacity: 0;
 }
 
-.no-preference .no-preference {
+.smooth-scroll-on .no-preference {
   opacity: 1;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .no-preference .VPSwitchSmoothScroll :deep(.check) {
-    transform: translateX(18px);
-  }
+.smooth-scroll-on .VPSwitchSmoothScroll :deep(.check) {
+  transform: translateX(18px);
 }
 </style>

--- a/src/client/theme-default/components/VPSwitchSmoothScroll.vue
+++ b/src/client/theme-default/components/VPSwitchSmoothScroll.vue
@@ -1,0 +1,76 @@
+<script lang="ts" setup>
+import { SMOOTH_SCROLL_KEY } from '../../shared'
+import VPSwitch from './VPSwitch.vue'
+import VPIconSun from './icons/VPIconSun.vue'
+import VPIconMoon from './icons/VPIconMoon.vue'
+
+const toggle = typeof localStorage !== 'undefined' ? useSmoothScroll() : () => {}
+
+function useSmoothScroll() {
+  const query = window.matchMedia('(prefers-reduced-motion: reduce)')
+  const classList = document.documentElement.classList
+
+  let userPreference = localStorage.getItem(SMOOTH_SCROLL_KEY) || 'auto'
+
+  let isSmoothScroll = userPreference === 'auto'
+    ? !query.matches
+    : userPreference === 'no-preference'
+
+  query.onchange = (e) => {
+    if (userPreference === 'auto') {
+      setClass((isSmoothScroll = !e.matches))
+    }
+  }
+
+  function toggle() {
+    setClass((isSmoothScroll = !isSmoothScroll))
+
+    userPreference = isSmoothScroll
+      ? query.matches ? 'auto' : 'no-preference'
+      : 'no-preference'
+
+    localStorage.setItem(SMOOTH_SCROLL_KEY, userPreference)
+  }
+
+  function setClass(smoothScroll: boolean): void {
+    classList[smoothScroll ? 'add' : 'remove']('no-preference')
+  }
+
+  return toggle
+}
+</script>
+
+<template>
+  <VPSwitch
+    class="VPSwitchSmoothScroll"
+    aria-label="toggle smooth scroll mode"
+    @click="toggle"
+  >
+    <VPIconSun class="reduce" />
+    <VPIconMoon class="no-preference" />
+  </VPSwitch>
+</template>
+
+<style scoped>
+.reduce {
+  opacity: 1;
+}
+
+.no-preference {
+  opacity: 0;
+}
+
+.no-preference .reduce {
+  opacity: 0;
+}
+
+.no-preference .no-preference {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .no-preference .VPSwitchSmoothScroll :deep(.check) {
+    transform: translateX(18px);
+  }
+}
+</style>

--- a/src/client/theme-default/components/icons/VPIconSmoothScrollOff.vue
+++ b/src/client/theme-default/components/icons/VPIconSmoothScrollOff.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  check: boolean
+}>()
+</script>
+
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       role="img"
+       aria-labelledby="smooth-scroll-icon"
+       focusable="false"
+       class="smooth-scroll-icon-off"
+       :class="{ check }"
+       width="32"
+       height="32"
+       preserveAspectRatio="xMidYMid meet"
+       viewBox="0 0 24 24">
+    <title id="smooth-scroll-icon">
+      {{ title }}
+    </title>
+    <path v-if="check" d="M5.293 5.293a1 1 0 0 1 1.414 0L12 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414L13.414 12l5.293 5.293a1 1 0 0 1-1.414 1.414L12 13.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L10.586 12L5.293 6.707a1 1 0 0 1 0-1.414z"></path>
+    <path v-else fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 9l5 12l1.774-5.226L21 14L9 9zm7.071 7.071l4.243 4.243M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"></path>
+
+  </svg>
+</template>
+<style scoped>
+svg.smooth-scroll-icon-off {
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+}
+svg.smooth-scroll-icon-off:not(.check) {
+  color: var(--vp-c-text-2);
+}
+.dark svg.smooth-scroll-icon-off:not(.check) {
+  color: var(--vp-c-text-1);
+}
+</style>

--- a/src/client/theme-default/components/icons/VPIconSmoothScrollOff.vue
+++ b/src/client/theme-default/components/icons/VPIconSmoothScrollOff.vue
@@ -8,7 +8,7 @@ defineProps<{
 <template>
   <svg xmlns="http://www.w3.org/2000/svg"
        role="img"
-       aria-labelledby="smooth-scroll-icon"
+       aria-labelledby="smooth-scroll-icon-off"
        focusable="false"
        class="smooth-scroll-icon-off"
        :class="{ check }"
@@ -16,7 +16,7 @@ defineProps<{
        height="32"
        preserveAspectRatio="xMidYMid meet"
        viewBox="0 0 24 24">
-    <title id="smooth-scroll-icon">
+    <title id="smooth-scroll-icon-off">
       {{ title }}
     </title>
     <path v-if="check" d="M5.293 5.293a1 1 0 0 1 1.414 0L12 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414L13.414 12l5.293 5.293a1 1 0 0 1-1.414 1.414L12 13.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L10.586 12L5.293 6.707a1 1 0 0 1 0-1.414z"></path>

--- a/src/client/theme-default/components/icons/VPIconSmoothScrollOn.vue
+++ b/src/client/theme-default/components/icons/VPIconSmoothScrollOn.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  check: boolean
+}>()
+</script>
+
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       role="img"
+       aria-labelledby="smooth-scroll-icon"
+       focusable="false"
+       class="smooth-scroll-icon-on"
+       width="32"
+       height="32"
+       preserveAspectRatio="xMidYMid meet"
+       viewBox="0 0 24 24">
+    <title id="smooth-scroll-icon">
+      {{ title }}
+    </title>
+    <path v-if="check" d="m9 20.42l-6.21-6.21l2.83-2.83L9 14.77l9.88-9.89l2.83 2.83L9 20.42Z"></path>
+    <path
+      v-else
+      d="m12.748 4.002l-.001.002h7.498c.967 0 1.75.784 1.75 1.75V18.25a1.75 1.75 0 0 1-1.75 1.75h-8.997l-.001-.002H3.75A1.75 1.75 0 0 1 2 18.247V5.752c0-.967.784-1.75 1.75-1.75h8.998Zm7.497 1.502h-7.497V18.5h7.497a.25.25 0 0 0 .25-.25V5.755a.25.25 0 0 0-.25-.25Zm-8.997-.002H3.75a.25.25 0 0 0-.25.25v12.495c0 .138.112.25.25.25h7.498V5.502Zm3.454 7.9l.083.073l1.718 1.75l1.714-1.75a.75.75 0 0 1 1.143.966l-.071.085l-2.25 2.296a.75.75 0 0 1-.987.074l-.084-.074l-2.253-2.296a.75.75 0 0 1 .987-1.124Zm2.337-6.176l2.25 2.296a.75.75 0 0 1-1.072 1.05l-1.714-1.75l-1.718 1.75a.75.75 0 1 1-1.07-1.05l2.253-2.297a.75.75 0 0 1 1.07 0Z"></path>
+  </svg>
+</template>
+<style scoped>
+svg.smooth-scroll-icon-on {
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+}
+</style>

--- a/src/client/theme-default/components/icons/VPIconSmoothScrollOn.vue
+++ b/src/client/theme-default/components/icons/VPIconSmoothScrollOn.vue
@@ -8,14 +8,14 @@ defineProps<{
 <template>
   <svg xmlns="http://www.w3.org/2000/svg"
        role="img"
-       aria-labelledby="smooth-scroll-icon"
+       aria-labelledby="smooth-scroll-icon-on"
        focusable="false"
        class="smooth-scroll-icon-on"
        width="32"
        height="32"
        preserveAspectRatio="xMidYMid meet"
        viewBox="0 0 24 24">
-    <title id="smooth-scroll-icon">
+    <title id="smooth-scroll-icon-on">
       {{ title }}
     </title>
     <path v-if="check" d="m9 20.42l-6.21-6.21l2.83-2.83L9 14.77l9.88-9.89l2.83 2.83L9 20.42Z"></path>

--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -14,14 +14,12 @@ html.dark {
   color-scheme: dark;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  html {
-    scroll-behavior: smooth;
-  }
+html.smooth-scroll-on {
+  scroll-behavior: smooth;
 }
 
-html.smooth-scroll {
-  scroll-behavior: smooth;
+html.smooth-scroll-off {
+  scroll-behavior: unset;
 }
 
 body {

--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -14,7 +14,7 @@ html.dark {
   color-scheme: dark;
 }
 
-html.smooth-scroll-on {
+html.smooth-scroll-on:focus-within {
   scroll-behavior: smooth;
 }
 

--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -14,6 +14,16 @@ html.dark {
   color-scheme: dark;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+html.smooth-scroll {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   width: 100%;

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -35,6 +35,7 @@ export interface UserConfig<ThemeConfig = any> {
   description?: string
   head?: HeadConfig[]
   appearance?: boolean
+  smoothScroll?: boolean
   themeConfig?: ThemeConfig
   locales?: Record<string, LocaleConfig>
   markdown?: MarkdownOptions
@@ -270,6 +271,7 @@ export async function resolveSiteData(
     base: userConfig.base ? userConfig.base.replace(/([^/])$/, '$1/') : '/',
     head: resolveSiteDataHead(userConfig),
     appearance: userConfig.appearance ?? true,
+    smoothScroll: userConfig.smoothScroll ?? true,
     themeConfig: userConfig.themeConfig || {},
     locales: userConfig.locales || {},
     langs: createLangDictionary(userConfig),

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -17,6 +17,7 @@ export type {
 
 export const EXTERNAL_URL_RE = /^[a-z]+:/i
 export const APPEARANCE_KEY = 'vitepress-theme-appearance'
+export const SMOOTH_SCROLL_KEY = 'vitepress-theme-scroll'
 
 // @ts-ignore
 export const inBrowser = typeof window !== 'undefined'

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -17,7 +17,7 @@ export type {
 
 export const EXTERNAL_URL_RE = /^[a-z]+:/i
 export const APPEARANCE_KEY = 'vitepress-theme-appearance'
-export const SMOOTH_SCROLL_KEY = 'vitepress-theme-scroll'
+export const SMOOTH_SCROLL_KEY = 'vitepress-theme-smooth-scroll'
 
 // @ts-ignore
 export const inBrowser = typeof window !== 'undefined'

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -33,6 +33,7 @@ export interface SiteData<ThemeConfig = any> {
   description: string
   head: HeadConfig[]
   appearance: boolean
+  smoothScroll: boolean
   themeConfig: ThemeConfig
   scrollOffset: number | string
   locales: Record<string, LocaleConfig>


### PR DESCRIPTION
POC: by default smooth scroll not enabled and we can remove it from the configuration, enabled by default (I need to change the docs).

From the comments here https://github.com/vuejs/vitepress/pull/978#issuecomment-1183549569, it seems there are some caveats with the implementation in all browsers:
- chrome: just works, but scrolling from the right aside links seems to not work; from the left aside seems to work
- firefox: ~~not working; we can add a manual focus using `scrollIntoView` in the right aside, we'll need to include `behavior: 'smooth'` (tested but removed, see safari)~~ check next comment
- safari: `smooth` not supported