### PR TITLE
Adding `<meta  name="theme-color"/>` 🎨

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   lastUpdated: true,
   cleanUrls: 'without-subfolders',
 
+  head: [
+    ['meta', { name: 'theme-color', content: '#3c8772' }]
+  ],
+
   markdown: {
     headers: {
       level: [0, 0]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
   lastUpdated: true,
   cleanUrls: 'without-subfolders',
 
-  head: [
-    ['meta', { name: 'theme-color', content: '#3c8772' }]
-  ],
+  head: [['meta', { name: 'theme-color', content: '#3c8772' }]],
 
   markdown: {
     headers: {


### PR DESCRIPTION
Ref-: https://github.com/vuejs/docs/pull/1870

I choosed `#3c8772` as a theme-color hence it looks nice in dark mode and white mode too, and that colour in presents in VitePress logo too.