### PR TITLE
fix: better `.has-aside` condition

### DIFF
--- a/__tests__/unit/client/theme-default/support/slot.test.ts
+++ b/__tests__/unit/client/theme-default/support/slot.test.ts
@@ -1,0 +1,37 @@
+import { isVNodeEmpty } from 'client/theme-default/support/slot'
+import { createVNode, createCommentVNode, createTextVNode } from 'vue'
+
+describe('client/theme-default/slot', () => {
+  test('it tests empty vnode', () => {
+    expect(isVNodeEmpty([])).toBeTruthy()
+    expect(isVNodeEmpty(null)).toBeTruthy()
+    expect(isVNodeEmpty(undefined)).toBeTruthy()
+  })
+
+  test('it tests comment vnode', () => {
+    expect(isVNodeEmpty(createCommentVNode('demo comment'))).toBeTruthy()
+  })
+
+  test('it tests textual vnode', () => {
+    expect(isVNodeEmpty(createTextVNode(' '))).toBeTruthy()
+    expect(isVNodeEmpty(createTextVNode('demo text'))).toBeFalsy()
+  })
+
+  test('it tests element vnode', () => {
+    expect(isVNodeEmpty(createVNode('p'))).toBeFalsy()
+  })
+
+  test('it tests combined deep vnode', () => {
+    expect(
+      isVNodeEmpty([createCommentVNode('demo comment'), createTextVNode(' ')])
+    ).toBeTruthy()
+
+    expect(
+      isVNodeEmpty([
+        createCommentVNode('demo comment'),
+        createTextVNode(' '),
+        createVNode('p')
+      ])
+    ).toBeFalsy()
+  })
+})

--- a/src/client/theme-default/components/VPContent.vue
+++ b/src/client/theme-default/components/VPContent.vue
@@ -44,11 +44,11 @@ const { hasSidebar } = useSidebar()
       <template #doc-after><slot name="doc-after" /></template>
 
       <template #aside-top><slot name="aside-top" /></template>
+      <template #aside-bottom><slot name="aside-bottom" /></template>
       <template #aside-outline-before><slot name="aside-outline-before" /></template>
       <template #aside-outline-after><slot name="aside-outline-after" /></template>
       <template #aside-ads-before><slot name="aside-ads-before" /></template>
       <template #aside-ads-after><slot name="aside-ads-after" /></template>
-      <template #aside-bottom><slot name="aside-bottom" /></template>
     </VPDoc>
   </div>
 </template>

--- a/src/client/theme-default/components/VPDoc.vue
+++ b/src/client/theme-default/components/VPDoc.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { useRoute } from 'vitepress'
-import { computed } from 'vue'
+import {onContentUpdated, useRoute} from 'vitepress'
+import {computed, shallowRef} from 'vue'
 import { useSidebar } from '../composables/sidebar'
 import VPDocAside from './VPDocAside.vue'
 import VPDocFooter from './VPDocFooter.vue'
 import VPDocOutlineDropdown from './VPDocOutlineDropdown.vue'
+import {getHeaders, type MenuItem} from "../composables/outline";
+import {useData} from "../composables/data";
 
 const route = useRoute()
 const { hasSidebar, hasAside, leftAside } = useSidebar()
@@ -12,16 +14,24 @@ const { hasSidebar, hasAside, leftAside } = useSidebar()
 const pageName = computed(() =>
   route.path.replace(/[./]+/g, '_').replace(/_html$/, '')
 )
+
+const { frontmatter, theme } = useData()
+const headers = shallowRef<MenuItem[]>([])
+onContentUpdated(() => {
+    headers.value = getHeaders(
+        frontmatter.value.outline ?? theme.value.outline
+    )
+})
 </script>
 
 <template>
   <div
     class="VPDoc"
-    :class="{ 'has-sidebar': hasSidebar, 'has-aside': hasAside }"
+    :class="{ 'has-sidebar': hasSidebar, 'has-aside': hasAside($slots, headers) }"
   >
     <slot name="doc-top" />
     <div class="container">
-      <div v-if="hasAside" class="aside" :class="{'left-aside': leftAside}">
+      <div v-if="hasAside($slots, headers)" class="aside" :class="{'left-aside': leftAside($slots, headers)}">
         <div class="aside-curtain" />
         <div class="aside-container">
           <div class="aside-content">

--- a/src/client/theme-default/components/VPDocAsideOutline.vue
+++ b/src/client/theme-default/components/VPDocAsideOutline.vue
@@ -14,11 +14,12 @@ const { frontmatter, theme } = useData()
 
 const headers = shallowRef<MenuItem[]>([])
 
-onContentUpdated(() => {
-  headers.value = getHeaders(
-    frontmatter.value.outline ?? theme.value.outline
-  )
-})
+function setHeaders() {
+  headers.value = getHeaders(frontmatter.value.outline ?? theme.value.outline)
+}
+
+onContentUpdated(setHeaders)
+setHeaders();
 
 const container = ref()
 const marker = ref()

