### PR TITLE
fix(theme): fix color of blockquote in custom containers

### DIFF
--- a/src/client/theme-default/styles/components/custom-block.css
+++ b/src/client/theme-default/styles/components/custom-block.css
@@ -16,6 +16,7 @@
 .custom-block.info th,
 .custom-block.info blockquote > p {
   color: var(--vp-custom-block-info-text);
+  font-size: 14px;
 }
 
 .custom-block.info code {
@@ -31,6 +32,7 @@
 .custom-block.tip th,
 .custom-block.tip blockquote > p {
   color: var(--vp-custom-block-tip-text);
+  font-size: 14px;
 }
 
 .custom-block.tip code {
@@ -46,6 +48,7 @@
 .custom-block.warning th,
 .custom-block.warning blockquote > p {
   color: var(--vp-custom-block-warning-text);
+  font-size: 14px;
 }
 
 .custom-block.warning code {
@@ -61,6 +64,7 @@
 .custom-block.danger th,
 .custom-block.danger blockquote > p {
   color: var(--vp-custom-block-danger-text);
+  font-size: 14px;
 }
 
 .custom-block.danger code {
@@ -76,6 +80,7 @@
 .custom-block.details th,
 .custom-block.details blockquote > p {
   color: var(--vp-custom-block-details-text);
+  font-size: 14px;
 }
 
 .custom-block.details code {

--- a/src/client/theme-default/styles/components/custom-block.css
+++ b/src/client/theme-default/styles/components/custom-block.css
@@ -13,7 +13,8 @@
   background-color: var(--vp-custom-block-info-bg);
 }
 
-.custom-block.info th {
+.custom-block.info th,
+.custom-block.info blockquote > p {
   color: var(--vp-custom-block-info-text);
 }
 
@@ -27,7 +28,8 @@
   background-color: var(--vp-custom-block-tip-bg);
 }
 
-.custom-block.tip th {
+.custom-block.tip th,
+.custom-block.tip blockquote > p {
   color: var(--vp-custom-block-tip-text);
 }
 
@@ -41,7 +43,8 @@
   background-color: var(--vp-custom-block-warning-bg);
 }
 
-.custom-block.warning th {
+.custom-block.warning th,
+.custom-block.warning blockquote > p {
   color: var(--vp-custom-block-warning-text);
 }
 
@@ -55,7 +58,8 @@
   background-color: var(--vp-custom-block-danger-bg);
 }
 
-.custom-block.danger th {
+.custom-block.danger th,
+.custom-block.danger blockquote > p {
   color: var(--vp-custom-block-danger-text);
 }
 
@@ -69,7 +73,8 @@
   background-color: var(--vp-custom-block-details-bg);
 }
 
-.custom-block.details th {
+.custom-block.details th,
+.custom-block.details blockquote > p {
   color: var(--vp-custom-block-details-text);
 }
 

--- a/src/client/theme-default/styles/components/custom-block.css
+++ b/src/client/theme-default/styles/components/custom-block.css
@@ -13,10 +13,10 @@
   background-color: var(--vp-custom-block-info-bg);
 }
 
-.custom-block.info th,
-.custom-block.info blockquote > p {
-  color: var(--vp-custom-block-info-text);
-  font-size: 14px;
+.custom-block.custom-block th,
+.custom-block.custom-block blockquote > p {
+  font-size: var(--vp-custom-block-font-size);
+  color: inherit;
 }
 
 .custom-block.info code {
@@ -29,12 +29,6 @@
   background-color: var(--vp-custom-block-tip-bg);
 }
 
-.custom-block.tip th,
-.custom-block.tip blockquote > p {
-  color: var(--vp-custom-block-tip-text);
-  font-size: 14px;
-}
-
 .custom-block.tip code {
   background-color: var(--vp-custom-block-tip-code-bg);
 }
@@ -43,12 +37,6 @@
   border-color: var(--vp-custom-block-warning-border);
   color: var(--vp-custom-block-warning-text);
   background-color: var(--vp-custom-block-warning-bg);
-}
-
-.custom-block.warning th,
-.custom-block.warning blockquote > p {
-  color: var(--vp-custom-block-warning-text);
-  font-size: 14px;
 }
 
 .custom-block.warning code {
@@ -61,12 +49,6 @@
   background-color: var(--vp-custom-block-danger-bg);
 }
 
-.custom-block.danger th,
-.custom-block.danger blockquote > p {
-  color: var(--vp-custom-block-danger-text);
-  font-size: 14px;
-}
-
 .custom-block.danger code {
   background-color: var(--vp-custom-block-danger-code-bg);
 }
@@ -75,12 +57,6 @@
   border-color: var(--vp-custom-block-details-border);
   color: var(--vp-custom-block-details-text);
   background-color: var(--vp-custom-block-details-bg);
-}
-
-.custom-block.details th,
-.custom-block.details blockquote > p {
-  color: var(--vp-custom-block-details-text);
-  font-size: 14px;
 }
 
 .custom-block.details code {


### PR DESCRIPTION
Similar bug to https://github.com/vuejs/vitepress/issues/2077 . Appeared in `blockquote` in custom containers this time.

![afe8b4a2dccc78454beac4233494877](https://user-images.githubusercontent.com/44596995/229011917-301ec9ec-285c-4e51-a2df-4733f5f7450e.png)
