### PR TITLE
feat: add vue to `resolve.dedupe`

### DIFF
--- a/src/node/build/buildMPAClient.ts
+++ b/src/node/build/buildMPAClient.ts
@@ -41,6 +41,9 @@ export async function buildMPAClient(
           }
         }
       }
-    ]
+    ],
+    resolve: {
+      dedupe: ['vue']
+    }
   }) as Promise<RollupOutput>
 }

--- a/src/node/build/bundle.ts
+++ b/src/node/build/bundle.ts
@@ -48,6 +48,9 @@ export async function bundle(
       pageToHashMap,
       clientJSMap
     ),
+    resolve: {
+      dedupe: ['vue']
+    },
     ssr: {
       noExternal: ['vitepress', '@docsearch/css']
     },

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -22,6 +22,9 @@ export async function createServer(
     base: config.site.base,
     // logLevel: 'warn',
     plugins: await createVitePressPlugin(config, false, {}, {}, recreateServer),
-    server: serverOptions
+    server: serverOptions,
+    resolve: {
+      dedupe: ['vue']
+    }
   })
 }


### PR DESCRIPTION
Developers who wants to extend the theme may use libraries depending on different versions of vue, causing client errors. Adding vue to `resolve.dedupe` can avoid such conditions.