### PR TITLE
fix(theme): break long words on overflow

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -213,3 +213,13 @@ fieldset {
   margin: 0;
   padding: 0;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
fixes #782, fixes #1064

li/td/th aren't needed because markdown lists have structure like `<li><p>...</p></li>` and p is already selected; and table resizes based on the content, so there won't be any overflow.