### PR TITLE
docs: update home layout slots of the docs

### DIFF
--- a/docs/guide/customization-intro.md
+++ b/docs/guide/customization-intro.md
@@ -212,6 +212,7 @@ Full list of slots available in the default theme layout:
   - `aside-ads-after`
 - When `layout: 'home'` is enabled via frontmatter:
   - `home-hero-before`
+  - `home-hero-info`
   - `home-hero-image`
   - `home-hero-after`
   - `home-features-before`


### PR DESCRIPTION


I observed that the default theme updated the slot of the home layout ([996a5f4](https://github.com/vuejs/vitepress/commit/996a5f47e9064da839aef9e81db22db70fa8d76d)), but did not update the document synchronously.

At present, `/src/client/theme-default/components/VPHome.vue` code is as follows:

https://github.com/vuejs/vitepress/blob/996a5f47e9064da839aef9e81db22db70fa8d76d/src/client/theme-default/components/VPHome.vue#L6-L21

The changes are as follows:

```diff
# File path: docs/guide/customization-intro.md
   - When `layout: 'home'` is enabled via frontmatter:
    - `home-hero-before`
+   - `home-hero-info`
    - `home-hero-image`
    - `home-hero-after`
    - `home-features-before`
    - `home-features-after`
```