### PR TITLE
fix: allow to use language page without ending slash

### DIFF
--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -41,6 +41,10 @@ export function isActive(
 
   currentPath = normalize(`/${currentPath}`)
 
+  if (currentPath === matchPath.replace(/\/$/, '')) {
+    return true
+  }
+
   if (asRegex) {
     return new RegExp(matchPath).test(currentPath)
   }


### PR DESCRIPTION
Expected behavior for a developer:

`site.com/zh/some-page` - Chinese page
`site.com/zh/` - Chinese page
`site.com/zh` - Chinese page
`site.com/zhezhezhe` - English (or other) page

Closes #2001