### PR TITLE
feat: support focus and colored diffs

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -71,11 +71,11 @@ For more details, see [Frontmatter](./frontmatter).
 **Input**
 
 ```
-| Tables        | Are           | Cool  |
-| ------------- |:-------------:| -----:|
+| Tables        |      Are      |  Cool |
+| ------------- | :-----------: | ----: |
 | col 3 is      | right-aligned | $1600 |
-| col 2 is      | centered      |   $12 |
-| zebra stripes | are neat      |    $1 |
+| col 2 is      |   centered    |   $12 |
+| zebra stripes |   are neat    |    $1 |
 ```
 
 **Output**
@@ -346,6 +346,98 @@ export default { // Highlighted
       but this and the next 2 are.`,
       motd: 'VitePress is awesome',
       lorem: 'ipsum',
+    }
+  }
+}
+```
+
+Alternatively, it's possible to highlight directly in the line by using the `// [!code hl]` comment.
+
+**Input**
+
+````
+```js
+export default {
+  data () {
+    return {
+      msg: 'Highlighted!' // [!codeㅤ hl]
+    }
+  }
+}
+```
+````
+
+**Output**
+
+```js
+export default {
+  data () {
+    return {
+      msg: 'Highlighted!' // [!code hl]
+    }
+  }
+}
+```
+
+## Focus in Code Blocks
+
+Adding the `// [!code focus]` comment on a line will focus it and blur the other parts of the code. 
+
+Additionally, you can define a number of lines to focus using `// [!code focus:<lines>]`.
+
+**Input**
+
+````
+```js
+export default {
+  data () {
+    return {
+      msg: 'Focused!' // [!codeㅤ focus]
+    }
+  }
+}
+```
+````
+
+**Output**
+
+```js
+export default {
+  data () {
+    return {
+      msg: 'Focused!' // [!code focus]
+    }
+  }
+}
+```
+
+## Colored diffs in Code Blocks
+
+Adding the `// [!code --]` or `// [!code ++]` comments on a line will create a diff of that line, while keeping the colors of the codeblock. 
+
+**Input**
+
+````
+```js
+export default {
+  data () {
+    return {
+      msg: 'Removed' // [!codeㅤ --]
+      msg: 'Added' // [!codeㅤ ++]
+    }
+  }
+}
+```
+````
+
+**Output**
+
+```js
+export default {
+  data () {
+    return {
+      msg: 'Removed' // [!code --]
+      msg: 'Added' // [!code ++]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@vueuse/core": "^9.3.0",
     "body-scroll-lock": "4.0.0-beta.0",
     "shiki": "^0.11.1",
+    "shiki-processor": "^0.1.0",
     "vite": "^3.1.6",
     "vue": "^3.2.40"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,7 @@ importers:
       rollup-plugin-esbuild: ^4.10.1
       semver: ^7.3.8
       shiki: ^0.11.1
+      shiki-processor: ^0.1.0
       simple-git-hooks: ^2.8.0
       sirv: ^2.0.2
       supports-color: ^9.2.3
@@ -92,6 +93,7 @@ importers:
       '@vueuse/core': 9.3.0_vue@3.2.40
       body-scroll-lock: 4.0.0-beta.0
       shiki: 0.11.1
+      shiki-processor: 0.1.0_shiki@0.11.1
       vite: 3.1.6
       vue: 3.2.40
     devDependencies:
@@ -3440,6 +3442,14 @@ packages:
   /shell-quote/1.7.3:
     resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
     dev: true
+
+  /shiki-processor/0.1.0_shiki@0.11.1:
+    resolution: {integrity: sha512-7ty3VouP7AQMlERKeiobVeyhjUW6rPMM1b+xFcFF/XwhkN4//Fg9Ju6hPfIOvO4ztylkbLqYufbJmLJmw7SfQA==}
+    peerDependencies:
+      shiki: ^0.11.1
+    dependencies:
+      shiki: 0.11.1
+    dev: false
 
   /shiki/0.11.1:
     resolution: {integrity: sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==}

--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -329,6 +329,54 @@
   display: inline-block;
 }
 
+.vp-doc [class*='language-'] code .diff {
+  transition: background-color 0.5s;
+  margin: 0 -24px;
+  padding: 0 24px;
+  width: calc(100% + 2 * 24px);
+  display: inline-block;
+}
+
+.vp-doc [class*='language-'] code .diff::before {
+  position: absolute;
+  left: 1rem;
+}
+
+.vp-doc [class*='language-'] .has-focused-lines .line:not(.has-focus) {
+  filter: blur(0.095rem);
+  opacity: 0.4;
+  transition: filter 0.35s, opacity 0.35s;
+}
+
+.vp-doc [class*='language-'] .has-focused-lines .line:not(.has-focus) {
+  opacity: 0.7;
+  transition: filter 0.35s, opacity 0.35s;
+}
+
+.vp-doc [class*='language-']:hover .has-focused-lines .line:not(.has-focus) {
+  filter: blur(0);
+  opacity: 1;
+}
+
+.vp-doc [class*='language-'] code .diff.remove {
+  background-color: var(--vp-code-line-diff-remove-color);
+  opacity: 0.7;
+}
+
+.vp-doc [class*='language-'] code .diff.remove::before {
+  content: '-';
+  color: var(--vp-code-line-diff-remove-symbol-color);
+}
+
+.vp-doc [class*='language-'] code .diff.add {
+  background-color: var(--vp-code-line-diff-add-color);
+}
+
+.vp-doc [class*='language-'] code .diff.add::before {
+  content: '+';
+  color: var(--vp-code-line-diff-add-symbol-color);
+}
+
 .vp-doc div[class*='language-'].line-numbers-mode {
   padding-left: 32px;
 }

--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -209,6 +209,17 @@
   --vp-code-line-highlight-color: rgba(0, 0, 0, 0.5);
   --vp-code-line-number-color: var(--vp-c-text-dark-3);
 
+  --vp-code-line-diff-add: 125, 191, 123;
+  --vp-code-line-diff-add-color: rgba(var(--vp-code-line-diff-add), 0.1);
+  --vp-code-line-diff-add-symbol-color: rgba(var(--vp-code-line-diff-add), 0.5);
+
+  --vp-code-line-diff-remove: 255, 128, 128;
+  --vp-code-line-diff-remove-color: rgba(var(--vp-code-line-diff-remove), 0.05);
+  --vp-code-line-diff-remove-symbol-color: rgba(
+    var(--vp-code-line-diff-remove),
+    0.5
+  );
+
   --vp-code-copy-code-hover-bg: rgba(255, 255, 255, 0.05);
   --vp-code-copy-code-active-text: var(--vp-c-text-dark-2);
 }


### PR DESCRIPTION
Fixes https://github.com/vuejs/vitepress/issues/830

This pull request adds support for colored diffs and focused lines in code blocks. This is done thanks to `shiki-processor`, which makes possible to add custom processors that act on a code snippet.

Specifically, the `focus`, `diff` and `highlight` processors are added. They work by adding a `// [!code <tag>]` comment inline, similar to [Torchlight](https://torchlight.dev/).

In a follow-up PR or in this one if you agree, it would be nice to add support for userland to provide processors as well.

Here is a preview of the line focusing:

https://user-images.githubusercontent.com/16060559/197787080-7a99f5ba-dcee-4785-94c2-107697bcf38b.mp4

And here is what the colored line diffing looks like:

![CleanShot 2022-10-25 at 15 33 06](https://user-images.githubusercontent.com/16060559/197787247-411ec39f-0e3b-47d3-ad7f-7ad065e37fba.png)

