### PR TITLE
fix(theme): adjust the position of the curtain to avoid block sidebar

### DIFF
--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -166,8 +166,7 @@ const { hasSidebar } = useSidebar()
     position: absolute;
     right: 0;
     bottom: -32px;
-    padding-left: var(--vp-sidebar-width);
-    width: 100%;
+    width: calc(100% - var(--vp-sidebar-width));
     height: 32px;
   }
 
@@ -182,7 +181,7 @@ const { hasSidebar } = useSidebar()
 
 @media (min-width: 1440px) {
   .VPNavBar.has-sidebar .curtain {
-    padding-left: calc((100vw - var(--vp-layout-max-width)) / 2 + var(--vp-sidebar-width));
+    width: calc(100% - ((100vw - var(--vp-layout-max-width)) / 2 + var(--vp-sidebar-width)));
   }
 }
 </style>


### PR DESCRIPTION
refs #1049 [#1709 ](https://github.com/vuejs/vitepress/pull/1790)

## reproduction

https://vitepress.vuejs.org/guide/what-is-vitepress

try collapse the first item of sidebar