### PR TITLE
perf(a11y): add aria-hidden to line numbers wrapper

### DIFF
--- a/src/node/markdown/plugins/lineNumbers.ts
+++ b/src/node/markdown/plugins/lineNumbers.ts
@@ -17,7 +17,7 @@ export const lineNumberPlugin = (md: MarkdownIt) => {
       .map((line, index) => `<span class="line-number">${index + 1}</span><br>`)
       .join('')
 
-    const lineNumbersWrapperCode = `<div class="line-numbers-wrapper">${lineNumbersCode}</div>`
+    const lineNumbersWrapperCode = `<div class="line-numbers-wrapper" aria-hidden="true">${lineNumbersCode}</div>`
 
     const finalCode = rawCode
       .replace(/<\/div>$/, `${lineNumbersWrapperCode}</div>`)


### PR DESCRIPTION
It seems to be more reasonable to set [`aria-hidden`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) to `true` for those line numbers.