### PR TITLE
fix(build): explicitly exit process after build to prevent hangup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pnpm-global
 TODOs.md
 .temp
 *.tgz
+examples-temp

--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -105,7 +105,6 @@ export async function build(
   await siteConfig.buildEnd?.(siteConfig)
 
   console.log(`build complete in ${((Date.now() - start) / 1000).toFixed(2)}s.`)
-  process.exit()
 }
 
 function linkVue() {

--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -105,6 +105,7 @@ export async function build(
   await siteConfig.buildEnd?.(siteConfig)
 
   console.log(`build complete in ${((Date.now() - start) / 1000).toFixed(2)}s.`)
+  process.exit(0);
 }
 
 function linkVue() {

--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -105,7 +105,7 @@ export async function build(
   await siteConfig.buildEnd?.(siteConfig)
 
   console.log(`build complete in ${((Date.now() - start) / 1000).toFixed(2)}s.`)
-  process.exit(0);
+  process.exit(0)
 }
 
 function linkVue() {

--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -105,7 +105,7 @@ export async function build(
   await siteConfig.buildEnd?.(siteConfig)
 
   console.log(`build complete in ${((Date.now() - start) / 1000).toFixed(2)}s.`)
-  process.exit(0)
+  process.exit()
 }
 
 function linkVue() {

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -28,10 +28,14 @@ if (!command || command === 'dev') {
     process.exit(1)
   })
 } else if (command === 'build') {
-  build(root, argv).catch((err) => {
-    console.error(c.red(`build error:\n`), err)
-    process.exit(1)
-  })
+  build(root, argv)
+    .then(() => {
+      process.exit()
+    })
+    .catch((err) => {
+      console.error(c.red(`build error:\n`), err)
+      process.exit(1)
+    })
 } else if (command === 'serve') {
   serve(argv).catch((err) => {
     console.error(c.red(`failed to start server. error:\n`), err)


### PR DESCRIPTION
When I used automated building, I found that vitepress did not quit the task at the end of the construction, causing the subsequent process