### PR TITLE
feat: Change the member introduction to html

### DIFF
--- a/src/client/theme-default/components/VPTeamMembersItem.vue
+++ b/src/client/theme-default/components/VPTeamMembersItem.vue
@@ -31,9 +31,7 @@ defineProps<{
             {{ member.org }}
           </VPLink>
         </p>
-        <p v-if="member.desc" class="desc">
-          {{ member.desc }}
-        </p>
+        <p v-if="member.desc" class="desc" v-html="member.desc"/>
         <div v-if="member.links" class="links">
           <VPSocialLinks :links="member.links" />
         </div>
@@ -178,6 +176,13 @@ defineProps<{
 
 .desc {
   margin: 0 auto;
+}
+
+.desc :deep(a) {
+  font-weight: 500;
+  color: var(--vp-c-brand);
+  text-decoration-style: dotted;
+  transition: color 0.25s;
 }
 
 .links {


### PR DESCRIPTION
This is handy when I want to write some html in member introduction, such as a tag