### PR TITLE
fix(build): line numbers mode when language specifier has symbol

### DIFF
--- a/src/node/markdown/plugins/lineNumbers.ts
+++ b/src/node/markdown/plugins/lineNumbers.ts
@@ -21,7 +21,7 @@ export const lineNumberPlugin = (md: MarkdownIt) => {
 
     const finalCode = rawCode
       .replace(/<\/div>$/, `${lineNumbersWrapperCode}</div>`)
-      .replace(/"(language-.*)"/, '"$1 line-numbers-mode"')
+      .replace(/"(language-\S*?)"/, '"$1 line-numbers-mode"')
 
     return finalCode
   }

--- a/src/node/markdown/plugins/lineNumbers.ts
+++ b/src/node/markdown/plugins/lineNumbers.ts
@@ -21,7 +21,7 @@ export const lineNumberPlugin = (md: MarkdownIt) => {
 
     const finalCode = rawCode
       .replace(/<\/div>$/, `${lineNumbersWrapperCode}</div>`)
-      .replace(/"(language-[-\w]*)"/, '"$1 line-numbers-mode"')
+      .replace(/"(language-.*)"/, '"$1 line-numbers-mode"')
 
     return finalCode
   }


### PR DESCRIPTION
fix #1352 

Code block's `language-` class should  compatible with special char, such as '-', '+', '#'...

After PR:

```
"language-" => "language- line-numbers-mode"
"language-js" => "language-js line-numbers-mode"
"language-c#" => "language-c# line-numbers-mode"
"language-c++" => "language-c++ line-numbers-mode"
"language-Objective-C" => "language-Objective-C line-numbers-mode"
```