### PR TITLE
feat(theme): preconnect algolia when idle

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -78,6 +78,22 @@ function poll() {
     }
   }, 16)
 }
+
+onMounted(() => {
+  const id = 'VPAlgoliaPreconnect'
+
+  const rIC = requestIdleCallback || setTimeout
+  rIC(() => {
+    if (!theme.value.algolia || document.head.querySelector(`#${id}`)) return
+
+    const preconnect = document.createElement('link')
+    preconnect.id = id
+    preconnect.rel = 'preconnect'
+    preconnect.href = `https://${theme.value.algolia.appId}-dsn.algolia.net`
+    preconnect.crossOrigin = ''
+    document.head.appendChild(preconnect)
+  })
+})
 </script>
 
 <template>


### PR DESCRIPTION
Add `<link rel="preconnect" />` for algolia when algolia search is enabled and idle.
https://docsearch.algolia.com/docs/docsearch-v3/#performance-optimization

I decided to inject this link tag on client-side by `requestIdleCallback` because I didn't find a good way to inject head tags from a theme on build step and didn't think this needs to be eagerly done.
