### PR TITLE
feat(client): export VPSocialLinks

### DIFF
--- a/src/client/theme-default/index.ts
+++ b/src/client/theme-default/index.ts
@@ -19,6 +19,7 @@ export { default as VPTeamPage } from './components/VPTeamPage.vue'
 export { default as VPTeamPageTitle } from './components/VPTeamPageTitle.vue'
 export { default as VPTeamPageSection } from './components/VPTeamPageSection.vue'
 export { default as VPTeamMembers } from './components/VPTeamMembers.vue'
+export { default as VPSocialLinks } from './components/VPSocialLinks.vue'
 
 const theme: Theme = {
   Layout,

--- a/theme.d.ts
+++ b/theme.d.ts
@@ -9,6 +9,7 @@ export const VPTeamPage: ComponentOptions
 export const VPTeamPageTitle: ComponentOptions
 export const VPTeamPageSection: ComponentOptions
 export const VPTeamMembers: ComponentOptions
+export const VPSocialLinks: ComponentOptions
 
 declare const theme: {
   Layout: ComponentOptions


### PR DESCRIPTION
Signed-off-by: Sepush <sepush@outlook.com>

need this component to display sociallinks of author in blog page some workaround in https://github.com/vuejs/vitepress/discussions/1123 but seems broken in alpha8
export it and we can reuse it will be convenient
eg:
![image](https://user-images.githubusercontent.com/39197136/185726933-2ad5b457-2a9f-4375-9126-01242fd065f0.png)


