### PR TITLE
fix(theme): prevent body scrolling when sidebar has opened on small screens

### DIFF
--- a/src/client/theme-default/components/VPSidebar.vue
+++ b/src/client/theme-default/components/VPSidebar.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, watchPostEffect, nextTick } from 'vue'
+import { ref, watchPostEffect, nextTick, watch } from 'vue'
 import { useSidebar } from '../composables/sidebar.js'
 import VPSidebarGroup from './VPSidebarGroup.vue'
 
@@ -8,6 +8,11 @@ const { sidebar, hasSidebar } = useSidebar()
 const props = defineProps<{
   open: boolean
 }>()
+
+// prevent body scrolling when sidebar has opened
+watch(() => props.open, (newVal) => {
+  document.body.style.overflow = newVal ? 'hidden' : ''
+})
 
 // a11y: focus Nav element when menu has opened
 let navEl = ref<(Element & { focus(): void }) | null>(null)


### PR DESCRIPTION
before:

![before](https://user-images.githubusercontent.com/24277775/192077164-022e7f9f-1b8d-4a5c-864c-27a7528062df.gif)

after:

![after](https://user-images.githubusercontent.com/24277775/192077338-56263ca8-a4d4-45b3-b2fe-dfd576615148.gif)
