### PR TITLE
fix(theme): default to vertical align top on badges inside headings

### DIFF
--- a/docs/guide/theme-badge.md
+++ b/docs/guide/theme-badge.md
@@ -15,10 +15,10 @@ You may use the `Badge` component which is globally available.
 
 Code above renders like:
 
-### Title <Badge type="info" text="default" vertical="middle" />
-### Title <Badge type="tip" text="^1.9.0" vertical="middle" />
-### Title <Badge type="warning" text="beta" vertical="middle" />
-### Title <Badge type="danger" text="caution" vertical="middle" />
+### Title <Badge type="info" text="default" />
+### Title <Badge type="tip" text="^1.9.0" />
+### Title <Badge type="warning" text="beta" />
+### Title <Badge type="danger" text="caution" />
 
 ## Custom Children
 

--- a/src/client/theme-default/components/VPBadge.vue
+++ b/src/client/theme-default/components/VPBadge.vue
@@ -19,7 +19,7 @@ defineProps<{
   border-radius: 10px;
   padding: 0 8px;
   line-height: 18px;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   transform: translateY(-2px);
 }

--- a/src/client/theme-default/components/VPBadge.vue
+++ b/src/client/theme-default/components/VPBadge.vue
@@ -24,6 +24,15 @@ defineProps<{
   transform: translateY(-2px);
 }
 
+h1 .VPBadge,
+h2 .VPBadge,
+h3 .VPBadge,
+h4 .VPBadge,
+h5 .VPBadge,
+h6 .VPBadge {
+  vertical-align: top;
+}
+
 h2 .VPBadge {
   border-radius: 11px;
   line-height: 20px;

--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -477,6 +477,15 @@
   opacity: 0;
 }
 
+.vp-doc h1 .VPBadge,
+.vp-doc h2 .VPBadge,
+.vp-doc h3 .VPBadge,
+.vp-doc h4 .VPBadge,
+.vp-doc h5 .VPBadge,
+.vp-doc h6 .VPBadge {
+  vertical-align: top;
+}
+
 /**
  * Component: Team
  * -------------------------------------------------------------------------- */

--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -477,15 +477,6 @@
   opacity: 0;
 }
 
-.vp-doc h1 .VPBadge,
-.vp-doc h2 .VPBadge,
-.vp-doc h3 .VPBadge,
-.vp-doc h4 .VPBadge,
-.vp-doc h5 .VPBadge,
-.vp-doc h6 .VPBadge {
-  vertical-align: top;
-}
-
 /**
  * Component: Team
  * -------------------------------------------------------------------------- */


### PR DESCRIPTION
This pull request makes two changes:

- remove usused `vertical` props (according to [this comment](https://github.com/vuejs/vitepress/pull/1239#pullrequestreview-1148952405))
- set default `vertical-align` inside h1~h6 to `top` (consistent with the [vuepress documentation](https://vuepress2.netlify.app/reference/default-theme/components.html))