### PR TITLE
fix(theme): sidebar icon and text inline

### DIFF
--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -118,6 +118,7 @@ function onCaretClick() {
 }
 
 .text {
+  display: inline-block;
   flex-grow: 1;
   padding: 4px 0;
   line-height: 24px;


### PR DESCRIPTION
Currently, icons and text for external links in the sidebar are displayed on multiple lines.
check [VueUse docs](https://vueuse.org/math/useTrunc/)
![image](https://user-images.githubusercontent.com/54026110/219948559-7d728f9a-1552-497b-b284-749828f40420.png)
