### PR TITLE
feat(search): clear search text when localSearchBox exit

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -6,8 +6,7 @@ import {
   onKeyStroke,
   useEventListener,
   useLocalStorage,
-  useScrollLock,
-  useSessionStorage
+  useScrollLock
 } from '@vueuse/core'
 import MiniSearch, { type SearchResult } from 'minisearch'
 import { useRouter } from 'vitepress'
@@ -80,7 +79,7 @@ const searchIndex = computedAsync(async () =>
   )
 )
 
-const filterText = useSessionStorage('vitepress:local-search-filter', '')
+const filterText = ref('')
 
 const showDetailedList = useLocalStorage(
   'vitepress:local-search-detailed-list',


### PR DESCRIPTION
It looks weird if the search text is not cleared when localSearchBox exits.