### PR TITLE
feat(theme): support dynamic headers and nesting in outline

### DIFF
--- a/__tests__/client/theme-default/composables/outline.spec.ts
+++ b/__tests__/client/theme-default/composables/outline.spec.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect } from 'vitest'
+import * as outline from 'client/theme-default/composables/outline'
+
+describe('client/theme-default/composables/outline', () => {
+  describe('resolveHeader', () => {
+    test('levels range', () => {
+      expect(
+        outline.resolveHeaders(
+          [
+            {
+              level: 2,
+              title: 'h2 - 1',
+              link: '#h2-1'
+            },
+            {
+              level: 3,
+              title: 'h3 - 1',
+              link: '#h3-1'
+            }
+          ],
+          [2, 3]
+        )
+      ).toEqual([
+        {
+          level: 2,
+          title: 'h2 - 1',
+          link: '#h2-1',
+          children: [
+            {
+              level: 3,
+              title: 'h3 - 1',
+              link: '#h3-1'
+            }
+          ]
+        }
+      ])
+    })
+
+    test('specific level', () => {
+      expect(
+        outline.resolveHeaders(
+          [
+            {
+              level: 2,
+              title: 'h2 - 1',
+              link: '#h2-1'
+            },
+            {
+              level: 3,
+              title: 'h3 - 1',
+              link: '#h3-1'
+            }
+          ],
+          2
+        )
+      ).toEqual([
+        {
+          level: 2,
+          title: 'h2 - 1',
+          link: '#h2-1'
+        }
+      ])
+    })
+
+    test('complex deep', () => {
+      expect(
+        outline.resolveHeaders(
+          [
+            {
+              level: 2,
+              title: 'h2 - 1',
+              link: '#h2-1'
+            },
+            {
+              level: 3,
+              title: 'h3 - 1',
+              link: '#h3-1'
+            },
+            {
+              level: 4,
+              title: 'h4 - 1',
+              link: '#h4-1'
+            },
+            {
+              level: 3,
+              title: 'h3 - 2',
+              link: '#h3-2'
+            },
+            {
+              level: 4,
+              title: 'h4 - 2',
+              link: '#h4-2'
+            },
+            {
+              level: 2,
+              title: 'h2 - 2',
+              link: '#h2-2'
+            },
+            {
+              level: 3,
+              title: 'h3 - 3',
+              link: '#h3-3'
+            },
+            {
+              level: 4,
+              title: 'h4 - 3',
+              link: '#h4-3'
+            }
+          ],
+          'deep'
+        )
+      ).toEqual([
+        {
+          level: 2,
+          title: 'h2 - 1',
+          link: '#h2-1',
+          children: [
+            {
+              level: 3,
+              title: 'h3 - 1',
+              link: '#h3-1',
+              children: [
+                {
+                  level: 4,
+                  title: 'h4 - 1',
+                  link: '#h4-1'
+                }
+              ]
+            },
+            {
+              level: 3,
+              title: 'h3 - 2',
+              link: '#h3-2',
+              children: [
+                {
+                  level: 4,
+                  title: 'h4 - 2',
+                  link: '#h4-2'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          level: 2,
+          title: 'h2 - 2',
+          link: '#h2-2',
+          children: [
+            {
+              level: 3,
+              title: 'h3 - 3',
+              link: '#h3-3',
+              children: [
+                {
+                  level: 4,
+                  title: 'h4 - 3',
+                  link: '#h4-3'
+                }
+              ]
+            }
+          ]
+        }
+      ])
+    })
+  })
+})

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
   lastUpdated: true,
   cleanUrls: 'without-subfolders',
 
+  markdown: {
+    headers: {
+      level: [0, 0]
+    }
+  },
+
   themeConfig: {
     nav: nav(),
 

--- a/docs/config/frontmatter-configs.md
+++ b/docs/config/frontmatter-configs.md
@@ -212,3 +212,10 @@ If you want the right aside component in `doc` layout not to be shown, set this 
 aside: false
 ---
 ```
+
+## outline
+
+- Type: `number | [number, number] | 'deep' | false`
+- Default: `2`
+
+The levels of header in the outline to display for the page. It's same as [config.themeConfig.outline](../config/theme-configs#outline), and it overrides the theme config.

--- a/docs/config/theme-configs.md
+++ b/docs/config/theme-configs.md
@@ -135,6 +135,13 @@ interface SidebarItem {
 }
 ```
 
+## outline
+
+- Type: `number | [number, number] | 'deep' | false`
+- Default: `2`
+
+The levels of header to display in the outline. You can specify a particular level by passing a number, or you can provide a level range by passing a tuple containing the bottom and upper limits. When passing `'deep'` which equals `[2, 6]`, all header levels are shown in the outline except `h1`. Set `false` to hide outline.
+
 ## outlineTitle
 
 - Type: `string`

--- a/examples/configured/__test__/outline.spec.ts
+++ b/examples/configured/__test__/outline.spec.ts
@@ -18,15 +18,27 @@ describe('outline', () => {
     expect(outlineLinksContent).toEqual([
       'h2 - 1',
       'h3 - 1',
+      'h4 - 1',
       'h3 - 2',
+      'h4 - 2',
       'h2 - 2',
-      'h3 - 3'
+      'h3 - 3',
+      'h4 - 3'
     ])
 
     const linkHrefs = await outlineLinksLocator.evaluateAll((element) =>
       element.map((element) => element.getAttribute('href'))
     )
 
-    expect(linkHrefs).toEqual(['#h2-1', '#h3-1', '#h3-2', '#h2-2', '#h3-3'])
+    expect(linkHrefs).toEqual([
+      '#h2-1',
+      '#h3-1',
+      '#h4-1',
+      '#h3-2',
+      '#h4-2',
+      '#h2-2',
+      '#h3-3',
+      '#h4-3'
+    ])
   })
 })

--- a/src/client/app/components/Content.ts
+++ b/src/client/app/components/Content.ts
@@ -1,10 +1,16 @@
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, onUpdated } from 'vue'
 import { useRoute } from '../router.js'
 
 export const Content = defineComponent({
   name: 'VitePressContent',
-  setup() {
+  props: {
+    onContentUpdated: Function
+  },
+  setup(props) {
     const route = useRoute()
+    onUpdated(() => {
+      props.onContentUpdated?.()
+    })
     return () =>
       h('div', { style: { position: 'relative' } }, [
         route.component ? h(route.component) : null

--- a/src/client/theme-default/components/VPDoc.vue
+++ b/src/client/theme-default/components/VPDoc.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useRoute } from 'vitepress'
+import { computed, provide, ref } from 'vue'
 import { useSidebar } from '../composables/sidebar.js'
 import VPDocAside from './VPDocAside.vue'
 import VPDocFooter from './VPDocFooter.vue'
@@ -11,6 +11,9 @@ const { hasSidebar, hasAside } = useSidebar()
 const pageName = computed(() =>
   route.path.replace(/[./]+/g, '_').replace(/_html$/, '')
 )
+
+const onContentUpdated = ref()
+provide('onContentUpdated', onContentUpdated)
 </script>
 
 <template>
@@ -39,7 +42,7 @@ const pageName = computed(() =>
         <div class="content-container">
           <slot name="doc-before" />
           <main class="main">
-            <Content class="vp-doc" :class="pageName" />
+            <Content class="vp-doc" :class="pageName" :onContentUpdated="onContentUpdated" />
           </main>
           <slot name="doc-footer-before" />
           <VPDocFooter />

--- a/src/client/theme-default/components/VPDocAside.vue
+++ b/src/client/theme-default/components/VPDocAside.vue
@@ -3,7 +3,7 @@ import { useData } from 'vitepress'
 import VPDocAsideOutline from './VPDocAsideOutline.vue'
 import VPDocAsideCarbonAds from './VPDocAsideCarbonAds.vue'
 
-const { page, theme } = useData()
+const { theme } = useData()
 </script>
 
 <template>
@@ -11,7 +11,7 @@ const { page, theme } = useData()
     <slot name="aside-top" />
 
     <slot name="aside-outline-before" />
-    <VPDocAsideOutline v-if="page.headers.length" />
+    <VPDocAsideOutline />
     <slot name="aside-outline-after" />
 
     <div class="spacer" />

--- a/src/client/theme-default/components/VPDocAsideOutlineItem.vue
+++ b/src/client/theme-default/components/VPDocAsideOutlineItem.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import type { MenuItem } from '../composables/outline.js'
+
+defineProps<{
+  headers: MenuItem[]
+  onClick: (e: MouseEvent) => void
+  root?: boolean
+}>()
+</script>
+
+<template>
+  <ul :class="root ? 'root' : 'nested'">
+    <li v-for="{ children, link, title } in headers">
+      <a class="outline-link" :href="link" @click="onClick">{{ title }}</a>
+      <template v-if="children?.length">
+        <VPDocAsideOutlineItem :headers="children" :onClick="onClick" />
+      </template>
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+.root {
+  position: relative;
+  z-index: 1;
+}
+
+.nested {
+  padding-left: 13px;
+}
+
+.outline-link {
+  display: block;
+  line-height: 28px;
+  color: var(--vp-c-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color 0.5s;
+}
+
+.outline-link:hover,
+.outline-link.active {
+  color: var(--vp-c-text-1);
+  transition: color 0.25s;
+}
+
+.outline-link.nested {
+  padding-left: 13px;
+}
+</style>

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -14,6 +14,13 @@ export namespace DefaultTheme {
     siteTitle?: string | false
 
     /**
+     * Custom header levels of outline in the aside component.
+     *
+     * @default 2
+     */
+    outline?: number | [number, number] | 'deep' | false
+
+    /**
      * Custom outline title in the aside component.
      *
      * @default 'On this page'


### PR DESCRIPTION
Most of the nesting-related stuff is copied as is from #965. (Huge thanks to @fi3ework!)

fixes #785, fixes #954, closes #965

---

⚠️  For those who are using/extending the default theme: 

This PR changes meaning of `outline: deep` -- earlier it meant `[2, 3]`, now it means `[2, 6]`. (Some projects are using it although it was never documented.)