### PR TITLE
feat: support markdown color preview

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -115,6 +115,19 @@
   font-weight: 600;
 }
 
+.vp-doc .color-swatch {
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  min-width: 12px;
+  min-height: 12px;
+  font-size: inherit;
+  border: 0;
+  border-radius: 2px;
+  margin: 0 3px 0 6px;
+  cursor: pointer;
+}
+
 /**
  * Lists
  * -------------------------------------------------------------------------- */

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -25,6 +25,7 @@ import { lineNumberPlugin } from './plugins/lineNumbers'
 import { linkPlugin } from './plugins/link'
 import { preWrapperPlugin } from './plugins/preWrapper'
 import { snippetPlugin } from './plugins/snippet'
+import { colorPreviewPlugin } from './plugins/colorPreview'
 
 export type { Header } from '../shared'
 
@@ -89,6 +90,7 @@ export const createMarkdownRenderer = async (
       base
     )
     .use(lineNumberPlugin, options.lineNumbers)
+    .use(colorPreviewPlugin)
 
   // 3rd party plugins
   if (!options.attrs?.disable) {

--- a/src/node/markdown/plugins/colorPreview.ts
+++ b/src/node/markdown/plugins/colorPreview.ts
@@ -22,8 +22,7 @@ export const colorPreviewPlugin = (md: MarkdownIt) => {
 
   md.renderer.rules.text = (tokens, idx) => {
     let text = tokens[idx].content
-    text = text.replace(COLOR_REGEX, replaceColor)
-
-    return text
+    text = md.utils.escapeHtml(text)
+    return text.replace(COLOR_REGEX, replaceColor)
   }
 }

--- a/src/node/markdown/plugins/colorPreview.ts
+++ b/src/node/markdown/plugins/colorPreview.ts
@@ -1,0 +1,29 @@
+import type MarkdownIt from 'markdown-it'
+
+const COLOR_REGEX =
+  /(?:\s|^)(#(?:[a-fA-F0-9]{3}){1,2}|(?:#(?:[a-fA-F0-9]{4}){1,2})?\b|rgba?\(\d+,\s*\d+,\s*\d+(?:,\s*\d+(?:\.\d+)?)?\)|hsla?\(\d+,\s*\d+%?,\s*\d+%?,?\s*(?:,\s*\d+(?:\.\d+)?)?\))(?:[^#a-zA-Z0-9]|$)/g
+
+export const colorPreviewPlugin = (md: MarkdownIt) => {
+  const replaceColor = (colorStr: string) => {
+    colorStr = colorStr.trim()
+    let color = colorStr.replace(/\P{ASCII}\p{Nd}/gu, '')
+
+    if (color.charAt(0) === '#') {
+      color = color.replace(/[^#0-9a-fA-F]/g, '')
+    } else {
+      let index = color.lastIndexOf(')')
+      if (index !== -1) {
+        color = color.slice(0, index + 1)
+      }
+    }
+
+    return `<span class='color-swatch' style='background-color: ${color}'></span>${colorStr} `
+  }
+
+  md.renderer.rules.text = (tokens, idx) => {
+    let text = tokens[idx].content
+    text = text.replace(COLOR_REGEX, replaceColor)
+
+    return text
+  }
+}


### PR DESCRIPTION
🎉 Hey there! Maintainers and Creators, I hope to kindly request that you consider this PR, as it offers high practicality and usefulness in various use cases.
### Description
This PR adds a new plugin for Vitepress. This plugin will automatically add a preview color palette of the current color value in front of color values that appear in the document.

### Features
- Requires no additional effort from the document author to generate color previews.
- Improves ` readability ` and `visual appeal` of documents.
- Offers a more simple and intuitive way to display color preview for color values in Markdown documents.
- Allows users to turn off the color preview feature or customize the appearance of the color boxes.
- Support  `RGB`, `HEX`,  `RGBA`,  `HSL`,  `HSLA` format recognition

### Tips for Use

```js
the #165DFF color formt is used as an example.
```
<img width="419" alt="image" src="https://user-images.githubusercontent.com/48879481/228605491-8df8bc4c-b347-45cb-9fee-3389c4787ab9.png">

1. The color preview feature is enabled by default in compliance with Markdown formatting conventions. This improves document readability by indicating color values to readers, which plain text alone cannot convey. 
2. To disable the feature, add "``" to exclude specific color values or overriding its styles.

<img width="803" alt="iShot_2023-03-29_22 53 36" src="https://user-images.githubusercontent.com/48879481/228606245-aa9de9da-5939-421d-a730-b5706ff4a506.png">
