### PR TITLE
feat: outline link add title attribute

### DIFF
--- a/src/client/theme-default/components/VPDocOutlineItem.vue
+++ b/src/client/theme-default/components/VPDocOutlineItem.vue
@@ -18,7 +18,7 @@ function onClick({ target: el }: Event) {
 <template>
   <ul :class="root ? 'root' : 'nested'">
     <li v-for="{ children, link, title } in headers">
-      <a class="outline-link" :href="link" @click="onClick">{{ title }}</a>
+      <a class="outline-link" :href="link" @click="onClick" :title="title">{{ title }}</a>
       <template v-if="children?.length">
         <VPDocOutlineItem :headers="children" />
       </template>


### PR DESCRIPTION
When the content exceeds the width, it will be omitted, and the entire text content cannot be seen intuitively.

![image](https://user-images.githubusercontent.com/24516654/233284695-91bd6668-b5bf-41f7-88ce-88488e2614f9.png)
