### PR TITLE
modify: 防止在shiki不支持的语言中报错，进行静默处理

### DIFF
--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -1,6 +1,13 @@
-import { IThemeRegistration, getHighlighter, HtmlRendererOptions } from 'shiki'
+import { IThemeRegistration, getHighlighter, HtmlRendererOptions, BUNDLED_LANGUAGES } from 'shiki'
 import type { ThemeOptions } from '../markdown'
 
+const SHIKI_LANGUAGES: string[] = []
+BUNDLED_LANGUAGES.forEach(item => {
+  if(item.aliases) {
+    SHIKI_LANGUAGES.push(...item.aliases)
+  }
+  SHIKI_LANGUAGES.push(item.id)
+})
 /**
  * 2 steps:
  *
@@ -48,6 +55,10 @@ export async function highlight(
   return (str: string, lang: string, attrs: string) => {
     const vPre = vueRE.test(lang) ? '' : 'v-pre'
     lang = lang.replace(vueRE, '').toLowerCase()
+
+    if(lang && !SHIKI_LANGUAGES.includes(lang)) {
+      lang = ''
+    }
 
     const lineOptions = attrsToLines(attrs)
 


### PR DESCRIPTION
vitepress 在不支持的语言中，会报错，比如：

**/etc/hosts**
```hosts
127.0.0.1       www.nodejs.red
```
则会报错，原因是wiki 中不支持这种语言。如果作为开发当然可以选择报错给用户，但是作为使用者，是不希望看到这个错误的。所以此时可以选择不处理这种高亮的代码。亦可以增加配置，添加语言高亮别名，按照其他的模式进行高亮。