### PR TITLE
feat: add `translations` class in VPNavBarExtra

### DIFF
--- a/src/client/theme-default/components/VPNavBarExtra.vue
+++ b/src/client/theme-default/components/VPNavBarExtra.vue
@@ -20,7 +20,7 @@ const hasExtraContent = computed(
 
 <template>
   <VPFlyout v-if="hasExtraContent" class="VPNavBarExtra" label="extra navigation">
-    <div v-if="localeLinks.length && currentLang.label" class="group">
+    <div v-if="localeLinks.length && currentLang.label" class="group translations">
       <p class="trans-title">{{ currentLang.label }}</p>
 
       <template v-for="locale in localeLinks" :key="locale.link">


### PR DESCRIPTION
This change is intended to unify `translations` class in all views. 

Before this change:
For desktop `VPNavBarTranslations` has `translations` class 
https://github.com/vuejs/vitepress/blob/3db532ed0999c9bddfd6bc90f6b627ae1b9178af/src/client/theme-default/components/VPNavBar.vue#L47

For mobile `VPNavScreenTranslations` has `translations` class 
https://github.com/vuejs/vitepress/blob/8de2f4499d9364d85e6070ce4b94651a1902b101/src/client/theme-default/components/VPNavScreen.vue#L34

But for intermediate views similar widget in `VPNavBarExtra` does not have `translations` class 