### PR TITLE
feat(theme): style scrollbar of the pre element.

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -213,3 +213,25 @@ fieldset {
   margin: 0;
   padding: 0;
 }
+
+pre {
+  scrollbar-width: thin; /* for firefox */
+}
+
+pre::-webkit-scrollbar {
+  height: 10px;
+}
+
+pre::-webkit-scrollbar-track {
+  background-color: var(--vp-scrollbar-track-bg);
+}
+
+pre::-webkit-scrollbar-thumb {
+  background-color: var(--vp-scrollbar-thumb-bg);
+  border: solid 2px var(--vp-scrollbar-track-bg);
+  border-radius: 10px;
+}
+
+pre::-webkit-scrollbar-thumb:hover {
+  background-color: var(--vp-scrollbar-thumb-bg-hover);
+}

--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -113,6 +113,10 @@
   --vp-c-brand-darker: var(--vp-c-green-darker);
 
   --vp-c-sponsor: #fd1d7c;
+
+  --vp-scrollbar-track-bg: var(--vp-code-block-bg);
+  --vp-scrollbar-thumb-bg: rgba(255, 255, 255, 0.38);
+  --vp-scrollbar-thumb-bg-hover: rgba(255, 255, 255, 0.48);
 }
 
 .dark {
@@ -138,6 +142,9 @@
   --vp-c-text-inverse-4: var(--vp-c-text-light-4);
 
   --vp-c-text-code: var(--vp-c-indigo-lighter);
+
+  --vp-scrollbar-thumb-bg: var(--vp-c-bg-soft);
+  --vp-scrollbar-thumb-bg-hover: var(--vp-c-bg-mute);
 }
 
 /**


### PR DESCRIPTION
Hi,

Style the scrollbar of the `pre` element:
![scroll-dark](https://user-images.githubusercontent.com/6343314/184557047-f0f3b133-ff50-4974-b736-6a2db5397bd3.PNG)
![scroll-light](https://user-images.githubusercontent.com/6343314/184557063-37885411-2dc8-4a64-b329-aace9776e871.PNG)

like `docusaurus` it have a custom scrollbars.

regards
