### PR TITLE
ci: simplify release github workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           body: |
-            Please refer to [CHANGELOG.md](https://github.com/vuejs/vitepress/blob/main/CHANGELOG.md) for details.
+            Please refer to [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.


### PR DESCRIPTION
- make it easier to move the repository if it happens
- avoid mistakes in case of copy-paste workflow code
- variables are always better and cleaner