### PR TITLE
fix(theme): navbar style

### DIFF
--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -64,6 +64,7 @@ const classes = computed(() => ({
   height: var(--vp-nav-height);
   transition: border-color 0.5s, background-color 0.5s;
   pointer-events: none;
+  white-space: nowrap;
 }
 
 .VPNavBar.has-sidebar {


### PR DESCRIPTION
If there are too many items in navbar and the text of navbar item is separated by `-` or ` `, there will be a problem , so that we can use `white-space: nowrap;` to solve it. I think it should be predictable.

|  before  |  after  |
|  ------  |  -----  |
|![vitepress1](https://user-images.githubusercontent.com/30711792/230745432-14af0cff-bfec-49ed-8ce9-e500adff7ea0.png)|![vitepress2](https://user-images.githubusercontent.com/30711792/230745437-08405fcc-068c-486c-8ad3-67cd11ce4b78.png)|