### PR TITLE
fix(theme): switch to navigator clipboard to copy code

### DIFF
--- a/src/client/theme-default/composables/copy-code.ts
+++ b/src/client/theme-default/composables/copy-code.ts
@@ -49,7 +49,7 @@ async function copyToClipboard(text: string) {
     element.selectionStart = 0
     element.selectionEnd = text.length
 
-    document.execCommand('copy')
+    navigator.clipboard.writeText(text)
     document.body.removeChild(element)
 
     if (originalRange) {


### PR DESCRIPTION
`document.execCommand` is deprecated.