### PR TITLE
feat(theme): customize default page layout

### DIFF
--- a/src/client/theme-default/components/VPContent.vue
+++ b/src/client/theme-default/components/VPContent.vue
@@ -7,7 +7,7 @@ import VPDoc from './VPDoc.vue'
 import { inject } from 'vue'
 
 const route = useRoute()
-const { frontmatter } = useData()
+const { frontmatter, theme } = useData()
 const { hasSidebar } = useSidebar()
 
 const NotFound = inject('NotFound')
@@ -33,7 +33,7 @@ const NotFound = inject('NotFound')
       <template #home-features-after><slot name="home-features-after" /></template>
     </VPHome>
 
-    <VPDoc v-else>
+	<component v-else :is="theme.pageLayout || VPDoc">
       <template #doc-footer-before><slot name="doc-footer-before" /></template>
       <template #doc-before><slot name="doc-before" /></template>
       <template #doc-after><slot name="doc-after" /></template>
@@ -44,7 +44,8 @@ const NotFound = inject('NotFound')
       <template #aside-ads-before><slot name="aside-ads-before" /></template>
       <template #aside-ads-after><slot name="aside-ads-after" /></template>
       <template #aside-bottom><slot name="aside-bottom" /></template>
-    </VPDoc>
+    </component>
+
   </div>
 </template>
 

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -38,6 +38,12 @@ export namespace DefaultTheme {
     sidebar?: Sidebar
 
     /**
+     * Default page layout component name in place of doc,
+     * which must be registered using enhanceApp
+     */
+    pageLayout?: string
+    /**
+
      * Info for the edit link. If it's undefined, the edit link feature will
      * be disabled.
      */


### PR DESCRIPTION
The default value of layout in the frontmatter is VPDoc, which can be changed now in themeConfig.

Solution for #1376