### PR TITLE
fix(theme): avoid layout shift caused by scrollbar

### DIFF
--- a/src/client/theme-default/components/VPContent.vue
+++ b/src/client/theme-default/components/VPContent.vue
@@ -19,7 +19,6 @@ const NotFound = inject('NotFound')
     id="VPContent"
     :class="{
       'has-sidebar': hasSidebar,
-      'is-home': frontmatter.layout === 'home'
     }"
   >
     <NotFound v-if="route.component === NotFound" />
@@ -56,13 +55,14 @@ const NotFound = inject('NotFound')
   width: 100%;
 }
 
-.VPContent.is-home {
-  width: 100%;
-  max-width: 100%;
-}
-
 .VPContent.has-sidebar {
   margin: 0;
+}
+
+@media (min-width: 768px) {
+  .VPContent {
+    width: 100vw;
+  }
 }
 
 @media (min-width: 960px) {

--- a/src/client/theme-default/components/VPFooter.vue
+++ b/src/client/theme-default/components/VPFooter.vue
@@ -30,6 +30,7 @@ const { hasSidebar } = useSidebar()
 
 @media (min-width: 768px) {
   .VPFooter {
+    width: 100vw;
     padding: 32px;
   }
 }

--- a/src/client/theme-default/components/VPLocalNav.vue
+++ b/src/client/theme-default/components/VPLocalNav.vue
@@ -74,6 +74,10 @@ function scrollToTop() {
 }
 
 @media (min-width: 768px) {
+  .VPLocalNav {
+    width: 100vw;
+  }
+
   .menu {
     padding: 0 32px;
   }

--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -36,6 +36,12 @@ provide('close-screen', closeScreen)
   pointer-events: none;
 }
 
+@media (min-width: 768px) {
+  .VPNav {
+    width: 100vw;
+  }
+}
+
 @media (min-width: 960px) {
   .VPNav {
     position: fixed;

--- a/src/client/theme-default/components/VPSidebar.vue
+++ b/src/client/theme-default/components/VPSidebar.vue
@@ -104,8 +104,8 @@ watchPostEffect(async () => {
 
 @media (min-width: 1440px) {
   .VPSidebar {
-    padding-left: max(32px, calc((100% - (var(--vp-layout-max-width) - 64px)) / 2));
-    width: calc((100% - (var(--vp-layout-max-width) - 64px)) / 2 + var(--vp-sidebar-width) - 32px);
+    padding-left: max(32px, calc((100vw - (var(--vp-layout-max-width) - 64px)) / 2));
+    width: calc((100vw - (var(--vp-layout-max-width) - 64px)) / 2 + var(--vp-sidebar-width) - 32px);
   }
 }
 

--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -30,6 +30,7 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 
 main {


### PR DESCRIPTION
fixes #1054

Previously, the disappearance of non-overlay scrollbars (the default for Chromium on Windows and Linux) changed width of the `body` element and its descendants, causing the whole page to shift slightly to right. This occurred in two cases:

1. Opening the search modal
2. Switching to a page without enough content

This change avoids the shift by using by `100vw` (which isn't changed by the presence of a scrollbar) instead of `100%` where appropriate.

Tested in Firefox and Chromium on Linux, could use a quick test on Safari with MacOS set to always show scrollbars.

Some caveats:

- only fixes layout shift for screen sizes `>= 768px` to avoid the scrollbar from overlapping the UI on smaller screens (the search modal becomes fullscreen at this size, so the shift is only visible in case 2 above)
- requires hiding overflow on `body` to avoid a horizontal scrollbar

I initially tried using the `scrollbar-gutter` rule but ran into trouble getting the modal backdrop and other content overlap the gutter. Then I tried using `#app` as the scroll container instead of `html` but that broke a lot of things 🥲. 

Also, is the `is-home` class needed on `VPContent`? I couldn't figure out what effect it had and needed to override it anyways to get the other rule to work, so hopefully it is okay I removed it.