### PR TITLE
fix(search): local search showDetailedList not working in pro env in windows

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -200,7 +200,7 @@ debouncedWatch(
 )
 
 async function fetchExcerpt(id: string) {
-  const file = slash(pathToFile(id.slice(0, id.indexOf('#'))))
+  const file = pathToFile(slash(id.slice(0, id.indexOf('#'))))
   try {
     return { id, mod: await import(/*@vite-ignore*/ file) }
   } catch (e) {


### PR DESCRIPTION
fix https://github.com/vuejs/vitepress/issues/2245

The function `slash` should be inside the function `pathToFile`.