### PR TITLE
fix: strip custom anchor with capital letters in outline

### DIFF
--- a/src/node/utils/parseHeader.ts
+++ b/src/node/utils/parseHeader.ts
@@ -33,7 +33,7 @@ const removeMarkdownTokens = (str: string) =>
     .replace(/(\\)(\*|_|`|\!|<|\$)/g, '$2') // remove escape char '\'
 
 const removeCustomAnchor = (str: string) =>
-  str.replace(/\{#([a-z0-9\-_]+?)\}\s*$/, '') // {#custom-header}
+  str.replace(/\{#([a-zA-Z0-9\-_]+?)\}\s*$/, '') // {#custom-header}
 
 const trim = (str: string) => str.trim()
 


### PR DESCRIPTION
Custom anchors that contain capital letters are currently displayed in the outline because the current processor is not matching capital case.
 
<img width="269" alt="Screenshot 2022-07-17 at 11 54 04" src="https://user-images.githubusercontent.com/3183686/179393041-5b7df5c8-e72a-4eeb-852c-4757cbf9c8fd.png">
 