### PR TITLE
docs: add different logos for light and dark modes

### DIFF
--- a/docs/config/theme-configs.md
+++ b/docs/config/theme-configs.md
@@ -21,15 +21,22 @@ Here it describes the settings for the VitePress default theme. If you're using 
 
 ## logo
 
-- Type: `string`
+- Type: `string | ThemedLogo`
 
-Logo file to display in nav bar, right before the site title.
+Logo file to display in nav bar, right before the site title. Accepts a path string, or an object to set a different logo for light/dark mode.
 
 ```ts
 export default {
   themeConfig: {
     logo: '/logo.svg'
   }
+}
+```
+
+```ts
+type ThemedLogo = {
+  light: string;
+  dark: string;
 }
 ```
 

--- a/docs/config/theme-configs.md
+++ b/docs/config/theme-configs.md
@@ -21,7 +21,7 @@ Here it describes the settings for the VitePress default theme. If you're using 
 
 ## logo
 
-- Type: `string | ThemedLogo`
+- Type: `ThemeableImage`
 
 Logo file to display in nav bar, right before the site title. Accepts a path string, or an object to set a different logo for light/dark mode.
 
@@ -34,10 +34,8 @@ export default {
 ```
 
 ```ts
-type ThemedLogo = {
-  light: string;
-  dark: string;
-}
+type Image = string | { src: string; alt?: string }
+type ThemeableImage = Image | { light: Image; dark: Image }
 ```
 
 ## siteTitle


### PR DESCRIPTION
https://github.com/vuejs/vitepress/pull/745 added support for a light vs dark mode logo by setting the `logo` configuration. According to @brc-dd in https://github.com/vuejs/vitepress/issues/1006#issuecomment-1186542000, it's officially supported but not documented yet. Seeing it's a super useful configuration, I figured it was a good first contribution to the project 🙂 

Please let me know if I correctly understood the setup for the "Type" description. Happy to make any changes where needed 👍🏻 

Closes https://github.com/vuejs/vitepress/issues/1006 [^1].

[^1]: 1006 is the open feature request for adding light/dark mode support in the logo. It already exists, so I _think_ the issue was left open as a reminder to add it to the docs, which is why this PR should close it.