### PR TITLE
fix: remove shell code copy trailing newline

### DIFF
--- a/src/client/app/composables/copyCode.ts
+++ b/src/client/app/composables/copyCode.ts
@@ -20,7 +20,7 @@ export function useCopyCode() {
         let { innerText: text = '' } = sibling
 
         if (isShell) {
-          text = text.replace(/^ *(\$|>) /gm, '')
+          text = text.replace(/^ *(\$|>) /gm, '').trim()
         }
 
         copyToClipboard(text).then(() => {


### PR DESCRIPTION
link #1559 

Shell code copy should be remove trailing newline.
In SHELL env (like bash) or some termianl apps, there is a trailing newline in our copy, the command will to be executed directly after paste, which is dangerous.