### PR TITLE
feat(shiki): support `ansi` code highlight

### DIFF
--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -127,15 +127,17 @@ export async function highlight(
       return s
     }
 
-    if (hasSingleTheme) {
+    str = removeMustache(str)
+
+    const codeToHtml = (theme: IThemeRegistration) => {
       return cleanup(
         restoreMustache(
           lang === 'ansi'
-            ? highlighter.ansiToHtml(removeMustache(str), {
+            ? highlighter.ansiToHtml(str, {
                 lineOptions,
                 theme: getThemeName(theme)
               })
-            : highlighter.codeToHtml(removeMustache(str), {
+            : highlighter.codeToHtml(str, {
                 lang,
                 lineOptions,
                 theme: getThemeName(theme)
@@ -144,40 +146,9 @@ export async function highlight(
       )
     }
 
-    const dark = addClass(
-      cleanup(
-        lang === 'ansi'
-          ? highlighter.ansiToHtml(str, {
-              lineOptions,
-              theme: getThemeName(theme.dark)
-            })
-          : highlighter.codeToHtml(str, {
-              lang,
-              lineOptions,
-              theme: getThemeName(theme.dark)
-            })
-      ),
-      'vp-code-dark',
-      'pre'
-    )
-
-    const light = addClass(
-      cleanup(
-        lang === 'ansi'
-          ? highlighter.ansiToHtml(str, {
-              lineOptions,
-              theme: getThemeName(theme.light)
-            })
-          : highlighter.codeToHtml(str, {
-              lang,
-              lineOptions,
-              theme: getThemeName(theme.light)
-            })
-      ),
-      'vp-code-light',
-      'pre'
-    )
-
+    if (hasSingleTheme) return codeToHtml(theme)
+    const dark = addClass(codeToHtml(theme.dark), 'vp-code-dark', 'pre')
+    const light = addClass(codeToHtml(theme.light), 'vp-code-light', 'pre')
     return dark + light
   }
 }

--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -88,7 +88,7 @@ export async function highlight(
 
     if (lang) {
       const langLoaded = highlighter.getLoadedLanguages().includes(lang as any)
-      if (!langLoaded) {
+      if (!langLoaded && lang !== 'ansi') {
         console.warn(
           c.yellow(
             `The language '${lang}' is not loaded, falling back to '${
@@ -130,22 +130,32 @@ export async function highlight(
     if (hasSingleTheme) {
       return cleanup(
         restoreMustache(
-          highlighter.codeToHtml(removeMustache(str), {
-            lang,
-            lineOptions,
-            theme: getThemeName(theme)
-          })
+          lang === 'ansi'
+            ? highlighter.ansiToHtml(removeMustache(str), {
+              lineOptions,
+              theme: getThemeName(theme)
+            })
+            : highlighter.codeToHtml(removeMustache(str), {
+              lang,
+              lineOptions,
+              theme: getThemeName(theme)
+            })
         )
       )
     }
 
     const dark = addClass(
       cleanup(
-        highlighter.codeToHtml(str, {
-          lang,
-          lineOptions,
-          theme: getThemeName(theme.dark)
-        })
+        lang === 'ansi'
+          ? highlighter.ansiToHtml(str, {
+            lineOptions,
+            theme: getThemeName(theme.dark)
+          })
+          : highlighter.codeToHtml(str, {
+            lang,
+            lineOptions,
+            theme: getThemeName(theme.dark)
+          })
       ),
       'vp-code-dark',
       'pre'
@@ -153,11 +163,16 @@ export async function highlight(
 
     const light = addClass(
       cleanup(
-        highlighter.codeToHtml(str, {
-          lang,
-          lineOptions,
-          theme: getThemeName(theme.light)
-        })
+        lang === 'ansi'
+          ? highlighter.ansiToHtml(str, {
+            lineOptions,
+            theme: getThemeName(theme.light)
+          })
+          : highlighter.codeToHtml(str, {
+            lang,
+            lineOptions,
+            theme: getThemeName(theme.light)
+          })
       ),
       'vp-code-light',
       'pre'

--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -132,14 +132,14 @@ export async function highlight(
         restoreMustache(
           lang === 'ansi'
             ? highlighter.ansiToHtml(removeMustache(str), {
-              lineOptions,
-              theme: getThemeName(theme)
-            })
+                lineOptions,
+                theme: getThemeName(theme)
+              })
             : highlighter.codeToHtml(removeMustache(str), {
-              lang,
-              lineOptions,
-              theme: getThemeName(theme)
-            })
+                lang,
+                lineOptions,
+                theme: getThemeName(theme)
+              })
         )
       )
     }
@@ -148,14 +148,14 @@ export async function highlight(
       cleanup(
         lang === 'ansi'
           ? highlighter.ansiToHtml(str, {
-            lineOptions,
-            theme: getThemeName(theme.dark)
-          })
+              lineOptions,
+              theme: getThemeName(theme.dark)
+            })
           : highlighter.codeToHtml(str, {
-            lang,
-            lineOptions,
-            theme: getThemeName(theme.dark)
-          })
+              lang,
+              lineOptions,
+              theme: getThemeName(theme.dark)
+            })
       ),
       'vp-code-dark',
       'pre'
@@ -165,14 +165,14 @@ export async function highlight(
       cleanup(
         lang === 'ansi'
           ? highlighter.ansiToHtml(str, {
-            lineOptions,
-            theme: getThemeName(theme.light)
-          })
+              lineOptions,
+              theme: getThemeName(theme.light)
+            })
           : highlighter.codeToHtml(str, {
-            lang,
-            lineOptions,
-            theme: getThemeName(theme.light)
-          })
+              lang,
+              lineOptions,
+              theme: getThemeName(theme.light)
+            })
       ),
       'vp-code-light',
       'pre'


### PR DESCRIPTION
Close #1876 

[shiki v0.14.0](https://github.com/shikijs/shiki/releases) support [ANSI code lang support](https://github.com/shikijs/shiki/pull/386#issuecomment-1404347813)

---

<details>
<summary>There have a usage recipe </summary>

### command output save a snippet file and import code snippet
1. mark sure output with ansi colorized code. Can try add `FORCE_COLOR` environment variable
e.g: `bun` command help
```sh
FORCE_COLOR=1 bun help > docs/snippets/bun.ansi
```
> or use `script` command to record https://man7.org/linux/man-pages/man1/script.1.html

2. use [import code snippet](https://vitepress.vuejs.org/guide/markdown#import-code-snippets) on md document
```md
<<< @/snippets/bun.ansi
```

demo:
<img width="1363" alt="image" src="https://user-images.githubusercontent.com/40693636/215996811-d664d1cf-f5e9-4f80-966f-420840a42395.png">


</details>



