### PR TITLE
refactor: migrate markdown toc plugin (close #1093)

### DIFF
--- a/docs/config/app-configs.md
+++ b/docs/config/app-configs.md
@@ -148,10 +148,8 @@ interface MarkdownOptions extends MarkdownIt.Options {
   lineNumbers?: boolean
 
   // markdown-it-anchor plugin options.
-  // See: https://github.com/valeriangalliat/markdown-it-anchor
-  anchor?: {
-    permalink?: anchor.AnchorOptions['permalink']
-  }
+  // See: https://github.com/valeriangalliat/markdown-it-anchor#usage
+  anchor?: anchorPlugin.AnchorOptions
 
   // markdown-it-attrs plugin options.
   // See: https://github.com/arve0/markdown-it-attrs
@@ -162,9 +160,9 @@ interface MarkdownOptions extends MarkdownIt.Options {
     disable?: boolean
   }
 
-  // markdown-it-toc-done-right plugin options
-  // See: https://github.com/nagaozen/markdown-it-toc-done-right
-  toc?: any
+  // @mdit-vue/plugin-toc plugin options.
+  // See: https://github.com/mdit-vue/mdit-vue/tree/main/packages/plugin-toc#options
+  toc?: TocPluginOptions
 
   // Configure the Markdown-it instance.
   config?: (md: MarkdownIt) => void

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -435,12 +435,13 @@ const anchor = require('markdown-it-anchor')
 module.exports = {
   markdown: {
     // options for markdown-it-anchor
-    // https://github.com/valeriangalliat/markdown-it-anchor#permalinks
+    // https://github.com/valeriangalliat/markdown-it-anchor#usage
     anchor: {
       permalink: anchor.permalink.headerLink()
     },
 
-    // options for markdown-it-toc-done-right
+    // options for @mdit-vue/plugin-toc
+    // https://github.com/mdit-vue/mdit-vue/tree/main/packages/plugin-toc#options
     toc: { level: [1, 2] },
 
     config: (md) => {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "vue": "^3.2.37"
   },
   "devDependencies": {
-    "@mdit-vue/plugin-component": "^0.9.0",
+    "@mdit-vue/plugin-component": "^0.9.2",
+    "@mdit-vue/plugin-toc": "^0.9.2",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
@@ -136,7 +137,6 @@
     "markdown-it-attrs": "^4.1.4",
     "markdown-it-container": "^3.0.0",
     "markdown-it-emoji": "^2.0.2",
-    "markdown-it-toc-done-right": "^4.2.0",
     "micromatch": "^4.0.5",
     "minimist": "^1.2.6",
     "npm-run-all": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,8 @@ importers:
     specifiers:
       '@docsearch/css': ^3.2.1
       '@docsearch/js': ^3.2.1
-      '@mdit-vue/plugin-component': ^0.9.0
+      '@mdit-vue/plugin-component': ^0.9.2
+      '@mdit-vue/plugin-toc': ^0.9.2
       '@rollup/plugin-alias': ^3.1.9
       '@rollup/plugin-commonjs': ^22.0.2
       '@rollup/plugin-json': ^4.1.0
@@ -54,7 +55,6 @@ importers:
       markdown-it-attrs: ^4.1.4
       markdown-it-container: ^3.0.0
       markdown-it-emoji: ^2.0.2
-      markdown-it-toc-done-right: ^4.2.0
       micromatch: ^4.0.5
       minimist: ^1.2.6
       npm-run-all: ^4.1.5
@@ -89,7 +89,8 @@ importers:
       vite: 3.0.8
       vue: 3.2.37
     devDependencies:
-      '@mdit-vue/plugin-component': 0.9.0
+      '@mdit-vue/plugin-component': 0.9.2
+      '@mdit-vue/plugin-toc': 0.9.2
       '@rollup/plugin-alias': 3.1.9_rollup@2.78.0
       '@rollup/plugin-commonjs': 22.0.2_rollup@2.78.0
       '@rollup/plugin-json': 4.1.0_rollup@2.78.0
@@ -133,7 +134,6 @@ importers:
       markdown-it-attrs: 4.1.4_markdown-it@13.0.1
       markdown-it-container: 3.0.0
       markdown-it-emoji: 2.0.2
-      markdown-it-toc-done-right: 4.2.0
       micromatch: 4.0.5
       minimist: 1.2.6
       npm-run-all: 4.1.5
@@ -394,11 +394,32 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@mdit-vue/plugin-component/0.9.0:
-    resolution: {integrity: sha512-HfrIQL8EiIyBeg42aSdTJJ/r2STI88fDFexPv7pI+a/qq1BG5AR0FTHTuzP3vwHn1ysgYB1qk4/hV/hodPYzhQ==}
+  /@mdit-vue/plugin-component/0.9.2:
+    resolution: {integrity: sha512-sTi9SWiakUGUs330zNRfEYSzGAVAXJ7gjbg46e/4HJQXxC8uEBC+Xg6IgsYcTRGHuJpCP65pcHvCLeDoCdWpyQ==}
     dependencies:
       '@types/markdown-it': 12.2.3
       markdown-it: 13.0.1
+    dev: true
+
+  /@mdit-vue/plugin-toc/0.9.2:
+    resolution: {integrity: sha512-Du3fFz+YezlXex9Syn+bc8ADDRx/kBfBokeHXfd/qCW5XqS7I4THLR/IRqlvi9CgIZ0dx7bJv0avxil9EX1PoQ==}
+    dependencies:
+      '@mdit-vue/shared': 0.9.2
+      '@mdit-vue/types': 0.9.2
+      '@types/markdown-it': 12.2.3
+      markdown-it: 13.0.1
+    dev: true
+
+  /@mdit-vue/shared/0.9.2:
+    resolution: {integrity: sha512-05Nk/o+kJCgeAa7oBGJOIazJq+6n0+VR4jPhzV3LGc9TyuMEqnrH5XzmBoy45vzyyoe7pGxJ/PBDxq4HebQHtQ==}
+    dependencies:
+      '@mdit-vue/types': 0.9.2
+      '@types/markdown-it': 12.2.3
+      markdown-it: 13.0.1
+    dev: true
+
+  /@mdit-vue/types/0.9.2:
+    resolution: {integrity: sha512-SuoxzZHS2/9bEqeJ+bjj2xBLjoZhRo6Ww/GVqNZS2ji9rkoM2teA0kbwSmj0X6Kf00K9HnLs6T0dtDtqpBqEHA==}
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -2735,10 +2756,6 @@ packages:
 
   /markdown-it-emoji/2.0.2:
     resolution: {integrity: sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ==}
-    dev: true
-
-  /markdown-it-toc-done-right/4.2.0:
-    resolution: {integrity: sha512-UB/IbzjWazwTlNAX0pvWNlJS8NKsOQ4syrXZQ/C72j+jirrsjVRT627lCaylrKJFBQWfRsPmIVQie8x38DEhAQ==}
     dev: true
 
   /markdown-it/13.0.1:

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -2,10 +2,9 @@ import MarkdownIt from 'markdown-it'
 import anchorPlugin from 'markdown-it-anchor'
 import attrsPlugin from 'markdown-it-attrs'
 import emojiPlugin from 'markdown-it-emoji'
-import tocPlugin from 'markdown-it-toc-done-right'
 import { componentPlugin } from '@mdit-vue/plugin-component'
+import { tocPlugin, type TocPluginOptions } from '@mdit-vue/plugin-toc'
 import { IThemeRegistration } from 'shiki'
-import { parseHeader } from '../utils/parseHeader'
 import { highlight } from './plugins/highlight'
 import { slugify } from './plugins/slugify'
 import { highlightLinePlugin } from './plugins/highlightLines'
@@ -26,9 +25,7 @@ export type ThemeOptions =
 export interface MarkdownOptions extends MarkdownIt.Options {
   lineNumbers?: boolean
   config?: (md: MarkdownIt) => void
-  anchor?: {
-    permalink?: anchorPlugin.AnchorOptions['permalink']
-  }
+  anchor?: anchorPlugin.AnchorOptions
   attrs?: {
     leftDelimiter?: string
     rightDelimiter?: string
@@ -36,8 +33,7 @@ export interface MarkdownOptions extends MarkdownIt.Options {
     disable?: boolean
   }
   theme?: ThemeOptions
-  // https://github.com/nagaozen/markdown-it-toc-done-right
-  toc?: any
+  toc?: TocPluginOptions
   externalLinks?: Record<string, string>
 }
 
@@ -95,15 +91,11 @@ export const createMarkdownRenderer = async (
     slugify,
     permalink: anchorPlugin.permalink.ariaHidden({}),
     ...options.anchor
-  })
+  } as anchorPlugin.AnchorOptions)
     .use(tocPlugin, {
       slugify,
-      level: [2, 3],
-      format: (x: string, htmlencode: (s: string) => string) =>
-        htmlencode(parseHeader(x)),
-      listType: 'ul',
       ...options.toc
-    })
+    } as TocPluginOptions)
     .use(emojiPlugin)
 
   // apply user config


### PR DESCRIPTION
- Migrate from `markdown-it-done-right` to `@mdit-vue/plugin-toc`
- Will fix #1093 
- Also refine the types of anchor plugin