### PR TITLE
docs: remove `OutboundLink`

### DIFF
--- a/docs/guide/using-vue.md
+++ b/docs/guide/using-vue.md
@@ -198,7 +198,7 @@ export default {
 
 ## Built-In Components
 
-VitePress provides Built-In Vue Components like `ClientOnly` and `OutboundLink`, check out the [Global Component Guide](./api) for more information.
+VitePress provides Built-In Vue Components like `ClientOnly`, check out the [Global Component Guide](./api) for more information.
 
 **Also see:**
 


### PR DESCRIPTION
I guess `OutboundLink` does not exist anymore, at least not a global component.
related: https://github.com/vuejs/vitepress/issues/583
