### PR TITLE
fix: filename with - cause a bug

### DIFF
--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -20,7 +20,9 @@ import type { ThemeOptions } from '../markdown'
  *    [{ line: number, classes: string[] }]
  */
 const attrsToLines = (attrs: string): HtmlRendererOptions['lineOptions'] => {
-  attrs = attrs.replace(/.*?([\d,-]+).*/, '$1').trim()
+  const [_name, ...other] = attrs.split(' ')
+  attrs = (other.join(' ') || attrs).replace(/.*?([\d,-]+).*/, '$1').trim()
+  // attrs = attrs.replace(/.*?([\d,-]+).*/, '$1').trim()
   const result: number[] = []
   if (!attrs) {
     return []


### PR DESCRIPTION
when you  use 
```md
:::code-group

```yaml{50} [.template/pnpm-lock.yaml]
```
the regexp cause bug when filename includes "-"

detect lineNums without filename fix the bug.
