### PR TITLE
fixed safari requestIdleCallback

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -82,7 +82,7 @@ function poll() {
 onMounted(() => {
   const id = 'VPAlgoliaPreconnect'
 
-  const rIC = requestIdleCallback || setTimeout
+  const rIC = window.requestIdleCallback || setTimeout
   rIC(() => {
     if (!theme.value.algolia || document.head.querySelector(`#${id}`)) return
 


### PR DESCRIPTION
Safari doesn't support `requestIdleCallback`.
But there's an error if we leave out `window` in `window.requestIdleCallback`.