### PR TITLE
docs: include @algolia/client-search as well, to avoid missing peer dependency

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -51,6 +51,7 @@ On PNPM, add this in your `package.json`:
 "pnpm": {
   "peerDependencyRules": {
     "ignoreMissing": [
+      "@algolia/client-search",
       "@types/react",
       "react",
       "react-dom"


### PR DESCRIPTION

@algolia/client-search also throws up  missing peer error.
```
 WARN  Issues with peer dependencies found
.
└─┬ vitepress
  └─┬ @docsearch/js
    └─┬ @docsearch/react
      └─┬ @algolia/autocomplete-preset-algolia
        └── ✕ missing peer @algolia/client-search@^4.9.1
Peer dependencies that should be installed:
  @algolia/client-search@^4.9.1
```

The document already mentions about react and 3 more, can we add this as well ? 
