### PR TITLE
feat(lastUpdate): Added option to specify desired date format.

### DIFF
--- a/docs/reference/default-theme-config.md
+++ b/docs/reference/default-theme-config.md
@@ -304,6 +304,21 @@ export default {
 }
 ```
 
+## lastUpdatedFormat
+
+- Type: `string`
+- Default: `null`
+
+The string to be applied to format last updated time using [VueUse/useDateFormat](https://vueuse.org/shared/useDateFormat/).
+
+```ts
+export default {
+  themeConfig: {
+    latdUpdatedFormat: 'DD/MM/YYYY HH:mm:ss'
+  }
+}
+```
+
 ## algolia
 
 - Type: `AlgoliaSearch`

--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -343,7 +343,7 @@ This option injects an inline script that restores users settings from local sto
 
 Whether to get the last updated timestamp for each page using Git. The timestamp will be included in each page's page data, accessible via [`useData`](./runtime-api#usedata).
 
-When using the default theme, enabling this option will display each page's last updated time. You can customize the text via [`themeConfig.lastUpdatedText`](./default-theme-config#lastupdatedtext) option.
+When using the default theme, enabling this option will display each page's last updated time. You can customize the text via [`themeConfig.lastUpdatedText`](./default-theme-config#lastupdatedtext) option and the format via [`themeConfig.lastUpdatedFormat`](./default-theme-config#lastupdatedformat) option.
 
 ## Customization
 

--- a/src/client/theme-default/components/VPDocFooterLastUpdated.vue
+++ b/src/client/theme-default/components/VPDocFooterLastUpdated.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { ref, computed, watchEffect, onMounted } from 'vue'
 import { useData } from '../composables/data'
+import { useDateFormat } from '@vueuse/core';
 
 const { theme, page, lang } = useData()
 
 const date = computed(() => new Date(page.value.lastUpdated!))
 const isoDatetime = computed(() => date.value.toISOString())
 const datetime = ref('')
+const formatedDate = useDateFormat(datetime, theme.value.lastUpdatedFormat, {locales: lang.value})
 
 // set time on mounted hook to avoid hydration mismatch due to
 // potential differences in timezones of the server and clients
@@ -20,7 +22,8 @@ onMounted(() => {
 <template>
   <p class="VPLastUpdated">
     {{ theme.lastUpdatedText || 'Last updated' }}:
-    <time :datetime="isoDatetime">{{ datetime }}</time>
+    <time v-if="!theme.lastUpdatedFormat" :datetime="isoDatetime">{{ datetime }}</time>
+    <time v-else :datetime="isoDatetime">{{ formatedDate }}</time>
   </p>
 </template>
 

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -63,6 +63,13 @@ export namespace DefaultTheme {
     lastUpdatedText?: string
 
     /**
+     * Set custom last updated data format.
+     *
+     * @default 'Last updated'
+     */
+    lastUpdatedFormat?: string
+
+    /**
      * Set custom prev/next labels.
      */
     docFooter?: DocFooter


### PR DESCRIPTION
When you write documentation in Spanish, French or any language that has different "date formats", it's very confusing the date that is displayed without this PR.

For exemple, as per today, you can see the *Last updated* as: `4/3/2023, 15:00`

If the target people of the documentation is not from an English-spoken country, they will think that de documentation was written the past month.

This PR is brings the possibility of specifying a *date format* to the `lastUpdated` option. That's useful in *non-english*  language.