### PR TITLE
fix(theme): remove `VPTeamMembers` some styles

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -507,18 +507,3 @@
 .vp-doc .VPTeamMembers {
   margin-top: 24px;
 }
-
-.vp-doc .VPTeamMembers.small.count-1 .container {
-  margin: 0 !important;
-  max-width: calc((100% - 24px) / 2) !important;
-}
-
-.vp-doc .VPTeamMembers.small.count-2 .container,
-.vp-doc .VPTeamMembers.small.count-3 .container {
-  max-width: 100% !important;
-}
-
-.vp-doc .VPTeamMembers.medium.count-1 .container {
-  margin: 0 !important;
-  max-width: calc((100% - 24px) / 2) !important;
-}


### PR DESCRIPTION
I tested locally that when the number of `VPTeamMembers` components is less than 3, using a `max-width: 100% !important;` will cause the components to overflow the width of the container. And use `margin: 0` which breaks the centered style of the component.

| Count | Preview Before | Preview After |
| -- | -- | -- |
| 3 | <img width="1469" alt="image" src="https://user-images.githubusercontent.com/42139754/222959623-8f552cca-f773-418c-8a8e-88dbbd849081.png"> |  <img width="1160" alt="image" src="https://user-images.githubusercontent.com/42139754/222959677-aae503d0-321d-43c3-b1f4-c202082a289f.png"> |
| 2 |  <img width="1494" alt="image" src="https://user-images.githubusercontent.com/42139754/222959760-b8ee6c1d-7e66-4bc0-9071-2b69dd4d5a75.png">  |  <img width="925" alt="image" src="https://user-images.githubusercontent.com/42139754/222959731-b754e646-fdba-43b3-98c3-8c2c52389592.png"> |
| 1 | <img width="1032" alt="image" src="https://user-images.githubusercontent.com/42139754/222959787-0d075c31-45d7-4143-b179-1acbb6bba6ec.png"> | <img width="752" alt="image" src="https://user-images.githubusercontent.com/42139754/222959805-fd724f71-72b7-4783-98e7-033b533b9672.png"> |
