### PR TITLE
docs: fix style module example

### DIFF
--- a/docs/guide/using-vue.md
+++ b/docs/guide/using-vue.md
@@ -53,7 +53,7 @@ const count = ref(0)
 
 The count is: {{ count }}
 
-<button :class="$style.module" @click="count++">Increment</button>
+<button :class="$style.button" @click="count++">Increment</button>
 
 <style module>
 .button {


### PR DESCRIPTION
The <style module/> example wasn't working. 
Changing the class binding to $style.button fixes this problem.

Thanks!