### PR TITLE
fix: refresh ads per page navigation

### DIFF
--- a/src/client/theme-default/components/VPCarbonAds.vue
+++ b/src/client/theme-default/components/VPCarbonAds.vue
@@ -3,16 +3,16 @@ import { ref, watch, onMounted } from 'vue'
 import { useData } from 'vitepress'
 import { useAside } from '../composables/aside.js'
 
-const { theme } = useData()
+const { theme, page } = useData()
 const carbonOptions = theme.value.carbonAds
 const { isAsideEnabled } = useAside()
 const container = ref()
 
-let hasInitalized = false
+let isInitialized = false
 
 function init() {
-  if (!hasInitalized) {
-    hasInitalized = true
+  if (!isInitialized) {
+    isInitialized = true
     const s = document.createElement('script')
     s.id = '_carbonads_js'
     s.src = `//cdn.carbonads.com/carbon.js?serve=${carbonOptions.code}&placement=${carbonOptions.placement}`
@@ -20,6 +20,12 @@ function init() {
     container.value.appendChild(s)
   }
 }
+
+watch(() => page.value.relativePath, () => {
+  if (isInitialized && isAsideEnabled.value) {
+    ;(window as any)._carbonads?.refresh()
+  }
+})
 
 // no need to account for option changes during dev, we can just
 // refresh the page

--- a/src/client/theme-default/components/VPDocAsideCarbonAds.vue
+++ b/src/client/theme-default/components/VPDocAsideCarbonAds.vue
@@ -1,16 +1,14 @@
 <script setup lang="ts">
-import { useData } from 'vitepress';
 import { defineAsyncComponent } from 'vue'
 
 const VPCarbonAds = __CARBON__
   ? defineAsyncComponent(() => import('./VPCarbonAds.vue'))
   : () => null
 
-const { page } = useData()
 </script>
 
 <template>
   <div class="VPDocAsideCarbonAds">
-    <VPCarbonAds :key="page.relativePath" />
+    <VPCarbonAds />
   </div>
 </template>

--- a/src/client/theme-default/components/VPDocAsideCarbonAds.vue
+++ b/src/client/theme-default/components/VPDocAsideCarbonAds.vue
@@ -4,7 +4,6 @@ import { defineAsyncComponent } from 'vue'
 const VPCarbonAds = __CARBON__
   ? defineAsyncComponent(() => import('./VPCarbonAds.vue'))
   : () => null
-
 </script>
 
 <template>

--- a/src/client/theme-default/components/VPDocAsideCarbonAds.vue
+++ b/src/client/theme-default/components/VPDocAsideCarbonAds.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
+import { useData } from 'vitepress';
 import { defineAsyncComponent } from 'vue'
 
 const VPCarbonAds = __CARBON__
   ? defineAsyncComponent(() => import('./VPCarbonAds.vue'))
   : () => null
+
+const { page } = useData()
 </script>
 
 <template>
   <div class="VPDocAsideCarbonAds">
-    <VPCarbonAds />
+    <VPCarbonAds :key="page.relativePath" />
   </div>
 </template>


### PR DESCRIPTION
This is the same behavior we had before: https://unpkg.com/browse/vitepress@0.20.10/dist/client/theme-default/Layout.vue#L135