### PR TITLE
feat(links): report no. of dead links, use rel. paths

### DIFF
--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -120,7 +120,7 @@ export async function createMarkdownToVueRenderFn(
       ;(siteConfig?.logger ?? console).warn(
         c.yellow(
           `\n(!) Found dead link ${c.cyan(url)} in file ${c.white(
-            c.dim(file)
+            c.dim(path.relative(srcDir, fileOrig))
           )}\nIf it is intended, you can use:\n    ${c.cyan(
             `<a href="${url}" target="_blank" rel="noreferrer">${url}</a>`
           )}`

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -94,7 +94,7 @@ export async function createVitePressPlugin(
   }
 
   let siteData = site
-  let hasDeadLinks = false
+  let deadLinksCount = 0
   let config: ResolvedConfig
 
   const vitePressPlugin: Plugin = {
@@ -185,7 +185,7 @@ export async function createVitePressPlugin(
           config.publicDir
         )
         if (deadLinks.length) {
-          hasDeadLinks = true
+          deadLinksCount += deadLinks.length
         }
         if (includes.length) {
           includes.forEach((i) => {
@@ -197,8 +197,10 @@ export async function createVitePressPlugin(
     },
 
     renderStart() {
-      if (hasDeadLinks) {
-        throw new Error(`One or more pages contain dead links.`)
+      if (deadLinksCount > 0) {
+        throw new Error(
+          `One or more pages contain ${deadLinksCount} dead links.`
+        )
       }
     },
 


### PR DESCRIPTION
Seeing the number of dead links helps in situations with large number of dead links.

Relative file paths lead to better readability.  Also, print true (unrewritten) file paths.