### PR TITLE
fix(theme): don't let navbar obstruct clicks to top part of scrollbar

### DIFF
--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -33,6 +33,7 @@ provide('close-screen', closeScreen)
   left: 0;
   z-index: var(--vp-z-index-nav);
   width: 100%;
+  pointer-events: none;
 }
 
 @media (min-width: 960px) {

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -54,6 +54,11 @@ const { hasSidebar } = useSidebar()
   padding: 0 8px 0 24px;
   height: var(--vp-nav-height-mobile);
   transition: border-color 0.5s, background-color 0.5s;
+  pointer-events: none;
+}
+
+.VPNavBar .container:deep(*) {
+  pointer-events: all;
 }
 
 @media (min-width: 768px) {
@@ -96,6 +101,7 @@ const { hasSidebar } = useSidebar()
   justify-content: space-between;
   margin: 0 auto;
   max-width: calc(var(--vp-layout-max-width) - 64px);
+  pointer-events: none;
 }
 
 .content {


### PR DESCRIPTION
On desktop screen sizes, if the sidebar has a scrollbar, the very top
part of the scrollbar can't be clicked on because the navbar obstructs
it due to having a higher z-index. (This higher z-index is necessary so
that the navbar is visible.) With this fix, the navbar container has
`pointer-events: none;` so that clicks to the scrollbar underneath will
work. Child elements of the navbar that need to receive clicks have
`pointer-events: all;` turned on for them.

fix vueuse/vueuse#2086

## Before

The red highlighted part of the scrollbar could not be clicked and dragged:

![image](https://user-images.githubusercontent.com/3038600/184559781-d5716ec6-2cb1-4cb1-85f6-c08e9feade4a.png)


## After

The part of the scrollbar above can now be clicked and dragged, and all of the other parts of the sidebar and navbar remain clickable as before.