### PR TITLE
docs(api): use code snippet for type definition

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -10,20 +10,7 @@ Methods that start with `use*` indicates that it is a [Vue 3 Composition API](ht
 
 Returns page-specific data. The returned object has the following type:
 
-```ts
-interface VitePressData<T = any> {
-  site: Ref<SiteData<T>>
-  page: Ref<PageData>
-  theme: Ref<T> // themeConfig from .vitepress/config.js
-  frontmatter: Ref<PageData['frontmatter']>
-  title: Ref<string>
-  description: Ref<string>
-  lang: Ref<string>
-  isDark: Ref<boolean>
-  dir: Ref<string>
-  localeIndex: Ref<string>
-}
-```
+<<< @/../src/client/app/data.ts#VitePressData
 
 **Example:**
 
@@ -43,24 +30,13 @@ const { theme } = useData()
 
 Returns the current route object with the following type:
 
-```ts
-interface Route {
-  path: string
-  data: PageData
-  component: Component | null
-}
-```
+<<< @/../src/client/app/router.ts#Route
 
 ## `useRouter`
 
 Returns the VitePress router instance so you can programmatically navigate to another page.
 
-```ts
-interface Router {
-  route: Route
-  go: (href?: string) => Promise<void>
-}
-```
+<<< @/../src/client/app/router.ts#Router
 
 ## `withBase`
 

--- a/src/client/app/data.ts
+++ b/src/client/app/data.ts
@@ -18,6 +18,7 @@ import {
 
 export const dataSymbol: InjectionKey<VitePressData> = Symbol()
 
+// #region VitePressData
 export interface VitePressData<T = any> {
   site: Ref<SiteData<T>>
   page: Ref<PageData>
@@ -30,6 +31,7 @@ export interface VitePressData<T = any> {
   dir: Ref<string>
   localeIndex: Ref<string>
 }
+// #endregion VitePressData
 
 // site data is a singleton
 export const siteDataRef: Ref<SiteData> = shallowRef(

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -5,18 +5,22 @@ import type { PageData, PageDataPayload, Awaitable } from '../shared.js'
 import { inBrowser, withBase } from './utils.js'
 import { siteDataRef } from './data.js'
 
+// #region Route
 export interface Route {
   path: string
   data: PageData
   component: Component | null
 }
+// #endregion Route
 
+// #region Router
 export interface Router {
   route: Route
   go: (href?: string) => Promise<void>
   onBeforeRouteChange?: (to: string) => Awaitable<void>
   onAfterRouteChanged?: (to: string) => Awaitable<void>
 }
+// #endregion Router
 
 export const RouterSymbol: InjectionKey<Router> = Symbol()
 


### PR DESCRIPTION
The advantage is that the source code will be automatically synchronized to the document when it is modified, but some noise is added to the code.