### PR TITLE
docs: update github page actions setting in deploy.md

### DIFF
--- a/docs/guide/deploying.md
+++ b/docs/guide/deploying.md
@@ -81,6 +81,9 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
    jobs:
      deploy:
        runs-on: ubuntu-latest
+       permissions:
+         pages: write     
+         id-token: write 
        environment:
          name: github-pages
          url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
当我运行 文档中的 gitbub actions 配置得到下面的错误
![image](https://user-images.githubusercontent.com/37231473/218319688-9a82acc2-75b0-4716-9ed3-41c32c0b4f32.png)

查阅 [actions/deploy-pages@v1 的文档](https://github.com/actions/deploy-pages)
缺少如下配置：

![image](https://user-images.githubusercontent.com/37231473/218319773-4770ef6b-b397-49a8-9095-22ee61d8267b.png)
