### PR TITLE
feat: use vite logger

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -106,7 +106,9 @@ export async function build(
 
   await siteConfig.buildEnd?.(siteConfig)
 
-  console.log(`build complete in ${((Date.now() - start) / 1000).toFixed(2)}s.`)
+  siteConfig.logger.info(
+    `build complete in ${((Date.now() - start) / 1000).toFixed(2)}s.`
+  )
 }
 
 function linkVue() {

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -1,11 +1,12 @@
 import c from 'picocolors'
 import minimist from 'minimist'
+import { createLogger } from 'vite'
 import { createServer, build, serve } from '.'
 import { version } from '../../package.json'
 
 const argv: any = minimist(process.argv.slice(2))
 
-console.log(c.cyan(`vitepress v${version}`))
+const tempLogger = createLogger()
 
 const command = argv._[0]
 const root = argv._[command ? 1 : 0]
@@ -17,27 +18,41 @@ if (!command || command === 'dev') {
   const createDevServer = async () => {
     const server = await createServer(root, argv, async () => {
       await server.close()
-      await createDevServer()
+      const newServer = await createDevServer()
+      await newServer.listen()
+      newServer.printUrls()
     })
-    await server.listen()
-    console.log()
-    server.printUrls()
+    return server
   }
-  createDevServer().catch((err) => {
-    console.error(c.red(`failed to start server. error:\n`), err)
-    process.exit(1)
-  })
-} else if (command === 'build') {
-  build(root, argv).catch((err) => {
-    console.error(c.red(`build error:\n`), err)
-    process.exit(1)
-  })
-} else if (command === 'serve' || command === 'preview') {
-  serve(argv).catch((err) => {
-    console.error(c.red(`failed to start server. error:\n`), err)
-    process.exit(1)
-  })
+  createDevServer()
+    .then(async (server) => {
+      await server.listen()
+      server.config.logger.info(
+        `\n  ${c.green(`${c.bold('VITEPRESS')} v${version}`)}\n`,
+        { clear: !server.config.logger.hasWarned }
+      )
+      server.printUrls()
+    })
+    .catch((err) => {
+      tempLogger.error(c.red(`failed to start server. error:\n${err}`))
+      process.exit(1)
+    })
 } else {
-  console.log(c.red(`unknown command "${command}".`))
-  process.exit(1)
+  tempLogger.info(`\n  ${c.green(`${c.bold('VITEPRESS')} v${version}`)}\n`, {
+    clear: true
+  })
+  if (command === 'build') {
+    build(root, argv).catch((err) => {
+      tempLogger.error(c.red(`build error:\n`), err)
+      process.exit(1)
+    })
+  } else if (command === 'serve' || command === 'preview') {
+    serve(argv).catch((err) => {
+      tempLogger.error(c.red(`failed to start server. error:\n${err}`))
+      process.exit(1)
+    })
+  } else {
+    tempLogger.info(c.red(`unknown command "${command}".`))
+    process.exit(1)
+  }
 }

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -1,12 +1,16 @@
-import c from 'picocolors'
 import minimist from 'minimist'
+import c from 'picocolors'
 import { createLogger } from 'vite'
-import { createServer, build, serve } from '.'
+import { build, createServer, serve } from '.'
 import { version } from '../../package.json'
 
 const argv: any = minimist(process.argv.slice(2))
 
-const tempLogger = createLogger()
+const logVersion = (logger = createLogger()) => {
+  logger.info(`\n  ${c.green(`${c.bold('vitepress')} v${version}`)}\n`, {
+    clear: !logger.hasWarned
+  })
+}
 
 const command = argv._[0]
 const root = argv._[command ? 1 : 0]
@@ -18,41 +22,30 @@ if (!command || command === 'dev') {
   const createDevServer = async () => {
     const server = await createServer(root, argv, async () => {
       await server.close()
-      const newServer = await createDevServer()
-      await newServer.listen()
-      newServer.printUrls()
+      await createDevServer()
     })
-    return server
+    await server.listen()
+    logVersion(server.config.logger)
+    server.printUrls()
   }
-  createDevServer()
-    .then(async (server) => {
-      await server.listen()
-      server.config.logger.info(
-        `\n  ${c.green(`${c.bold('VITEPRESS')} v${version}`)}\n`,
-        { clear: !server.config.logger.hasWarned }
-      )
-      server.printUrls()
-    })
-    .catch((err) => {
-      tempLogger.error(c.red(`failed to start server. error:\n${err}`))
-      process.exit(1)
-    })
-} else {
-  tempLogger.info(`\n  ${c.green(`${c.bold('VITEPRESS')} v${version}`)}\n`, {
-    clear: true
+  createDevServer().catch((err) => {
+    createLogger().error(c.red(`failed to start server. error:\n`), err)
+    process.exit(1)
   })
+} else {
+  logVersion()
   if (command === 'build') {
     build(root, argv).catch((err) => {
-      tempLogger.error(c.red(`build error:\n`), err)
+      createLogger().error(c.red(`build error:\n`), err)
       process.exit(1)
     })
   } else if (command === 'serve' || command === 'preview') {
     serve(argv).catch((err) => {
-      tempLogger.error(c.red(`failed to start server. error:\n${err}`))
+      createLogger().error(c.red(`failed to start server. error:\n`), err)
       process.exit(1)
     })
   } else {
-    tempLogger.info(c.red(`unknown command "${command}".`))
+    createLogger().error(c.red(`unknown command "${command}".`))
     process.exit(1)
   }
 }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -3,15 +3,15 @@ import _debug from 'debug'
 import fg from 'fast-glob'
 import fs from 'fs-extra'
 import path from 'path'
-import { match, compile } from 'path-to-regexp'
+import { compile, match } from 'path-to-regexp'
 import c from 'picocolors'
 import {
   createLogger,
   loadConfigFromFile,
   mergeConfig as mergeViteConfig,
   normalizePath,
-  type UserConfig as ViteConfig,
-  type Logger
+  type Logger,
+  type UserConfig as ViteConfig
 } from 'vite'
 import { DEFAULT_THEME_PATH } from './alias'
 import type { MarkdownOptions } from './markdown/markdown'

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -209,12 +209,18 @@ export async function resolveConfig(
   command: 'serve' | 'build' = 'serve',
   mode = 'development'
 ): Promise<SiteConfig> {
-  const logger = createLogger('info', { prefix: '[vitepress]' })
   const [userConfig, configPath, configDeps] = await resolveUserConfig(
     root,
     command,
     mode
   )
+
+  const logger =
+    userConfig.vite?.customLogger ??
+    createLogger(userConfig.vite?.logLevel, {
+      prefix: '[vitepress]',
+      allowClearScreen: userConfig.vite?.clearScreen
+    })
   const site = await resolveSiteData(root, userConfig)
   const srcDir = path.resolve(root, userConfig.srcDir || '.')
   const outDir = userConfig.outDir

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -6,10 +6,12 @@ import path from 'path'
 import { match, compile } from 'path-to-regexp'
 import c from 'picocolors'
 import {
+  createLogger,
   loadConfigFromFile,
   mergeConfig as mergeViteConfig,
   normalizePath,
-  type UserConfig as ViteConfig
+  type UserConfig as ViteConfig,
+  type Logger
 } from 'vite'
 import { DEFAULT_THEME_PATH } from './alias'
 import type { MarkdownOptions } from './markdown/markdown'
@@ -180,6 +182,7 @@ export interface SiteConfig<ThemeConfig = any>
     map: Record<string, string | undefined>
     inv: Record<string, string | undefined>
   }
+  logger: Logger
 }
 
 const resolve = (root: string, file: string) =>
@@ -206,6 +209,7 @@ export async function resolveConfig(
   command: 'serve' | 'build' = 'serve',
   mode = 'development'
 ): Promise<SiteConfig> {
+  const logger = createLogger('info', { prefix: '[vitepress]' })
   const [userConfig, configPath, configDeps] = await resolveUserConfig(
     root,
     command,
@@ -264,6 +268,7 @@ export async function resolveConfig(
     configDeps,
     outDir,
     cacheDir,
+    logger,
     tempDir: resolve(root, '.temp'),
     markdown: userConfig.markdown,
     lastUpdated: userConfig.lastUpdated,

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -15,6 +15,7 @@ import { sfcPlugin, type SfcPluginOptions } from '@mdit-vue/plugin-sfc'
 import { titlePlugin } from '@mdit-vue/plugin-title'
 import { tocPlugin, type TocPluginOptions } from '@mdit-vue/plugin-toc'
 import { slugify } from '@mdit-vue/shared'
+import type { Logger } from 'vite'
 import type { IThemeRegistration } from 'shiki'
 import { highlight } from './plugins/highlight'
 import { highlightLinePlugin } from './plugins/highlightLines'
@@ -55,14 +56,15 @@ export type MarkdownRenderer = MarkdownIt
 export const createMarkdownRenderer = async (
   srcDir: string,
   options: MarkdownOptions = {},
-  base = '/'
+  base = '/',
+  logger: Logger
 ): Promise<MarkdownRenderer> => {
   const md = MarkdownIt({
     html: true,
     linkify: true,
     highlight:
       options.highlight ||
-      (await highlight(options.theme, options.defaultHighlightLang)),
+      (await highlight(options.theme, options.defaultHighlightLang, logger)),
     ...options
   }) as MarkdownRenderer
 

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -1,7 +1,3 @@
-import MarkdownIt from 'markdown-it'
-import anchorPlugin from 'markdown-it-anchor'
-import attrsPlugin from 'markdown-it-attrs'
-import emojiPlugin from 'markdown-it-emoji'
 import { componentPlugin } from '@mdit-vue/plugin-component'
 import {
   frontmatterPlugin,
@@ -15,16 +11,20 @@ import { sfcPlugin, type SfcPluginOptions } from '@mdit-vue/plugin-sfc'
 import { titlePlugin } from '@mdit-vue/plugin-title'
 import { tocPlugin, type TocPluginOptions } from '@mdit-vue/plugin-toc'
 import { slugify } from '@mdit-vue/shared'
-import type { Logger } from 'vite'
+import MarkdownIt from 'markdown-it'
+import anchorPlugin from 'markdown-it-anchor'
+import attrsPlugin from 'markdown-it-attrs'
+import emojiPlugin from 'markdown-it-emoji'
 import type { IThemeRegistration } from 'shiki'
+import type { Logger } from 'vite'
+import { containerPlugin } from './plugins/containers'
 import { highlight } from './plugins/highlight'
 import { highlightLinePlugin } from './plugins/highlightLines'
-import { lineNumberPlugin } from './plugins/lineNumbers'
-import { containerPlugin } from './plugins/containers'
-import { snippetPlugin } from './plugins/snippet'
-import { preWrapperPlugin } from './plugins/preWrapper'
-import { linkPlugin } from './plugins/link'
 import { imagePlugin } from './plugins/image'
+import { lineNumberPlugin } from './plugins/lineNumbers'
+import { linkPlugin } from './plugins/link'
+import { preWrapperPlugin } from './plugins/preWrapper'
+import { snippetPlugin } from './plugins/snippet'
 
 export type { Header } from '../shared'
 
@@ -57,7 +57,7 @@ export const createMarkdownRenderer = async (
   srcDir: string,
   options: MarkdownOptions = {},
   base = '/',
-  logger: Logger
+  logger: Pick<Logger, 'warn'> = console
 ): Promise<MarkdownRenderer> => {
   const md = MarkdownIt({
     html: true,

--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -12,6 +12,7 @@ import {
   type Processor
 } from 'shiki-processor'
 import type { ThemeOptions } from '../markdown'
+import type { Logger } from 'vite'
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 10)
 
@@ -57,7 +58,8 @@ const errorLevelProcessor = defineProcessor({
 
 export async function highlight(
   theme: ThemeOptions = 'material-theme-palenight',
-  defaultLang: string = ''
+  defaultLang: string = '',
+  logger: Logger
 ): Promise<(str: string, lang: string, attrs: string) => string> {
   const hasSingleTheme = typeof theme === 'string' || 'name' in theme
   const getThemeName = (themeValue: IThemeRegistration) =>
@@ -89,7 +91,7 @@ export async function highlight(
     if (lang) {
       const langLoaded = highlighter.getLoadedLanguages().includes(lang as any)
       if (!langLoaded && lang !== 'ansi') {
-        console.warn(
+        logger.warn(
           c.yellow(
             `The language '${lang}' is not loaded, falling back to '${
               defaultLang || 'txt'

--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -11,8 +11,8 @@ import {
   getHighlighter,
   type Processor
 } from 'shiki-processor'
-import type { ThemeOptions } from '../markdown'
 import type { Logger } from 'vite'
+import type { ThemeOptions } from '../markdown'
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 10)
 
@@ -59,7 +59,7 @@ const errorLevelProcessor = defineProcessor({
 export async function highlight(
   theme: ThemeOptions = 'material-theme-palenight',
   defaultLang: string = '',
-  logger: Logger
+  logger: Pick<Logger, 'warn'> = console
 ): Promise<(str: string, lang: string, attrs: string) => string> {
   const hasSingleTheme = typeof theme === 'string' || 'name' in theme
   const getThemeName = (themeValue: IThemeRegistration) =>
@@ -93,7 +93,7 @@ export async function highlight(
       if (!langLoaded && lang !== 'ansi') {
         logger.warn(
           c.yellow(
-            `The language '${lang}' is not loaded, falling back to '${
+            `\nThe language '${lang}' is not loaded, falling back to '${
               defaultLang || 'txt'
             }' for syntax highlighting.`
           )

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -39,9 +39,14 @@ export async function createMarkdownToVueRenderFn(
   base = '/',
   includeLastUpdatedData = false,
   cleanUrls = false,
-  siteConfig: SiteConfig | null = null
+  siteConfig: SiteConfig
 ) {
-  const md = await createMarkdownRenderer(srcDir, options, base)
+  const md = await createMarkdownRenderer(
+    srcDir,
+    options,
+    base,
+    siteConfig.logger
+  )
   pages = pages.map((p) => slash(p.replace(/\.md$/, '')))
   const replaceRegex = genReplaceRegexp(userDefines, isBuild)
 
@@ -95,7 +100,7 @@ export async function createMarkdownToVueRenderFn(
     // validate data.links
     const deadLinks: string[] = []
     const recordDeadLink = (url: string) => {
-      console.warn(
+      siteConfig.logger.warn(
         c.yellow(
           `\n(!) Found dead link ${c.cyan(url)} in file ${c.white(
             c.dim(file)

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -1,19 +1,19 @@
+import { resolveTitleFromToken } from '@mdit-vue/shared'
+import _debug from 'debug'
 import fs from 'fs'
+import LRUCache from 'lru-cache'
 import path from 'path'
 import c from 'picocolors'
-import LRUCache from 'lru-cache'
-import { resolveTitleFromToken } from '@mdit-vue/shared'
 import type { SiteConfig } from './config'
-import { type PageData, type HeadConfig, EXTERNAL_URL_RE } from './shared'
-import { slash } from './utils/slash'
-import { getGitTimestamp } from './utils/getGitTimestamp'
 import {
   createMarkdownRenderer,
   type MarkdownEnv,
   type MarkdownOptions,
   type MarkdownRenderer
 } from './markdown'
-import _debug from 'debug'
+import { EXTERNAL_URL_RE, type HeadConfig, type PageData } from './shared'
+import { getGitTimestamp } from './utils/getGitTimestamp'
+import { slash } from './utils/slash'
 
 const debug = _debug('vitepress:md')
 const cache = new LRUCache<string, MarkdownCompileResult>({ max: 1024 })
@@ -39,13 +39,13 @@ export async function createMarkdownToVueRenderFn(
   base = '/',
   includeLastUpdatedData = false,
   cleanUrls = false,
-  siteConfig: SiteConfig
+  siteConfig: SiteConfig | null = null
 ) {
   const md = await createMarkdownRenderer(
     srcDir,
     options,
     base,
-    siteConfig.logger
+    siteConfig?.logger
   )
   pages = pages.map((p) => slash(p.replace(/\.md$/, '')))
   const replaceRegex = genReplaceRegexp(userDefines, isBuild)
@@ -100,7 +100,7 @@ export async function createMarkdownToVueRenderFn(
     // validate data.links
     const deadLinks: string[] = []
     const recordDeadLink = (url: string) => {
-      siteConfig.logger.warn(
+      ;(siteConfig?.logger ?? console).warn(
         c.yellow(
           `\n(!) Found dead link ${c.cyan(url)} in file ${c.white(
             c.dim(file)

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import c from 'picocolors'
+import type { OutputAsset, OutputChunk } from 'rollup'
 import {
   defineConfig,
   mergeConfig,
@@ -7,18 +8,17 @@ import {
   type Plugin,
   type ResolvedConfig
 } from 'vite'
-import type { SiteConfig } from './config'
-import { createMarkdownToVueRenderFn, clearCache } from './markdownToVue'
 import {
-  DIST_CLIENT_PATH,
   APP_PATH,
-  SITE_DATA_REQUEST_PATH,
-  resolveAliases
+  DIST_CLIENT_PATH,
+  resolveAliases,
+  SITE_DATA_REQUEST_PATH
 } from './alias'
-import { slash } from './utils/slash'
-import type { OutputAsset, OutputChunk } from 'rollup'
-import { staticDataPlugin } from './staticDataPlugin'
+import type { SiteConfig } from './config'
+import { clearCache, createMarkdownToVueRenderFn } from './markdownToVue'
 import type { PageDataPayload } from './shared'
+import { staticDataPlugin } from './staticDataPlugin'
+import { slash } from './utils/slash'
 import { webFontsPlugin } from './webFontsPlugin'
 
 const hashRE = /\.(\w+)\.js$/
@@ -295,7 +295,7 @@ export async function createVitePressPlugin(
             `${path.relative(
               process.cwd(),
               file
-            )} changed, restarting server...`
+            )} changed, restarting server...\n`
           ),
           { clear: true, timestamp: true }
         )
@@ -304,7 +304,7 @@ export async function createVitePressPlugin(
           await recreateServer?.()
         } catch (err) {
           siteConfig.logger.error(
-            c.red(`failed to restart server. error:\n${err}`)
+            c.red(`\nfailed to restart server. error:\n${err}`)
           )
         }
         return

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -290,19 +290,22 @@ export async function createVitePressPlugin(
     async handleHotUpdate(ctx) {
       const { file, read, server } = ctx
       if (file === configPath || configDeps.includes(file)) {
-        console.log(
+        siteConfig.logger.info(
           c.green(
-            `\n${path.relative(
+            `${path.relative(
               process.cwd(),
               file
             )} changed, restarting server...`
-          )
+          ),
+          { clear: true, timestamp: true }
         )
         try {
           clearCache()
           await recreateServer?.()
         } catch (err) {
-          console.error(c.red(`failed to restart server. error:\n`), err)
+          siteConfig.logger.error(
+            c.red(`failed to restart server. error:\n${err}`)
+          )
         }
         return
       }

--- a/src/node/serve/serve.ts
+++ b/src/node/serve/serve.ts
@@ -54,13 +54,15 @@ export async function serve(options: ServeOptions = {}) {
     return polka({ onNoMatch })
       .use(base, compress, serve)
       .listen(port, () => {
-        console.log(`Built site served at http://localhost:${port}/${base}/\n`)
+        site.logger.info(
+          `Built site served at http://localhost:${port}/${base}/\n`
+        )
       })
   } else {
     return polka({ onNoMatch })
       .use(compress, serve)
       .listen(port, () => {
-        console.log(`Built site served at http://localhost:${port}/\n`)
+        site.logger.info(`Built site served at http://localhost:${port}/\n`)
       })
   }
 }

--- a/src/node/serve/serve.ts
+++ b/src/node/serve/serve.ts
@@ -1,6 +1,6 @@
+import compression from 'compression'
 import fs from 'fs'
 import path from 'path'
-import compression from 'compression'
 import polka, { type IOptions } from 'polka'
 import sirv, { type RequestHandler } from 'sirv'
 import { resolveConfig } from '../config'
@@ -55,14 +55,14 @@ export async function serve(options: ServeOptions = {}) {
       .use(base, compress, serve)
       .listen(port, () => {
         site.logger.info(
-          `Built site served at http://localhost:${port}/${base}/\n`
+          `Built site served at http://localhost:${port}/${base}/`
         )
       })
   } else {
     return polka({ onNoMatch })
       .use(compress, serve)
       .listen(port, () => {
-        site.logger.info(`Built site served at http://localhost:${port}/\n`)
+        site.logger.info(`Built site served at http://localhost:${port}/`)
       })
   }
 }

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -21,8 +21,8 @@ export async function createServer(
     root: config.srcDir,
     base: config.site.base,
     cacheDir: config.cacheDir,
-    // logLevel: 'warn',
     plugins: await createVitePressPlugin(config, false, {}, {}, recreateServer),
-    server: serverOptions
+    server: serverOptions,
+    customLogger: config.logger
   })
 }


### PR DESCRIPTION
## Summary

use vite logger to replace console

## Features

1. clear screen when starting cli
2. replace logger output prefix `[vite]` to `[vitepress]`: `上午12:18:03 [vitepress] hmr update /index.md`
3. display timestamp when restarting server
4. respect logger options passing by `userconfig.vite`