### PR TITLE
docs: docs say that footer won't display for 'template: doc', but it does. 

### DIFF
--- a/docs/guide/theme-footer.md
+++ b/docs/guide/theme-footer.md
@@ -1,6 +1,6 @@
 # Footer
 
-When the [page layout](./theme-layout) is set to either `home` or `page`, VitePress will display global footer at the bottom of the page. Set `themeConfig.footer` to configure footer content.
+VitePress will display global footer at the bottom of the page when `themeConfig.footer` is present.
 
 ```ts
 export default {

--- a/docs/guide/theme-footer.md
+++ b/docs/guide/theme-footer.md
@@ -1,6 +1,6 @@
 # Footer
 
-VitePress will display global footer at the bottom of the page. Set `themeConfig.footer` to configure footer content.
+When the [page layout](./theme-layout) is set to either `home` or `page`, VitePress will display global footer at the bottom of the page. Set `themeConfig.footer` to configure footer content.
 
 ```ts
 export default {
@@ -23,3 +23,4 @@ export interface Footer {
 }
 ```
 
+Note that footer will not be displayed when the [SideBar](./theme-sidebar) is visible.

--- a/docs/guide/theme-footer.md
+++ b/docs/guide/theme-footer.md
@@ -1,6 +1,6 @@
 # Footer
 
-When the [page layout](./theme-layout) is set to either `home` or `page`, VitePress will display global footer at the bottom of the page. Set `themeConfig.footer` to configure footer content.
+VitePress will display global footer at the bottom of the page. Set `themeConfig.footer` to configure footer content.
 
 ```ts
 export default {
@@ -23,4 +23,3 @@ export interface Footer {
 }
 ```
 
-Note that footer will not be displayed when the page layout is set to `doc`.


### PR DESCRIPTION
The documentation incorrectly states that the footer isn't displayed when the page layout is set to 'doc'.