### PR TITLE
fix(theme): close dropdown menus after an item is clicked

### DIFF
--- a/src/client/theme-default/components/VPFlyout.vue
+++ b/src/client/theme-default/components/VPFlyout.vue
@@ -87,6 +87,12 @@ function onBlur() {
   transform: translateY(0);
 }
 
+.button[aria-expanded="false"] + .menu {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(0);
+}
+
 .button {
   display: flex;
   align-items: center;


### PR DESCRIPTION
close [#2132](https://github.com/vuejs/vitepress/issues/2132)
