### PR TITLE
fix(theme): remove label background of code-group tabs

### DIFF
--- a/src/client/theme-default/styles/components/vp-code-group.css
+++ b/src/client/theme-default/styles/components/vp-code-group.css
@@ -46,7 +46,6 @@
   font-size: 14px;
   font-weight: 500;
   color: var(--vp-code-tab-text-color);
-  background-color: var(--vp-code-tab-bg);
   white-space: nowrap;
   cursor: pointer;
   transition: color 0.25s;


### PR DESCRIPTION
If you set a semi-transparent color to it:

```css
:root {
  --vp-code-block-bg: rgba(0,0,0,0.2);
}
```

The background overlaps:

<img width="320" alt="image" src="https://user-images.githubusercontent.com/11247099/227734126-c3d87811-74e6-4819-adb0-50efcdb7b4e3.png">

This is because `.vp-code-group .tabs` already set the background color, where `.vp-code-group .tabs label` duplicated that.
