### PR TITLE
fix(theme): don't update opacity on hover

### DIFF
--- a/src/client/theme-default/components/VPNavBarTitle.vue
+++ b/src/client/theme-default/components/VPNavBarTitle.vue
@@ -35,10 +35,6 @@ const { currentLang } = useLangs()
   transition: opacity 0.25s;
 }
 
-.title:hover {
-  opacity: 0.6;
-}
-
 @media (min-width: 960px) {
   .title {
     flex-shrink: 0;


### PR DESCRIPTION
Reducing opacity of title on hover looks bad when logo (logo is of bold color) is also used

![chrome-capture-2023-4-1](https://user-images.githubusercontent.com/47495003/235445619-7b51965b-92c0-416d-aa91-228c4810769e.gif)

You can already check existing sites: 