### PR TITLE
feat: more flexible `ignoreDeadLinks`

### DIFF
--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -300,15 +300,15 @@ It can also be an array of extact url string, regex patterns, or custom filter f
 ```ts
 export default {
   ignoreDeadLinks: [
-    // exact url
+    // ignore exact url "/playground"
     '/playground',
-    // all localhost links
+    // ignore all localhost links
     /^https?:\/\/localhost/,
-    // all links include `/repl/`
+    // ignore all links include "/repl/""
     /\/repl\//,
-    // custom function, return true to ignore
+    // custom function, ignore all links include "ignore"
     (url) => {
-      return url.includes('ignore'
+      return url.toLowerCase().includes('ignore')
     }
   ]
 }

--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -282,14 +282,35 @@ export default {
 
 ### ignoreDeadLinks
 
-- Type: `boolean | 'localhostLinks'`
+- Type: `boolean | 'localhostLinks' | (string | RegExp | ((link: string) => boolean))[]`
 - Default: `false`
 
-When set to `true`, VitePress will not fail builds due to dead links. When set to `'localhostLinks'`, the build will fail on dead links, but won't check `localhost` links.
+When set to `true`, VitePress will not fail builds due to dead links.
+
+When set to `'localhostLinks'`, the build will fail on dead links, but won't check `localhost` links.
 
 ```ts
 export default {
   ignoreDeadLinks: true
+}
+```
+
+It can also be an array of extact url string, regex patterns, or custom filter functions. 
+
+```ts
+export default {
+  ignoreDeadLinks: [
+    // exact url
+    '/playground',
+    // all localhost links
+    /^https?:\/\/localhost/,
+    // all links include `/repl/`
+    /\/repl\//,
+    // custom function, return true to ignore
+    (url) => {
+      return url.includes('ignore'
+    }
+  ]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-alpha.62",
   "description": "Vite & Vue powered static site generator",
   "type": "module",
-  "packageManager": "pnpm@7.30.0",
+  "packageManager": "pnpm@7.30.3",
   "main": "dist/node/index.js",
   "types": "types/index.d.ts",
   "exports": {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -85,7 +85,10 @@ export interface UserConfig<ThemeConfig = any>
    *
    * @default false
    */
-  ignoreDeadLinks?: boolean | 'localhostLinks' | (string | RegExp | ((link: string) => boolean))[]
+  ignoreDeadLinks?:
+    | boolean
+    | 'localhostLinks'
+    | (string | RegExp | ((link: string) => boolean))[]
 
   /**
    * Don't force `.html` on URLs.

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -85,7 +85,7 @@ export interface UserConfig<ThemeConfig = any>
    *
    * @default false
    */
-  ignoreDeadLinks?: boolean | 'localhostLinks'
+  ignoreDeadLinks?: boolean | 'localhostLinks' | (string | RegExp | ((link: string) => boolean))[]
 
   /**
    * Don't force `.html` on URLs.

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -126,21 +126,26 @@ export async function createMarkdownToVueRenderFn(
     }
 
     function shouldIgnoreDeadLink(url: string) {
-      if (!(siteConfig?.ignoreDeadLinks))
+      if (!siteConfig?.ignoreDeadLinks) {
         return false
-      if (siteConfig.ignoreDeadLinks === true)
+      }
+      if (siteConfig.ignoreDeadLinks === true) {
         return true
-
-      if (siteConfig.ignoreDeadLinks === 'localhostLinks')
+      }
+      if (siteConfig.ignoreDeadLinks === 'localhostLinks') {
         return url.replace(EXTERNAL_URL_RE, '').startsWith('//localhost')
-      
+      }
+
       return siteConfig.ignoreDeadLinks.some((ignore) => {
-        if (typeof ignore === 'string')
+        if (typeof ignore === 'string') {
           return url === ignore
-        if (ignore instanceof RegExp)
+        }
+        if (ignore instanceof RegExp) {
           return ignore.test(url)
-        if (typeof ignore === 'function')
+        }
+        if (typeof ignore === 'function') {
           return ignore(url)
+        }
         return false
       })
     }

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -125,15 +125,32 @@ export async function createMarkdownToVueRenderFn(
       deadLinks.push(url)
     }
 
+    function shouldIgnoreDeadLink(url: string) {
+      if (!(siteConfig?.ignoreDeadLinks))
+        return false
+      if (siteConfig.ignoreDeadLinks === true)
+        return true
+
+      if (siteConfig.ignoreDeadLinks === 'localhostLinks')
+        return url.replace(EXTERNAL_URL_RE, '').startsWith('//localhost')
+      
+      return siteConfig.ignoreDeadLinks.some((ignore) => {
+        if (typeof ignore === 'string')
+          return url === ignore
+        if (ignore instanceof RegExp)
+          return ignore.test(url)
+        if (typeof ignore === 'function')
+          return ignore(url)
+        return false
+      })
+    }
+
     if (links) {
       const dir = path.dirname(file)
       for (let url of links) {
         if (/\.(?!html|md)\w+($|\?)/i.test(url)) continue
 
-        if (
-          siteConfig?.ignoreDeadLinks !== 'localhostLinks' &&
-          url.replace(EXTERNAL_URL_RE, '').startsWith('//localhost:')
-        ) {
+        if (!shouldIgnoreDeadLink(url)) {
           recordDeadLink(url)
           continue
         }

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -155,11 +155,6 @@ export async function createMarkdownToVueRenderFn(
       for (let url of links) {
         if (/\.(?!html|md)\w+($|\?)/i.test(url)) continue
 
-        if (!shouldIgnoreDeadLink(url)) {
-          recordDeadLink(url)
-          continue
-        }
-
         url = url.replace(/[?#].*$/, '').replace(/\.(html|md)$/, '')
         if (url.endsWith('/')) url += `index`
         let resolved = decodeURIComponent(
@@ -173,7 +168,8 @@ export async function createMarkdownToVueRenderFn(
           siteConfig?.rewrites.inv[resolved + '.md']?.slice(0, -3) || resolved
         if (
           !pages.includes(resolved) &&
-          !fs.existsSync(path.resolve(dir, publicDir, `${resolved}.html`))
+          !fs.existsSync(path.resolve(dir, publicDir, `${resolved}.html`)) &&
+          !shouldIgnoreDeadLink(url)
         ) {
           recordDeadLink(url)
         }

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -70,7 +70,6 @@ export async function createVitePressPlugin(
     vue: userVuePluginOptions,
     vite: userViteConfig,
     pages,
-    ignoreDeadLinks,
     lastUpdated,
     cleanUrls
   } = siteConfig
@@ -195,7 +194,7 @@ export async function createVitePressPlugin(
     },
 
     renderStart() {
-      if (hasDeadLinks && ignoreDeadLinks !== true) {
+      if (hasDeadLinks) {
         throw new Error(`One or more pages contain dead links.`)
       }
     },

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -195,7 +195,7 @@ export async function createVitePressPlugin(
     },
 
     renderStart() {
-      if (hasDeadLinks && !ignoreDeadLinks) {
+      if (hasDeadLinks && ignoreDeadLinks !== true) {
         throw new Error(`One or more pages contain dead links.`)
       }
     },


### PR DESCRIPTION
Sometimes user might have custom routes, custom subpath site, etc, which is out of the awareness of VitePress to consider as "Dead link". The current `false | true | 'localhostLinks'` option is a bit too extreme. Forcing those cases to disable the dead links check completely.

This PR adds more fine-grain control over them to make exceptions. 