### PR TITLE
feat(theme) sidebar nav slots

### DIFF
--- a/docs/guide/theme-introduction.md
+++ b/docs/guide/theme-introduction.md
@@ -201,6 +201,8 @@ Full list of slots available in the default theme layout:
   - `doc-footer-before`
   - `doc-before`
   - `doc-after`
+  - `sidebar-nav-before`
+  - `sidebar-nav-after`
   - `aside-top`
   - `aside-bottom`
   - `aside-outline-before`

--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -40,7 +40,11 @@ const { frontmatter } = useData()
       <template #nav-screen-content-after><slot name="nav-screen-content-after" /></template>
     </VPNav>
     <VPLocalNav :open="isSidebarOpen" @open-menu="openSidebar" />
-    <VPSidebar :open="isSidebarOpen" />
+
+    <VPSidebar :open="isSidebarOpen">
+      <template #sidebar-nav-before><slot name="sidebar-nav-before" /></template>
+      <template #sidebar-nav-after><slot name="sidebar-nav-after" /></template>
+    </VPSidebar>
 
     <VPContent>
       <template #home-hero-before><slot name="home-hero-before" /></template>

--- a/src/client/theme-default/components/VPSidebar.vue
+++ b/src/client/theme-default/components/VPSidebar.vue
@@ -44,6 +44,8 @@ watchPostEffect(async () => {
         Sidebar Navigation
       </span>
 
+      <slot name="sidebar-nav-before" />
+
       <div v-for="group in sidebar" :key="group.text" class="group">
         <VPSidebarGroup
           :text="group.text"
@@ -52,6 +54,8 @@ watchPostEffect(async () => {
           :collapsed="group.collapsed"
         />
       </div>
+
+      <slot name="sidebar-nav-after" />
     </nav>
   </aside>
 </template>


### PR DESCRIPTION
For the new FeathersJS docs, we've been using [this hack](https://github.com/vuejs/core/issues/2097#issuecomment-707975628) to show select boxes above the sidebar nav.  It works ok but occasionally detaches from the DOM. (Geez, lazy much, Marshall? lol 🤷)

This PR adds `sidebar-nav-before` and `sidebar-nav-after` slots to the default theme layout.  I've also listed the new slots in the documentation.

Below is a screenshot of what we're achieving.  You can see it in action on the Feathers v5 Dove site: https://dove.feathersjs.com/guides/basics/starting.html

![Screen Shot 2022-11-05 at 11 27 55 AM](https://user-images.githubusercontent.com/128857/200133221-8a20e770-c7bb-4e45-9396-daaf262b76f1.jpg)