--- a/src/client/theme-default/composables/sidebar.ts
+++ b/src/client/theme-default/composables/sidebar.ts
@@ -1,6 +1,7 @@
 import {
   type ComputedRef,
   type Ref,
+  type Slots,
   computed,
   onMounted,
   onUnmounted,
@@ -17,6 +18,8 @@ import {
   getSidebarGroups
 } from '../support/sidebar'
 import { useData } from './data'
+import { type MenuItem } from './outline'
+import { hasAnySlot } from '../support/slot'
 
 export interface SidebarControl {
   collapsed: Ref<boolean>
@@ -49,18 +52,35 @@ export function useSidebar() {
     )
   })
 
-  const leftAside = computed(() => {
-    if (hasAside)
+  const leftAside = computed(() => ($slots: Slots, headers: MenuItem[]) => {
+    if (hasAside.value($slots, headers))
       return frontmatter.value.aside == null
         ? theme.value.aside === 'left'
         : frontmatter.value.aside === 'left'
     return false
   })
 
-  const hasAside = computed(() => {
+  function hasAsideContent($slots: Slots, headers: MenuItem[]): boolean {
+    if (theme.value.carbonAds) return true
+    if (headers.length > 0) return true
+
+    const slots = [
+      'aside-top',
+      'aside-bottom',
+      'aside-outline-before',
+      'aside-outline-after',
+      'aside-ads-before',
+      'aside-ads-after'
+    ]
+    return hasAnySlot($slots, slots)
+  }
+
+  const hasAside = computed(() => ($slots: Slots, headers: MenuItem[]) => {
     if (frontmatter.value.layout === 'home') return false
     if (frontmatter.value.aside != null) return !!frontmatter.value.aside
-    return theme.value.aside !== false
+    if (theme.value.aside === false) return false
+
+    return hasAsideContent($slots, headers)
   })
 
   const isSidebarEnabled = computed(() => hasSidebar.value && is960.value)

--- a/src/client/theme-default/support/slot.ts
+++ b/src/client/theme-default/support/slot.ts
@@ -1,0 +1,91 @@
+import {
+  Fragment,
+  Text,
+  Comment,
+  type VNode,
+  type Slot,
+  type Slots,
+  type VNodeArrayChildren
+} from 'vue'
+
+export function slotHasContent(
+  slot: Slot | undefined | null,
+  props = {}
+): boolean {
+  if (!slot) return false
+
+  return isVNodeEmpty(slot(props))
+}
+
+export function isVNodeEmpty(
+  vnode: VNode | VNode[] | null | undefined
+): boolean {
+  if (!vnode) {
+    return true
+  }
+
+  return !asArray(vnode)
+    .filter((vnode: VNode) => vnode?.type && vnode?.type !== Comment)
+    .some((vnode: VNode) => hasVNodeAnyContent(vnode))
+}
+
+export function hasVNodeAnyContent(vnode: VNode | null | undefined) {
+  return (
+    isElementVNode(vnode) ||
+    hasVNodeTextContent(vnode) ||
+    hasFragmentVNodeContent(vnode) ||
+    hasVNodeChildrenContent(vnode)
+  )
+}
+
+export function hasVNodeTextContent(vnode: VNode | null | undefined): boolean {
+  if (vnode?.type !== Text) {
+    return false
+  }
+
+  if (!vnode.children) {
+    return false
+  }
+
+  return (vnode.children as string).trim().length > 0
+}
+
+export function isElementVNode(vnode: VNode | null | undefined) {
+  return typeof vnode?.type === 'string'
+}
+
+export function hasFragmentVNodeContent(vnode: VNode | null | undefined) {
+  if (vnode?.type !== Fragment) {
+    return false
+  }
+
+  if (!vnode.children?.length) {
+    return false
+  }
+
+  return (vnode.children as VNodeArrayChildren).length > 0
+}
+
+export function hasVNodeChildrenContent(
+  vnode: VNode | null | undefined
+): boolean {
+  if (!vnode?.children?.length) {
+    return false
+  }
+
+  if (vnode.type === Text || vnode.type === Fragment) {
+    return false
+  }
+
+  return (vnode.children as VNode[]).some((vnode: VNode) =>
+    hasVNodeAnyContent(vnode)
+  )
+}
+
+export function asArray(arg: VNode | VNode[]): VNode[] {
+  return Array.isArray(arg) ? arg : arg !== null ? [arg] : []
+}
+
+export function hasAnySlot($slots: Slots, slots: string[]): boolean {
+  return slots.some((slot) => slotHasContent($slots[slot]))
+}


### PR DESCRIPTION
This PR updates how `.has-aside` is applied to `VPDoc` component and `.aside` element, taking into account:
 - rendered slots
 - `theme.carbonAds` config
 - `getHeaders()`
 - `frontmatter.layout`, `frontmatter.aside` and `theme.aside` configs (previous settings)