### PR TITLE
fix(router): scroll back to the hash anchor even if it is already selected

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -188,7 +188,7 @@ export function createRouter(
             ) {
               // scroll between hash anchors in the same page
               if (hash) {
-                // avoid non-response with the same hash anchor
+                // avoid duplicate history entries when the hash is same
                 if (hash !== currentUrl.hash) {
                   history.pushState(null, '', hash)
                   // still emit the event so we can listen to it in themes

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -187,10 +187,13 @@ export function createRouter(
               search === currentUrl.search
             ) {
               // scroll between hash anchors in the same page
-              if (hash && hash !== currentUrl.hash) {
-                history.pushState(null, '', hash)
-                // still emit the event so we can listen to it in themes
-                window.dispatchEvent(new Event('hashchange'))
+              if (hash) {
+                // avoid non-response with the same hash anchor
+                if (hash !== currentUrl.hash) {
+                  history.pushState(null, '', hash)
+                  // still emit the event so we can listen to it in themes
+                  window.dispatchEvent(new Event('hashchange'))
+                }
                 // use smooth scroll when clicking on header anchor links
                 scrollTo(link, hash, link.classList.contains('header-anchor'))
               }


### PR DESCRIPTION
即使hash与当前hash相等，我们仍然需要将其滚动到对应锚点。
否则当我们点击锚点后手动滚回原位，再次点击相同的锚点时将没有任何反应。
Even if the hash is equal to the current hash, we still need to scroll it to the corresponding anchor.
Otherwise, when we click on the anchor and then manually roll back and click on the same anchor again, there will be no response. 