### PR TITLE
chore: fix example

### DIFF
--- a/docs/config/frontmatter-configs.md
+++ b/docs/config/frontmatter-configs.md
@@ -35,8 +35,8 @@ The suffix for the title. It's same as [config.titleTemplate](../config/app-conf
 
 ```yaml
 ---
-title: VitePress,
-titleTemplate: Vite & Vue powered static site generator.
+title: VitePress
+titleTemplate: Vite & Vue powered static site generator
 ---
 ```
 


### PR DESCRIPTION
Compared to https://vitepress.vuejs.org/, have extra comma

https://vitepress.vuejs.org/
![image](https://user-images.githubusercontent.com/35157761/186067361-78c6af0a-446b-4c8d-9a4f-9020719073c3.png)

example
![image](https://user-images.githubusercontent.com/35157761/186067331-0518b9c6-bd6c-4253-8c80-b77dc517ff3d.png)
