### PR TITLE
docs: fix typo in theme-configs

### DIFF
--- a/docs/config/theme-configs.md
+++ b/docs/config/theme-configs.md
@@ -91,7 +91,7 @@ interface NavItemWithChildren {
 
 - Type: `Sidebar`
 
-The configuration for the sidebar menu item. You may learn more details at [Theme: Nav](../guide/theme-sidebar).
+The configuration for the sidebar menu item. You may learn more details at [Theme: Sidebar](../guide/theme-sidebar).
 
 ```js
 export default {


### PR DESCRIPTION
Typo: `Theme: Sidebar`  was written incorrectly as `Theme: Nav`  in this section.