### PR TITLE
feat(theme-default): headings anchor should not be selectable

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -40,6 +40,7 @@
   margin-left: -0.87em;
   padding-right: 0.23em;
   font-weight: 500;
+  user-select: none;
   opacity: 0;
   transition: color 0.25s, opacity 0.25s;
 }


### PR DESCRIPTION
Currently, when users select the page content to copy & paste the text, it also selects the headings `#` anchors. This PR removes the headings anchor-selection by defining the anchors as not selectable (`user-select: none;`).

I created similar PRs in:

* vuepress:
  https://github.com/vuejs/vuepress/pull/3063
* vuepress-next:
  https://github.com/vuepress/vuepress-next/pull/973

