### PR TITLE
feat(docs): improve footer configuration documentation 

### DIFF
--- a/docs/guide/theme-footer.md
+++ b/docs/guide/theme-footer.md
@@ -23,4 +23,19 @@ export interface Footer {
 }
 ```
 
+The above configuration also supports strings of DOM structure. if we want to configure footer text to jump to other links a website, we can adjust the configuration as follows:
+
+```ts
+export default {
+  themeConfig: {
+    footer: {
+      message:
+        '<a href="https://github.com/vuejs/vitepress">Released under the MIT License.</a>',
+      copyright:
+        '<a href="https://github.com/yyx990803">Copyright © 2019-present Evan You</a>'
+    }
+  }
+}
+```
+
 Note that footer will not be displayed when the [SideBar](./theme-sidebar) is visible.

--- a/docs/guide/theme-footer.md
+++ b/docs/guide/theme-footer.md
@@ -23,16 +23,14 @@ export interface Footer {
 }
 ```
 
-The above configuration also supports strings of DOM structure. if we want to configure footer text to jump to other links a website, we can adjust the configuration as follows:
+The above configuration also supports HTML strings. So, for example, if you want to configure footer text to have some links, you can adjust the configuration as follows:
 
 ```ts
 export default {
   themeConfig: {
     footer: {
-      message:
-        '<a href="https://github.com/vuejs/vitepress">Released under the MIT License.</a>',
-      copyright:
-        '<a href="https://github.com/yyx990803">Copyright © 2019-present Evan You</a>'
+      message: 'Released under the <a href="https://github.com/vuejs/vitepress/blob/main/LICENSE">MIT License</a>.',
+      copyright: 'Copyright © 2019-present <a href="https://github.com/yyx990803">Evan You</a>'
     }
   }
 }


### PR DESCRIPTION
# About PR

> Thanks for checking
Sometimes we want able to jump other website by click footer copyright or message,  especially in China, the Ministry of Industry and Information Technology requires that the footer's information must be able to jump to the homepage of the Ministry of Industry and Information Technology. so this configuration is still necessary!

In fact, the rendering method of footer is now through v-html, which we can easily complete it! Unfortunately, the documentation does not describe this. so I made a simple explanation in the documentation.

> Please forgive me if my updated docs description is not in place

## The new content is as follows
The above configuration also supports strings of DOM structure. if we want to configure footer text to jump to other links a website, we can adjust the configuration as follows:

```ts
export default {
  themeConfig: {
    footer: {
      message:
        '<a href="https://github.com/vuejs/vitepress">Released under the MIT License.</a>',
      copyright:
        '<a href="https://github.com/yyx990803">Copyright © 2019-present Evan You</a>'
    }
  }
}
```