### PR TITLE
fix(theme): a gap appear when DocSearch is clicked in macOS

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -257,7 +257,7 @@ function load() {
 
 .DocSearch-Button .DocSearch-Button-Key:first-child {
   font-size: 1px;
-  letter-spacing: -1px;
+  letter-spacing: -12px;
   color: transparent;
 }
 


### PR DESCRIPTION
A gap appear when DocSearch is clicked in macOS.

![image](https://user-images.githubusercontent.com/44596995/192126719-e601d567-7dc4-4cc9-982c-96236185c46c.png)
