### PR TITLE
feat: transformPageData hook

### DIFF
--- a/docs/config/app-configs.md
+++ b/docs/config/app-configs.md
@@ -314,6 +314,28 @@ export default {
 }
 ```
 
+### transformPageData
+
+- Type: `(pageData: PageData) => Awaitable<Partial<PageData> | void>`
+
+`transformPageData` is a hook to transform the pageData of each page. You can directly mutate `pageData` or return changed values which will be merged into PageData.
+
+
+```ts
+export default {
+  async transformPageData(pageData) {
+    pageData.contributors = await getPageContributors(pageData.relativePath)
+  }
+
+  // or return data to be merged
+  async transformPageData(pageData) {
+    return {
+      contributors: await getPageContributors(pageData.relativePath)
+    }
+  }
+}
+```
+
 ### buildEnd
 
 - Type: `(siteConfig: SiteConfig) => Awaitable<void>`

--- a/docs/config/app-configs.md
+++ b/docs/config/app-configs.md
@@ -316,9 +316,9 @@ export default {
 
 ### transformPageData
 
-- Type: `(pageData: PageData) => Awaitable<Partial<PageData> | void>`
+- Type: `(pageData: PageData) => Awaitable<Partial<PageData> | { [key: string]: any } | void>`
 
-`transformPageData` is a hook to transform the pageData of each page. You can directly mutate `pageData` or return changed values which will be merged into PageData.
+`transformPageData` is a hook to transform the `pageData` of each page. You can directly mutate `pageData` or return changed values which will be merged into PageData.
 
 
 ```ts

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -114,7 +114,7 @@ export interface UserConfig<ThemeConfig = any> {
    */
   transformPageData?: (
     pageData: PageData
-  ) => Awaitable<Partial<PageData> | void>
+  ) => Awaitable<Partial<PageData> | { [key: string]: any } | void>
 }
 
 export interface TransformContext {
@@ -232,7 +232,8 @@ export async function resolveConfig(
     cleanUrls: userConfig.cleanUrls || 'disabled',
     buildEnd: userConfig.buildEnd,
     transformHead: userConfig.transformHead,
-    transformHtml: userConfig.transformHtml
+    transformHtml: userConfig.transformHtml,
+    transformPageData: userConfig.transformPageData
   }
 
   return config

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -112,7 +112,9 @@ export interface UserConfig<ThemeConfig = any> {
   /**
    * PageData transform hook: runs when rendering markdown to vue
    */
-  transformPageData?: (pageData: PageData) => Awaitable<PageData | void>
+  transformPageData?: (
+    pageData: PageData
+  ) => Awaitable<Partial<PageData> | void>
 }
 
 export interface TransformContext {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -108,6 +108,11 @@ export interface UserConfig<ThemeConfig = any> {
     id: string,
     ctx: TransformContext
   ) => Awaitable<string | void>
+
+  /**
+   * PageData transform hook: runs when rendering markdown to vue
+   */
+  transformPageData?: (pageData: PageData) => Awaitable<PageData | void>
 }
 
 export interface TransformContext {
@@ -138,6 +143,7 @@ export interface SiteConfig<ThemeConfig = any>
     | 'buildEnd'
     | 'transformHead'
     | 'transformHtml'
+    | 'transformPageData'
   > {
   root: string
   srcDir: string

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -147,9 +147,12 @@ export async function createMarkdownToVueRenderFn(
     }
 
     if (siteConfig?.transformPageData) {
-      pageData = {
-        ...pageData,
-        ...((await siteConfig.transformPageData(pageData)) ?? {})
+      const dataToMerge = await siteConfig.transformPageData(pageData)
+      if (dataToMerge) {
+        pageData = {
+          ...pageData,
+          ...dataToMerge
+        }
       }
     }
 

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import c from 'picocolors'
 import LRUCache from 'lru-cache'
 import { resolveTitleFromToken } from '@mdit-vue/shared'
+import { SiteConfig } from './config'
 import { PageData, HeadConfig, EXTERNAL_URL_RE, CleanUrlsMode } from './shared'
 import { slash } from './utils/slash'
 import { getGitTimestamp } from './utils/getGitTimestamp'
@@ -13,7 +14,6 @@ import {
   type MarkdownRenderer
 } from './markdown'
 import _debug from 'debug'
-import { SiteConfig } from 'config'
 
 const debug = _debug('vitepress:md')
 const cache = new LRUCache<string, MarkdownCompileResult>({ max: 1024 })

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -147,9 +147,9 @@ export async function createMarkdownToVueRenderFn(
     }
 
     if (siteConfig?.transformPageData) {
-      const updatedPageData = await siteConfig.transformPageData(pageData)
-      if (updatedPageData) {
-        pageData = updatedPageData
+      pageData = {
+        ...pageData,
+        ...((await siteConfig.transformPageData(pageData)) ?? {})
       }
     }
 

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -95,7 +95,8 @@ export async function createVitePressPlugin(
         config.command === 'build',
         config.base,
         lastUpdated,
-        cleanUrls
+        cleanUrls,
+        siteConfig
       )
     },
 


### PR DESCRIPTION
This allows injecting custom data into PageData.

This could be used to implement lastUpdated in a more dynamic way as well.

Primary motivation behind this change is to be able to inject data during build, in our case I want to be able to inject a list of contributors to a given page - this requires some async calls to be made & injected into the PageData to be accessible site-wide for any given page.

I've tried implementing the above without this change, and while I was able to do most of it, I was limited to the scope of the `<Content>` component, and wasn't able to display this new data in the sidebar for example.