### PR TITLE
refactor: polyfill punycode

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "polka": "^0.5.2",
     "prettier": "^2.7.1",
     "prompts": "^2.4.2",
+    "punycode": "^2.1.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.78.0",
     "rollup-plugin-dts": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,7 @@ importers:
       polka: ^0.5.2
       prettier: ^2.7.1
       prompts: ^2.4.2
+      punycode: ^2.1.1
       rimraf: ^3.0.2
       rollup: ^2.78.0
       rollup-plugin-dts: ^4.2.2
@@ -153,6 +154,7 @@ importers:
       polka: 0.5.2
       prettier: 2.7.1
       prompts: 2.4.2
+      punycode: 2.1.1
       rimraf: 3.0.2
       rollup: 2.78.0
       rollup-plugin-dts: 4.2.2_nm5mlcuxlwr6samvke7b2fz27i
@@ -3244,6 +3246,11 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+    dev: true
+
+  /punycode/2.1.1:
+    resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
+    engines: {node: '>=6'}
     dev: true
 
   /q/1.5.1:

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs'
+import { builtinModules } from 'module'
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { RollupOptions, defineConfig } from 'rollup'
@@ -17,7 +18,12 @@ const PROD = !DEV
 const ROOT = fileURLToPath(import.meta.url)
 const r = (p: string) => resolve(ROOT, '..', p)
 
-const external = [...Object.keys(pkg.dependencies)]
+const external = [
+  ...Object.keys(pkg.dependencies),
+  ...builtinModules.flatMap((m) =>
+    m.includes('punycode') ? [] : [m, `node:${m}`]
+  )
+]
 
 const plugins = [
   alias({
@@ -32,7 +38,7 @@ const plugins = [
     preventAssignment: true
   }),
   commonjs(),
-  nodeResolve({ preferBuiltins: true }),
+  nodeResolve({ preferBuiltins: false }),
   esbuild({ target: 'node14' }),
   json()
 ]


### PR DESCRIPTION
Background:

punycode was a builtin node module, but it was deprecated since v7, although its still available, it is less likely that other runtimes like deno, etc. are gonna implement it natively. We are not directly using it anywhere, markdown-it is using this module without the userland version in their deps (https://github.com/markdown-it/markdown-it/issues/230).

PS: There is no significant size difference after bundling punycode in vitepress itself.