### PR TITLE
feat: support html strings for SidebarGroup headings, SidebarItem text

### DIFF
--- a/src/client/theme-default/components/VPSidebarGroup.vue
+++ b/src/client/theme-default/components/VPSidebarGroup.vue
@@ -41,7 +41,7 @@ function toggle() {
       :role="collapsible ? 'button' : undefined"
       @click="toggle"
     >
-      <h2 class="title-text">{{ text }}</h2>
+      <h2 v-html="text" class="title-text"></h2>
       <div class="action">
         <VPIconMinusSquare class="icon minus" />
         <VPIconPlusSquare class="icon plus" />

--- a/src/client/theme-default/components/VPSidebarLink.vue
+++ b/src/client/theme-default/components/VPSidebarLink.vue
@@ -25,7 +25,7 @@ const closeSideBar = inject('close-sidebar') as () => void
     :href="item.link"
     @click="closeSideBar"
   >
-    <span class="link-text" :class="{ light: depth > 1 }">{{ item.text }}</span>
+    <span v-html="item.text" class="link-text" :class="{ light: depth > 1 }"></span>
   </VPLink>
   <template
     v-if="'items' in item && depth < maxDepth"


### PR DESCRIPTION
closes #1486 

migrates text interpolation to [`v-html`](https://vuejs.org/guide/essentials/template-syntax.html#raw-html) to support providing raw HTML strings to `SidebarGroup` headings and `SidebarItem` text