### PR TITLE
docs: fix carbonAds

### DIFF
--- a/docs/config/theme-configs.md
+++ b/docs/config/theme-configs.md
@@ -306,11 +306,11 @@ export interface AlgoliaSearchOptions extends DocSearchProps {
 
 View full options [here](https://github.com/vuejs/vitepress/blob/main/types/docsearch.d.ts).
 
-## carbonAds {#carbon-ads}
+## carbonAds
 
-- Type: `CarbonAds`
+- Type: `CarbonAdsOptions`
 
-A option to display [Carbon Ads](https://www.carbonads.net/).
+An option to display [Carbon Ads](https://www.carbonads.net/).
 
 ```ts
 export default {
@@ -324,7 +324,7 @@ export default {
 ```
 
 ```ts
-export interface CarbonAds {
+export interface CarbonAdsOptions {
   code: string
   placement: string
 }


### PR DESCRIPTION
- Remove incorrect hash symbols and make the right sidebar navigable to the correct text fragment
- Synchronize CarbonAds option type declarations from ·`default-theme.d.ts`
- Fix syntax issue
- Empty line at the end, forgot about last commit