### PR TITLE
Fix/ssr hydrate

### DIFF
--- a/docs/guide/extending-default-theme.md
+++ b/docs/guide/extending-default-theme.md
@@ -53,6 +53,32 @@ export default {
 
 Since we are using Vite, you can also leverage Vite's [glob import feature](https://vitejs.dev/guide/features.html#glob-import) to auto register a directory of components.
 
+## Overriding Internal Components
+
+You can use Vite's [aliases](https://vitejs.dev/config/shared-options.html#resolve-alias) to replace certain components with your custom ones:
+
+```ts
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  vite: {
+    resolve: {
+      alias: [
+        {
+          find: /^.*\/VPNavBar\.vue$/,
+          replacement: fileURLToPath(
+            new URL('./components/CustomNavBar.vue', import.meta.url)
+          )
+        }
+      ]
+    }
+  }
+})
+```
+
+To know the exact name of the component refer [our source code](https://github.com/vuejs/vitepress/tree/main/src/client/theme-default/components). Since the components are internal, there is a slight change their name is updated between minor releases.
+
 ## Layout Slots
 
 The default theme's `<Layout/>` component has a few slots that can be used to inject content at certain locations of the page. Here's an example of injecting a component into the before outline:

--- a/docs/guide/extending-default-theme.md
+++ b/docs/guide/extending-default-theme.md
@@ -53,32 +53,6 @@ export default {
 
 Since we are using Vite, you can also leverage Vite's [glob import feature](https://vitejs.dev/guide/features.html#glob-import) to auto register a directory of components.
 
-## Overriding Internal Components
-
-You can use Vite's [aliases](https://vitejs.dev/config/shared-options.html#resolve-alias) to replace certain components with your custom ones:
-
-```ts
-import { fileURLToPath, URL } from 'node:url'
-import { defineConfig } from 'vitepress'
-
-export default defineConfig({
-  vite: {
-    resolve: {
-      alias: [
-        {
-          find: /^.*\/VPNavBar\.vue$/,
-          replacement: fileURLToPath(
-            new URL('./components/CustomNavBar.vue', import.meta.url)
-          )
-        }
-      ]
-    }
-  }
-})
-```
-
-To know the exact name of the component refer [our source code](https://github.com/vuejs/vitepress/tree/main/src/client/theme-default/components). Since the components are internal, there is a slight change their name is updated between minor releases.
-
 ## Layout Slots
 
 The default theme's `<Layout/>` component has a few slots that can be used to inject content at certain locations of the page. Here's an example of injecting a component into the before outline:

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@docsearch/js": "^3.3.3",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vue/devtools-api": "^6.5.0",
+    "@vue/shared": "^3.2.47",
     "@vueuse/core": "^9.13.0",
     "body-scroll-lock": "4.0.0-beta.0",
     "shiki": "^0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,7 @@ importers:
       '@types/prompts': ^2.4.2
       '@vitejs/plugin-vue': ^4.0.0
       '@vue/devtools-api': ^6.5.0
+      '@vue/shared': ^3.2.47
       '@vueuse/core': ^9.13.0
       body-scroll-lock: 4.0.0-beta.0
       chokidar: ^3.5.3
@@ -93,6 +94,7 @@ importers:
       '@docsearch/js': 3.3.3
       '@vitejs/plugin-vue': 4.0.0_vite@4.1.4+vue@3.2.47
       '@vue/devtools-api': 6.5.0
+      '@vue/shared': 3.2.47
       '@vueuse/core': 9.13.0_vue@3.2.47
       body-scroll-lock: 4.0.0-beta.0
       shiki: 0.14.1

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { DirectiveBinding } from 'vue'
+import { normalizeClass } from '@vue/shared'
 import type { DefaultTheme } from 'vitepress/theme'
 import { useSidebarControl } from '../composables/sidebar.js'
 import VPIconChevronRight from './icons/VPIconChevronRight.vue'
@@ -33,13 +35,19 @@ const textTag = computed(() => {
 const itemRole = computed(() => isLink.value ? undefined : 'button')
 
 const classes = computed(() => [
-  [`level-${props.depth}`],
+  ['VPSidebarItem', `level-${props.depth}`],
   { collapsible: collapsible.value },
   { collapsed: collapsed.value },
   { 'is-link': isLink.value },
   { 'is-active': isActiveLink.value },
   { 'has-active': hasActiveLink.value }
 ])
+
+// skip vue ssr hydrate optimizations
+// See: https://github.com/vuejs/core/issues/6246#issuecomment-1179711088
+const vClass = (el: HTMLElement, binding: DirectiveBinding) => {
+  el.className = normalizeClass(binding.value)
+}
 
 function onItemClick() {
   !props.item.link && toggle()
@@ -51,7 +59,7 @@ function onCaretClick() {
 </script>
 
 <template>
-  <component :is="sectionTag" class="VPSidebarItem" :class="classes">
+  <component :is="sectionTag" v-class="classes">
     <div v-if="item.text" class="item" :role="itemRole" @click="onItemClick">
       <div class="indicator" />
 


### PR DESCRIPTION
**Problem:**

When you refresh the example page of the Vue docs web page, its left navigation is not highlighted.

The reason is because SSR Hydrate did not update the class correctly.

Here is the vue docs page: [https://cn.vuejs.org/examples/#hello-world](https://cn.vuejs.org/examples/#hello-world)