### PR TITLE
fix(snippet): rawPathRegexp did not match ps1 filename extension

### DIFF
--- a/src/node/markdown/plugins/snippet.ts
+++ b/src/node/markdown/plugins/snippet.ts
@@ -109,7 +109,7 @@ export const snippetPlugin = (md: MarkdownIt, srcDir: string) => {
      * captures: ['/path/to/file.extension', 'extension', '#region', '{meta}']
      */
     const rawPathRegexp =
-      /^(.+(?:\.([a-z]+)))(?:(#[\w-]+))?(?: ?(?:{(\d+(?:[,-]\d+)*)? ?(\S+)?}))?$/
+      /^(.+(?:\.([a-z0-9]+)))(?:(#[\w-]+))?(?: ?(?:{(\d+(?:[,-]\d+)*)? ?(\S+)?}))?$/
 
     const rawPath = state.src
       .slice(start, end)


### PR DESCRIPTION
[.ps1](https://learn.microsoft.com/en-us/powershell/scripting/windows-powershell/ise/how-to-write-and-run-scripts-in-the-windows-powershell-ise?view=powershell-7.3#how-to-create-and-run-scripts) file should be able to be imported as a legal code snippet