### PR TITLE
chore(theme): remove useless style

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -116,7 +116,6 @@ iframe,
 embed,
 object {
   display: block;
-  vertical-align: middle;
 }
 
 figure {


### PR DESCRIPTION
> `vertical-align` only applies to inline, inline-block and table-cell elements. [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)