### PR TITLE
fix(theme): click outline title to carbonAds fail

### DIFF
--- a/docs/config/theme-configs.md
+++ b/docs/config/theme-configs.md
@@ -262,7 +262,7 @@ export default {
 }
 ```
 
-## carbonAds
+## carbon Ads
 
 - Type: `CarbonAds`
 

--- a/docs/config/theme-configs.md
+++ b/docs/config/theme-configs.md
@@ -262,7 +262,7 @@ export default {
 }
 ```
 
-## carbon Ads
+## carbonAds {#carbon-ads}
 
 - Type: `CarbonAds`
 


### PR DESCRIPTION
Duplicate id 【carbonAds】，add space will change the id to 【carbon-ads】,no conflict

![image](https://user-images.githubusercontent.com/35157761/193198998-0400f676-8780-49c3-8a80-cfc07443e4d3.png)

![image](https://user-images.githubusercontent.com/35157761/193199022-5f3db847-3735-416a-bdd0-91b541347801.png)

