### PR TITLE
fix(highlight): skip warning for `txt` language

### DIFF
--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -97,7 +97,7 @@ export async function highlight(
 
     if (lang) {
       const langLoaded = highlighter.getLoadedLanguages().includes(lang as any)
-      if (!langLoaded && lang !== 'ansi') {
+      if (!langLoaded && lang !== 'ansi' && lang !== 'txt') {
         logger.warn(
           c.yellow(
             `\nThe language '${lang}' is not loaded, falling back to '${


### PR DESCRIPTION
Skip logging a warning when trying to highlight a Markdown code-block that has the language `txt`, e.g.

````markdown
```txt
Hello world!
```
````

Otherwise we get a warning when running `vitepress build docs` that says:

> The language 'txt' is not loaded, falling back to 'txt' for syntax highlighting.