### PR TITLE
fix mono+dev+enhanceApp+fs.server.strict: sometimes run error ?

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -112,7 +112,7 @@ export async function createVitePressPlugin(
         },
         optimizeDeps: {
           // force include vue to avoid duplicated copies when linked + optimized
-          include: ['vue'],
+          include: ['vue', 'vitepress/theme'],
           exclude: ['@docsearch/js', 'vitepress']
         },
         server: {


### PR DESCRIPTION
fix https://github.com/vuejs/vitepress/issues/1608

maybe
while not use theme/index.js, vitepress will use theme-default/index.js, and will prebundling VPNavBarSearch.vue and '@docsearch/css'   and will hit  transformMiddleware, then be well

while use theme/index.js, it likes not prebundled,  and will  hit  vite/serveRawFsMiddleware, then be 403