### PR TITLE
chore: add stackblitz link to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
     id: reproduction
     attributes:
       label: Reproduction
-      description: Steps to reproduce the behavior
+      description: Steps to reproduce the behavior. [vitepress.new](https://vitepress.new/) can be used as a starter template.
       placeholder: Reproduction
     validations:
       required: true


### PR DESCRIPTION
I think this would be nice for both people reporting and triaging issues.