### PR TITLE
fix: double base path when navigating to local search results

### DIFF
--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -97,10 +97,7 @@ export async function localSearchPlugin(
   function getDocId(file: string) {
     let relFile = path.relative(siteConfig.srcDir, file)
     relFile = siteConfig.rewrites.map[relFile] || relFile
-    let id = path.join(
-      siteConfig.userConfig.base ?? siteConfig.site.base,
-      relFile
-    )
+    let id = path.join(siteConfig.site.base, relFile)
     id = id.replace(/\.md$/, siteConfig.cleanUrls ? '' : '.html')
     return id
   }

--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -97,7 +97,10 @@ export async function localSearchPlugin(
   function getDocId(file: string) {
     let relFile = path.relative(siteConfig.srcDir, file)
     relFile = siteConfig.rewrites.map[relFile] || relFile
-    let id = path.join(siteConfig.userConfig.base ?? '/', relFile)
+    let id = path.join(
+      siteConfig.userConfig.base ?? siteConfig.site.base,
+      relFile
+    )
     id = id.replace(/\.md$/, siteConfig.cleanUrls ? '' : '.html')
     return id
   }


### PR DESCRIPTION
Hello, first of all, thank you for implementing the local search feature. I just discovered the double base path issue, and I was planning to open a PR to fix it, but it was already resolved shortly after. 🚀
After comparing my fix with the existing one, I think using `siteConfig.site.base` is a better option, as currently `siteConfig.site.base` is set to `/` and it aligns with the purpose here. 😊