### PR TITLE
feat: allow configuring light theme codeblocks

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   title: 'VitePress',
   description: 'Vite & Vue powered static site generator.',
 
+  //TODO: remove this once ready
+  preserveCodeAppearance: true,
   lastUpdated: true,
   cleanUrls: true,
 

--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -351,20 +351,20 @@ export default {
 }
 ```
 
-//TODO: update the light theme when updated node/config.ts entry
-
-VitePress will use `material-theme-palenight` and `github-light` Shiki themes for the dark and light appearance respectively. You can replace both themes by providing the Shiki theme variants in the markdown settings option:
+VitePress will use `github-dark` and `github-light` Shiki themes for the dark and light appearance respectively. You can replace both themes by providing the Shiki theme variants in the markdown settings option:
 ```ts
 export default {
   preserveCodeAppearance: true,
   markdown: {
     theme: {
-      dark: 'material-theme-palenight',
+      dark: 'github-dark',
       light: 'github-light'
     }  
   }
 }
 ```
+
+You can check [Shiki Themes](https://github.com/shikijs/shiki/blob/main/docs/themes.md#all-themes) for more information.
 
 ### lastUpdated
 

--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -336,6 +336,36 @@ Whether to enable dark mode (by adding the `.dark` class to the `<html>` element
 
 This option injects an inline script that restores users settings from local storage using the `vitepress-theme-appearance` key. This ensures the `.dark` class is applied before the page is rendered to avoid flickering.
 
+### preserveCodeAppearance
+
+- Type: `boolean`
+- Default: `false`
+
+By default, VitePress will use dark appearance for code blocks independently of the current selected appearance and the user's preference.
+
+You can disable this behavior by setting `preserveCodeAppearance` option to `true`, which will use the same appearance for code blocks as the current selected appearance.
+
+```ts
+export default {
+  preserveCodeAppearance: true
+}
+```
+
+//TODO: update the light theme when updated node/config.ts entry
+
+VitePress will use `material-theme-palenight` and `github-light` Shiki themes for the dark and light appearance respectively. You can replace both themes by providing the Shiki theme variants in the markdown settings option:
+```ts
+export default {
+  preserveCodeAppearance: true,
+  markdown: {
+    theme: {
+      dark: 'material-theme-palenight',
+      light: 'github-light'
+    }  
+  }
+}
+```
+
 ### lastUpdated
 
 - Type: `boolean`

--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -240,8 +240,29 @@
   --vp-code-tab-active-bar-color: var(--vp-c-brand);
 }
 
+.preserve-code-appearance {
+  --vp-code-block-color: var(--vp-c-text-1);
+  --vp-code-block-bg: rgba(125, 125, 125, 0.04);
+  --vp-code-tab-divider: var(--vp-c-divider);
+  --vp-code-copy-code-bg: rgba(125, 125, 125, 0.1);
+  --vp-code-copy-code-hover-bg: rgba(125, 125, 125, 0.2);
+  --vp-code-tab-text-color: var(--vp-c-text-2);
+  --vp-code-tab-active-text-color: var(--vp-c-text-1);
+  --vp-code-tab-hover-text-color: var(--vp-c-text-1);
+  --vp-code-copy-code-active-text: var(--vp-c-text-2);
+  --vp-c-text-dark-3: rgba(56, 56, 56, 0.8);
+}
+
 .dark {
   --vp-code-block-bg: #161618;
+}
+
+.dark.preserve-code-appearance {
+  --vp-code-tab-text-color: var(--vp-c-text-dark-2);
+  --vp-code-tab-active-text-color: var(--vp-c-text-dark-1);
+  --vp-code-tab-hover-text-color: var(--vp-c-text-dark-1);
+  --vp-code-copy-code-active-text: var(--vp-c-text-dark-2);
+  --vp-c-text-dark-3: var(--vp-c-text-dark-2);
 }
 
 /**

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -156,9 +156,13 @@ export async function renderPage(
     metadataScript += `__VP_SITE_DATA__ = JSON.parse(${siteDataString})`
   }
 
+  const preserveCodeAppearance = siteData.preserveCodeAppearance
+    ? ' class="preserve-code-appearance"'
+    : ''
+
   const html = `
 <!DOCTYPE html>
