### PR TITLE
fix(theme): prevent vertical scrollbar on code group tabs (#1793)

### DIFF
--- a/src/client/theme-default/styles/components/vp-code-group.css
+++ b/src/client/theme-default/styles/components/vp-code-group.css
@@ -10,6 +10,7 @@
   padding: 0 12px;
   background-color: var(--vp-code-tab-bg);
   overflow: auto;
+  overflow-y: hidden;
 }
 
 .vp-code-group .tabs::after {

--- a/src/client/theme-default/styles/components/vp-code-group.css
+++ b/src/client/theme-default/styles/components/vp-code-group.css
@@ -9,7 +9,7 @@
   margin-left: -24px;
   padding: 0 12px;
   background-color: var(--vp-code-tab-bg);
-  overflow: auto;
+  overflow-x: auto;
   overflow-y: hidden;
 }
 


### PR DESCRIPTION
fix(theme): codeblocks always show vertical scrollbar (#1793)