### PR TITLE
fix(theme): fix locale links ignoring base option

### DIFF
--- a/src/client/theme-default/components/VPNavScreenTranslations.vue
+++ b/src/client/theme-default/components/VPNavScreenTranslations.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useData } from 'vitepress'
+import { useData, withBase } from 'vitepress'
 import VPIconChevronDown from './icons/VPIconChevronDown.vue'
 import VPIconLanguages from './icons/VPIconLanguages.vue'
 
@@ -23,7 +23,7 @@ function toggle() {
 
     <ul class="list">
       <li v-for="locale in theme.localeLinks.items" :key="locale.link" class="item">
-        <a class="link" :href="locale.link">{{ locale.text }}</a>
+        <a class="link" :href="locale.link ? withBase(locale.link) : undefined">{{ locale.text }}</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Fix locale links under the "Languages" section on navigation bar not working properly on mobile devices when both `base` and `themeConfig.localeLinks` options are set by passing them to `withBase()` function first.