### PR TITLE
chore: update netlify configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,6 @@
 [build.environment]
   NODE_VERSION = "16"
-  NPM_FLAGS = "--version" # prevent Netlify npm install
 
 [build]
   publish = "docs/.vitepress/dist"
-  command = "npx pnpm i --store=node_modules/.pnpm-store && npm run ci-docs"
+  command = "pnpm ci-docs"


### PR DESCRIPTION
The pnpm hack should no longer be required (https://github.com/netlify/build-image/pull/845), but waiting as it might not have rolled out to everyone yet.