### PR TITLE
fix(theme): `activeMatch` support regexp

### DIFF
--- a/src/client/theme-default/components/VPMenuLink.vue
+++ b/src/client/theme-default/components/VPMenuLink.vue
@@ -13,7 +13,7 @@ const { page } = useData()
 <template>
   <div class="VPMenuLink">
     <VPLink 
-      :class="{ active: isActive(page.relativePath, item.activeMatch || item.link) }"
+      :class="{ active: isActive(page.relativePath, item.activeMatch || item.link, !!item.activeMatch) }"
       :href="item.link"
     >
       {{ item.text }}


### PR DESCRIPTION
Similar to below:
https://github.com/vuejs/vitepress/blob/565ae711b9b90ad2fe820cdbaa04a9d41506ac53/src/client/theme-default/components/VPNavBarMenuLink.vue#L18-L24