### PR TITLE
docs:  fix wording in text regarding enabling local search

### DIFF
--- a/docs/reference/default-theme-search.md
+++ b/docs/reference/default-theme-search.md
@@ -2,7 +2,7 @@
 
 ## Local Search
 
-VitePress supports fuzzy full-text search using a in-browser index thanks to [minisearch](https://github.com/lucaong/minisearch/). You can enable it in your `.vitepress/config.ts` with the `localSearch` theme config:
+VitePress supports fuzzy full-text search using a in-browser index thanks to [minisearch](https://github.com/lucaong/minisearch/). To enable this feature, simply set the `themeConfig.search.provider` option to `'local'` in your `.vitepress/config.ts` file:
 
 ```ts
 import { defineConfig } from 'vitepress'


### PR DESCRIPTION
Hello,

Option `localSearch` has been modified, updating it to `search.provider`. However, it looks like the corresponding documentation has not been updated to reflect this change yet.