### PR TITLE
fix: update language regex to avoid user unexpect input

### DIFF
--- a/src/node/markdown/plugins/lineNumbers.ts
+++ b/src/node/markdown/plugins/lineNumbers.ts
@@ -21,7 +21,7 @@ export const lineNumberPlugin = (md: MarkdownIt) => {
 
     const finalCode = rawCode
       .replace(/<\/div>$/, `${lineNumbersWrapperCode}</div>`)
-      .replace(/"(language-[-\w]*)"/, '"$1 line-numbers-mode"')
+      .replace(/class="(.*language-[^"]*)"/, 'class="$1 line-numbers-mode"')
 
     return finalCode
   }


### PR DESCRIPTION
reproduction:

`markdown.lineNumbers` with the following incorrect language `ts c`

```md
\```ts c
const a = 1
\```
```

![image](https://user-images.githubusercontent.com/25995358/188195616-fb582030-1c10-4275-a33c-ea5e95c0be9d.png)
