### PR TITLE
Added missing comma

### DIFF
--- a/docs/guide/theme-introduction.md
+++ b/docs/guide/theme-introduction.md
@@ -65,7 +65,7 @@ export default {
     // app is the Vue 3 app instance from `createApp()`.
     // router is VitePress' custom router. `siteData` is
     // a `ref` of current site-level metadata.
-  }
+  },
 
   setup() {
     // this function will be executed inside VitePressApp's


### PR DESCRIPTION
The theme entry file example had a missing comma(in line `15`) that generated an error when copy-pasting. Added the comma.