### PR TITLE
docs(routing): correct "rewrites" examples

### DIFF
--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -125,8 +125,8 @@ You may configure the mapping via [`rewrites`](/config/app-configs#rewrites) opt
 ```ts
 export default {
   rewrites: {
-    'packages/pkg-a/src/pkg-a-code.md': 'pkg-a/pkg-a-code',
-    'packages/pkg-b/src/pkg-b-code.md': 'pkg-b/pkg-b-code'
+    'packages/pkg-a/src/pkg-a-code.md': 'pkg-a/pkg-a-code.md',
+    'packages/pkg-b/src/pkg-b-code.md': 'pkg-b/pkg-b-code.md'
   }
 }
 ```
@@ -156,8 +156,8 @@ export default {
 The above will create mapping as below.
 
 ```
-packages/pkg-a/src/pkg-a-code.md  -> /pkg-a/pkg-a-code
-packages/pkg-b/src/folder/file.md -> /pkg-b/folder/file
+packages/pkg-a/src/pkg-a-code.md  -> /pkg-a/pkg-a-code.md
+packages/pkg-b/src/folder/file.md -> /pkg-b/folder/file.md
 ```
 
 ::: warning You need server restart on page addition


### PR DESCRIPTION
The destination values of "rewrites" examples of static mappings should end with ".md"

For the static example of "rewrites" in "Customize the Mappings" part, the desired mappings are:

```txt
packages/pkg-a/src/pkg-a-code.md -> /pkg-a/pkg-a-code.md
packages/pkg-b/src/pkg-b-code.md -> /pkg-b/pkg-b-code.md
``` 

And the original example is as below:

```js
export default {
  rewrites: {
    'packages/pkg-a/src/pkg-a-code.md': 'pkg-a/pkg-a-code',
    'packages/pkg-b/src/pkg-b-code.md': 'pkg-b/pkg-b-code'
  }
}
```

It will generate two wrong mappings:

```txt
packages/pkg-a/src/pkg-a-code.md -> /pkg-a/pkg-a-code
packages/pkg-b/src/pkg-b-code.md -> /pkg-b/pkg-b-code
```

When you access a URL like `https://localhost:9527/pkg-a/pkg-a-code` in the browser you will get the **raw markdown content** instead of a rendered page of `packages/pkg-a/src/pkg-a-code.md`, which is not desired.