-<html lang="${siteData.lang}" dir="${siteData.dir}">
+<html lang="${siteData.lang}" dir="${siteData.dir}"${preserveCodeAppearance}>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -49,6 +49,7 @@ export interface UserConfig<ThemeConfig = any>
   locales?: LocaleConfig<ThemeConfig>
 
   appearance?: boolean | 'dark'
+  preserveCodeAppearance?: boolean
   lastUpdated?: boolean
 
   /**
@@ -394,6 +395,20 @@ export async function resolveSiteData(
 ): Promise<SiteData> {
   userConfig = userConfig || (await resolveUserConfig(root, command, mode))[0]
 
+  const preserveCodeAppearance = userConfig.preserveCodeAppearance ?? false
+
+  //TODO: gh light theme is working
+  if (
+    preserveCodeAppearance &&
+    (!userConfig.markdown || typeof userConfig.markdown.theme !== 'object')
+  ) {
+    userConfig.markdown = userConfig.markdown || {}
+    userConfig.markdown.theme = {
+      light: 'github-light',
+      dark: 'material-theme-palenight'
+    }
+  }
+
   return {
     lang: userConfig.lang || 'en-US',
     dir: userConfig.dir || 'ltr',
@@ -403,6 +418,7 @@ export async function resolveSiteData(
     base: userConfig.base ? userConfig.base.replace(/([^/])$/, '$1/') : '/',
     head: resolveSiteDataHead(userConfig),
     appearance: userConfig.appearance ?? true,
+    preserveCodeAppearance,
     themeConfig: userConfig.themeConfig || {},
     locales: userConfig.locales || {},
     scrollOffset: userConfig.scrollOffset || 90,

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -397,7 +397,6 @@ export async function resolveSiteData(
 
   const preserveCodeAppearance = userConfig.preserveCodeAppearance ?? false
 
-  //TODO: gh light theme is working
   if (
     preserveCodeAppearance &&
     (!userConfig.markdown || typeof userConfig.markdown.theme !== 'object')
@@ -405,7 +404,7 @@ export async function resolveSiteData(
     userConfig.markdown = userConfig.markdown || {}
     userConfig.markdown.theme = {
       light: 'github-light',
-      dark: 'material-theme-palenight'
+      dark: 'github-dark'
     }
   }
 

--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -62,7 +62,7 @@ const errorLevelProcessor = defineProcessor({
 })
 
 export async function highlight(
-  theme: ThemeOptions = 'material-theme-palenight',
+  theme: ThemeOptions = 'github-dark',
   languages: ILanguageRegistration[] = [],
   defaultLang: string = '',
   logger: Pick<Logger, 'warn'> = console

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -171,6 +171,12 @@ export async function createVitePressPlugin(
       }
     },
 
+    transformIndexHtml(html) {
+      if (siteData.preserveCodeAppearance) {
+        return html.replace('<html', '<html class="preserve-code-appearance"')
+      }
+    },
+
     async transform(code, id) {
       if (id.endsWith('.vue')) {
         return processClientJS(code, id)

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -55,6 +55,7 @@ export interface SiteData<ThemeConfig = any> {
   description: string
   head: HeadConfig[]
   appearance: boolean | 'dark'
+  preserveCodeAppearance?: boolean
   themeConfig: ThemeConfig
   scrollOffset: number | string | string[]
   locales: LocaleConfig<ThemeConfig>


### PR DESCRIPTION
I need to check some weird behavior in code copy styles, the left block sometimes scrolls 1 or 2 pixels up.

Right now, this PR using `github-light` Shiki theme for light theme.

There are 3 TODO we should review:
- `node/config.ts`: we also need to handle when configuring only 1 appareance
- `docs/reference/site-config.md`: if we change Shiki light theme, update also the docs
- `docs/.vitepress/config.ts`: remove `preserveCodeAppearance: true` configuration

We should also review code colors (`vars.css`).