### PR TITLE
docs(frontmatter-configs): Fix reference to HeadConfig type

### DIFF
--- a/docs/config/frontmatter-configs.md
+++ b/docs/config/frontmatter-configs.md
@@ -54,7 +54,7 @@ description: VitePress
 
 ### head
 
-- Type: `Head[]`
+- Type: `HeadConfig[]`
 
 Specify extra head tags to be injected:
 
@@ -71,7 +71,7 @@ head:
 ```
 
 ```ts
-type Head =
+type HeadConfig =
   | [string, Record<string, string>]
   | [string, Record<string, string>, string]
 ```


### PR DESCRIPTION
The frontmatter docs reference a `Head` type that seems to be incorrect.

From what I can tell, the correct type is `HeadConfig`, used here: https://github.com/vuejs/vitepress/blob/f6d5697ed7f247e8673614f4e0ff7232e808ef1e/src/node/config.ts#L29-L36