### PR TITLE
docs: GitHub Actions deploy Workflow

### DIFF
--- a/docs/guide/deploying.md
+++ b/docs/guide/deploying.md
@@ -73,15 +73,17 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
 
    ```yaml
    name: Deploy
-
    on:
+     workflow_dispatch: {}
      push:
        branches:
          - main
-
    jobs:
      deploy:
        runs-on: ubuntu-latest
+       environment:
+         name: github-pages
+         url: ${{ steps.deployment.outputs.page_url }}
        steps:
          - uses: actions/checkout@v3
            with:
@@ -91,16 +93,15 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
              node-version: 16
              cache: yarn
          - run: yarn install --frozen-lockfile
-
          - name: Build
            run: yarn docs:build
-
-         - name: Deploy
-           uses: peaceiris/actions-gh-pages@v3
+         - uses: actions/configure-pages@v2
+         - uses: actions/upload-pages-artifact@v1
            with:
-             github_token: ${{ secrets.GITHUB_TOKEN }}
-             publish_dir: docs/.vitepress/dist
-             # cname: example.com # if wanna deploy to custom domain
+             path: docs/.vitepress/dist
+         - name: Deploy
+           id: deployment
+           uses: actions/deploy-pages@v1
    ```
 
    ::: tip


### PR DESCRIPTION
Previously I needed 2 workflows to publish to GitHub Pages. The documentation workflow and another through the repository's Pages settings.

This PR changes the current setup for deploying using GitHub Actions. It allows to build and deploy in a single job run using GitHub's officials actions instead of building and deploying from a branch.

Here is a brief of it working on my project. https://github.com/FelixLuciano/celulas-solares/actions/runs/3567337170

[Learn more about deploying to GitHub Pages using custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow)