### PR TITLE
feat(theme): add ability to hide nav per-page

### DIFF
--- a/docs/guide/theme-nav.md
+++ b/docs/guide/theme-nav.md
@@ -132,6 +132,26 @@ export default {
 }
 ```
 
+### Hide navbar
+
+It is possible to hide the navbar globally. This can be achived by setting the `showNav` attribute to false. The navbar will always be shown by default.
+
+```js
+export default {
+  themeConfig: {
+    showNav: false
+  }
+}
+```
+
+There is also the possibility to hide the navbar for specific pages. This can be done by declaring `nav: false` in the frontmatter.
+
+```md
+---
+nav: false
+---
+```
+
 ::: warning
 `activeMatch` is expected to be a regex string, but you must define it as a string. We can't use actual RegExp object here because it isn't serializable during the build time.
 :::

--- a/docs/guide/what-is-vitepress.md
+++ b/docs/guide/what-is-vitepress.md
@@ -1,3 +1,8 @@
+---
+title: Test
+nav: false
+---
+
 # What is VitePress?
 
 VitePress is [VuePress](https://vuepress.vuejs.org/)' little brother, built on top of [Vite](https://vitejs.dev/).

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { useData } from 'vitepress'
 import { useSidebar } from '../composables/sidebar.js'
 import VPNavBarTitle from './VPNavBarTitle.vue'
 import VPNavBarSearch from './VPNavBarSearch.vue'
@@ -18,10 +19,11 @@ defineEmits<{
 }>()
 
 const { hasSidebar } = useSidebar()
+const { theme, page } = useData()
 </script>
 
 <template>
-  <div class="VPNavBar" :class="{ 'has-sidebar' : hasSidebar }">
+  <div v-if="theme.showNav != false && page.nav != false" class="VPNavBar" :class="{ 'has-sidebar' : hasSidebar }">
     <div class="container">
       <VPNavBarTitle>
         <template #nav-bar-title-before><slot name="nav-bar-title-before" /></template>

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -131,6 +131,7 @@ export async function createMarkdownToVueRenderFn(
     const pageData: PageData = {
       title: inferTitle(frontmatter, content),
       titleTemplate: frontmatter.titleTemplate as any,
+      nav: frontmatter.nav as any,
       description: inferDescription(frontmatter),
       frontmatter,
       headers: data.headers || [],

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -25,6 +25,7 @@ export const notFoundPageData: PageData = {
   relativePath: '',
   title: '404',
   description: 'Not Found',
+  nav: true,
   headers: [],
   frontmatter: { sidebar: false, layout: 'page' },
   lastUpdated: 0

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -26,6 +26,11 @@ export namespace DefaultTheme {
     nav?: NavItem[]
 
     /**
+     * Show navbar globally.
+     */
+    showNav?: boolean
+
+    /**
      * The sidebar items.
      */
     sidebar?: Sidebar

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -6,6 +6,7 @@ export interface PageData {
   relativePath: string
   title: string
   titleTemplate?: string | boolean
+  nav: boolean
   description: string
   headers: Header[]
   frontmatter: Record<string, any>


### PR DESCRIPTION
Adds the ability to hide nav globally or per-page as requested in #1227