### PR TITLE
fix(theme-default): remove duplicate judgments in the preconnect function

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -34,22 +34,20 @@ const preconnect = () => {
 
   const rIC = window.requestIdleCallback || setTimeout
   rIC(() => {
-    if (!theme.value.algolia || document.head.querySelector(`#${id}`)) return
-
     const preconnect = document.createElement('link')
     preconnect.id = id
     preconnect.rel = 'preconnect'
-    preconnect.href = `https://${theme.value.algolia.appId}-dsn.algolia.net`
+    preconnect.href = `https://${theme.value.algolia!.appId}-dsn.algolia.net`
     preconnect.crossOrigin = ''
     document.head.appendChild(preconnect)
   })
- }
+}
 
 onMounted(() => {
   if (!theme.value.algolia) {
     return
   }
-  
+
   preconnect()
 
   // meta key detect (same logic as in @docsearch/js)


### PR DESCRIPTION
* The `preconnect()` has been judged before calling, so there is no need to repeat the judgment
 ```js
onMounted(() => {
  if (!theme.value.algolia) {
    return
  }
  preconnect()
...
}
```

