### PR TITLE
fix(a11y): add title to copy code button

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -90,13 +90,7 @@ export const createMarkdownRenderer = async (
   // mdit-vue plugins
   md.use(anchorPlugin, {
     slugify,
-    permalink: anchorPlugin.permalink.ariaHidden({
-      renderAttrs() {
-        return {
-          tabindex: '-1'
-        }
-      }
-    }),
+    permalink: anchorPlugin.permalink.ariaHidden({}),
     ...options.anchor
   } as anchorPlugin.AnchorOptions)
     .use(frontmatterPlugin, {

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -90,7 +90,13 @@ export const createMarkdownRenderer = async (
   // mdit-vue plugins
   md.use(anchorPlugin, {
     slugify,
-    permalink: anchorPlugin.permalink.ariaHidden({}),
+    permalink: anchorPlugin.permalink.ariaHidden({
+      renderAttrs() {
+        return {
+          tabindex: '-1'
+        }
+      }
+    }),
     ...options.anchor
   } as anchorPlugin.AnchorOptions)
     .use(frontmatterPlugin, {

--- a/src/node/markdown/plugins/preWrapper.ts
+++ b/src/node/markdown/plugins/preWrapper.ts
@@ -15,7 +15,7 @@ export const preWrapperPlugin = (md: MarkdownIt) => {
     const [tokens, idx] = args
     const lang = tokens[idx].info.trim().replace(/-vue$/, '')
     const rawCode = fence(...args)
-    return `<div class="language-${lang}"><button class="copy"></button><span class="lang">${
+    return `<div class="language-${lang}"><button title="copy code" class="copy"></button><span class="lang">${
       lang === 'vue-html' ? 'template' : lang
     }</span>${rawCode}</div>`
   }

--- a/src/node/markdown/plugins/preWrapper.ts
+++ b/src/node/markdown/plugins/preWrapper.ts
@@ -15,7 +15,7 @@ export const preWrapperPlugin = (md: MarkdownIt) => {
     const [tokens, idx] = args
     const lang = tokens[idx].info.trim().replace(/-vue$/, '')
     const rawCode = fence(...args)
-    return `<div class="language-${lang}"><button title="copy code" class="copy"></button><span class="lang">${
+    return `<div class="language-${lang}"><button title="Copy Code" class="copy"></button><span class="lang">${
       lang === 'vue-html' ? 'template' : lang
     }</span>${rawCode}</div>`
   }


### PR DESCRIPTION
Lighthouse is complaining about a11y isssues:

![vp-copy-content-btn](https://user-images.githubusercontent.com/6311119/194081610-ca654dbf-b99e-4ea1-996e-ad891f6cc7ef.png)

![vp-permalink-anchor](https://user-images.githubusercontent.com/6311119/194081622-da080bae-1877-4a53-b715-8a07de6bc6e3.png)

![imagen](https://user-images.githubusercontent.com/6311119/194081887-315fa416-a374-483a-b5df-20deca016564.png)

With this PR:

![vp-a11y-result](https://user-images.githubusercontent.com/6311119/194081654-272f152a-7978-4117-92eb-d68ec048774b.png)
