### PR TITLE
feat: if image is configured to generate `background-image` value

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@vue/devtools-api": "^6.4.5",
     "@vueuse/core": "^9.4.0",
     "body-scroll-lock": "4.0.0-beta.0",
+    "quantize": "^1.0.2",
     "shiki": "^0.11.1",
     "vite": "^3.1.8",
     "vue": "^3.2.41"
@@ -154,9 +155,9 @@
     "rollup-plugin-dts": "^4.2.3",
     "rollup-plugin-esbuild": "^4.10.1",
     "semver": "^7.3.8",
+    "shiki-processor": "^0.1.1",
     "simple-git-hooks": "^2.8.1",
     "sirv": "^2.0.2",
-    "shiki-processor": "^0.1.1",
     "supports-color": "^9.2.3",
     "typescript": "~4.8.4",
     "vitest": "^0.24.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ importers:
       prettier: ^2.7.1
       prompts: ^2.4.2
       punycode: ^2.1.1
+      quantize: ^1.0.2
       rimraf: ^3.0.2
       rollup: ^2.79.1
       rollup-plugin-dts: ^4.2.3
@@ -90,6 +91,7 @@ importers:
       '@vue/devtools-api': 6.4.5
       '@vueuse/core': 9.4.0_vue@3.2.41
       body-scroll-lock: 4.0.0-beta.0
+      quantize: 1.0.2
       shiki: 0.11.1
       vite: 3.1.8
       vue: 3.2.41
@@ -1533,8 +1535,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -3188,6 +3190,11 @@ packages:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     dev: true
+
+  /quantize/1.0.2:
+    resolution: {integrity: sha512-25P7wI2UoDbIQsQp50ARkt+5pwPsOq7G/BqvT5xAbapnRoNWMN8/p55H9TXd5MuENiJnm5XICB2H2aDZGwts7w==}
+    engines: {node: '>=0.10.21'}
+    dev: false
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}

--- a/src/client/app/utils.ts
+++ b/src/client/app/utils.ts
@@ -1,3 +1,4 @@
+import quantize from 'quantize'
 import { siteDataRef } from './data.js'
 import { inBrowser, EXTERNAL_URL_RE, sanitizeFileName } from '../shared.js'
 
@@ -52,4 +53,35 @@ export function pathToFile(path: string): string {
   }
 
   return pagePath
+}
+
+export const getColors = (img: HTMLImageElement) => {
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')!
+  const { naturalWidth, naturalHeight } = img
+  canvas.width = naturalWidth
+  canvas.height = naturalHeight
+  ctx.drawImage(img, 0, 0, naturalWidth, naturalHeight)
+  const imageData = ctx.getImageData(0, 0, naturalWidth, naturalHeight)
+  const pixels = imageData.data
+  const pixelCount = naturalWidth * naturalHeight
+
+  const pixelArray: number[][] = []
+  for (let i = 0; i < pixelCount; i = i + 10) {
+    const offset = i * 4;
+    const r = pixels[offset + 0]
+    const g = pixels[offset + 1]
+    const b = pixels[offset + 2]
+    const a = pixels[offset + 3]
+
+    // If pixel is mostly opaque and not white
+    if (typeof a === 'undefined' || a >= 125) {
+      if (!(r > 250 && g > 250 && b > 250)) {
+        pixelArray.push([r, g, b])
+      }
+    }
+  }
+
+  const cmap = quantize(pixelArray, 10)
+  return cmap ? cmap.palette() : null
 }

--- a/src/client/shim.d.ts
+++ b/src/client/shim.d.ts
@@ -20,3 +20,7 @@ declare module '@theme/index' {
   const theme: Theme
   export default theme
 }
+
+declare module 'quantize' {
+  export default function quantize(pixels: number[][], maxColors: number): any
+}

--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -2,6 +2,7 @@
 import type { DefaultTheme } from 'vitepress/theme'
 import VPButton from './VPButton.vue'
 import VPImage from './VPImage.vue'
+import { getColors } from '../../app/utils.js'
 
 export interface HeroAction {
   theme?: 'brand' | 'alt'
@@ -16,6 +17,22 @@ defineProps<{
   image?: DefaultTheme.ThemeableImage
   actions?: HeroAction[]
 }>()
+const loaded = (e: Event) => {
+  const img = e.target as HTMLImageElement
+  const colors = getColors(img)
+  if (colors) {
+    const root = document.documentElement
+    let v: string[] = []
+    const useColors = colors.slice(0, 5)
+    const gap = Math.floor(100 / (useColors.length - 1))
+    useColors.forEach((c: number[], i: number) => {
+      v.push(`rgb(${c[0]}, ${c[1]}, ${c[2]}) ${i * gap}%`)
+    })
+    const bg = `linear-gradient(-45deg, ${v.join(', ')})`
+    root.style.setProperty('--vp-home-hero-image-background-image', bg)
+    root.style.setProperty('--vp-home-hero-image-filter', 'blur(72px)')
+  }
+}
 </script>
 
 <template>
@@ -44,7 +61,7 @@ defineProps<{
       <div v-if="image" class="image">
         <div class="image-container">
           <div class="image-bg" />
-          <VPImage class="image-src" :image="image" />
+          <VPImage class="image-src" :image="image" @load="loaded" />
         </div>
       </div>
     </div>

--- a/src/client/theme-default/components/VPImage.vue
+++ b/src/client/theme-default/components/VPImage.vue
@@ -6,6 +6,7 @@ defineProps<{
   image: DefaultTheme.ThemeableImage
   alt?: string
 }>()
+defineEmits(['load'])
 </script>
 
 <script lang="ts">
@@ -22,6 +23,7 @@ export default {
       v-bind="typeof image === 'string' ? $attrs : { ...image, ...$attrs }"
       :src="withBase(typeof image === 'string' ? image : image.src)"
       :alt="alt ?? (typeof image === 'string' ? '' : image.alt || '')"
+      @load="$emit('load', $event)"
     />
     <template v-else>
       <VPImage


### PR DESCRIPTION
When image is configured in `index.md`, the css variables `--vp-home-hero-image-background-image` and `--vp-home-hero-image-filter` will be applied to elements with class `image-bg`. However, their value is `none`, so I created this pr to generate it.