### PR TITLE
feat: alow to use configuration file from current working directory

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -20,13 +20,13 @@ export default {
 }
 ```
 
-You may also create your configuration file in current working directory with name `vuepress.config.js`:
+You may also create your configuration file in current working directory with name `vitepress.config.js`:
 
 ```
 .
 ├─ docs
 │  └─ index.md
-├─ vuepress.config.js
+├─ vitepress.config.js
 └─ package.json
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -20,6 +20,16 @@ export default {
 }
 ```
 
+You may also create your configuration file in current working directory with name `vuepress.config.js`:
+
+```
+.
+├─ docs
+│  └─ index.md
+├─ vuepress.config.js
+└─ package.json
+```
+
 In the above example, the site will have the title of `VitePress`, and `Just playing around.` as the description meta tag.
 
 Learn everything about VitePress features at [Theme: Introduction](./theme-introduction) to find how to configure specific features within this config file.


### PR DESCRIPTION
Tried to implement #1842 

Makes the use of the `.vitepress` directory optional