### PR TITLE
fix: VPNavBarMenuLink no external icon

### DIFF
--- a/src/client/theme-default/components/VPNavBarMenuLink.vue
+++ b/src/client/theme-default/components/VPNavBarMenuLink.vue
@@ -22,7 +22,6 @@ const { page } = useData()
       )
     }"
     :href="item.link"
-    :noIcon="true"
   >
     {{ item.text }}
   </VPLink>


### PR DESCRIPTION
i found externalIcon only show in VPMenuLink,   not show in VPNavBarMenuLink
why?   so i remove the noIcon bind
![image](https://user-images.githubusercontent.com/35157761/216220504-f5c0656d-beb1-45f3-ae40-a299ef4e09d0.png)


![image](https://user-images.githubusercontent.com/35157761/216209327-8b02fd38-23e6-4972-be73-75af41cdafc7.png)

![image](https://user-images.githubusercontent.com/35157761/216209261-f698e929-ac2f-4cd4-83aa-3fc5d2923a6c.png)

![image](https://user-images.githubusercontent.com/35157761/216220199-da60bc7d-e401-4c43-98b7-0d4ee0370cc1.png)


