### PR TITLE
feat(theme): use inert to avoid traverse menus and content with keyboard

### DIFF
--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -2,6 +2,7 @@
 import { computed, provide, useSlots, watch } from 'vue'
 import { useRoute } from 'vitepress'
 import { useData } from './composables/data'
+import { useNav } from './composables/nav'
 import { useSidebar, useCloseSidebarOnEscape } from './composables/sidebar'
 import VPSkipLink from './components/VPSkipLink.vue'
 import VPBackdrop from './components/VPBackdrop.vue'
@@ -14,8 +15,10 @@ import VPFooter from './components/VPFooter.vue'
 const {
   isOpen: isSidebarOpen,
   open: openSidebar,
-  close: closeSidebar
+  close: closeSidebar,
+  isSidebarEnabled,
 } = useSidebar()
+const { isScreenOpen } = useNav()
 
 const route = useRoute()
 watch(() => route.path, closeSidebar)
@@ -36,9 +39,9 @@ provide('hero-image-slot-exists', heroImageSlotExists)
 <template>
   <div v-if="frontmatter.layout !== false" class="Layout">
     <slot name="layout-top" />
-    <VPSkipLink />
+    <VPSkipLink :inert="(isSidebarOpen || isScreenOpen) ? true : undefined" />
     <VPBackdrop class="backdrop" :show="isSidebarOpen" @click="closeSidebar" />
-    <VPNav>
+    <VPNav :inert="isSidebarOpen ? true : undefined">
       <template #nav-bar-title-before><slot name="nav-bar-title-before" /></template>
       <template #nav-bar-title-after><slot name="nav-bar-title-after" /></template>
       <template #nav-bar-content-before><slot name="nav-bar-content-before" /></template>
@@ -46,17 +49,17 @@ provide('hero-image-slot-exists', heroImageSlotExists)
       <template #nav-screen-content-before><slot name="nav-screen-content-before" /></template>
       <template #nav-screen-content-after><slot name="nav-screen-content-after" /></template>
     </VPNav>
-    <VPLocalNav :open="isSidebarOpen" @open-menu="openSidebar" />
+    <VPLocalNav :inert="(isSidebarOpen || isScreenOpen) ? true : undefined" :open="isSidebarOpen" @open-menu="openSidebar" />
 
-    <VPSidebar :open="isSidebarOpen">
+    <VPSidebar :inert="!isSidebarEnabled ? ((!isSidebarOpen || isScreenOpen) ? true : undefined) : undefined" :open="isSidebarOpen">
       <template #sidebar-nav-before><slot name="sidebar-nav-before" /></template>
       <template #sidebar-nav-after><slot name="sidebar-nav-after" /></template>
     </VPSidebar>
 
-    <VPContent>
+    <VPContent :inert="(isSidebarOpen || isScreenOpen) ? true : undefined">
       <template #page-top><slot name="page-top" /></template>
       <template #page-bottom><slot name="page-bottom" /></template>
-      
+
       <template #not-found><slot name="not-found" /></template>
       <template #home-hero-before><slot name="home-hero-before" /></template>
       <template #home-hero-info><slot name="home-hero-info" /></template>
@@ -79,7 +82,7 @@ provide('hero-image-slot-exists', heroImageSlotExists)
       <template #aside-ads-after><slot name="aside-ads-after" /></template>
     </VPContent>
 
-    <VPFooter />
+    <VPFooter :inert="(isSidebarOpen || isScreenOpen) ? true : undefined" />
     <slot name="layout-bottom" />
   </div>
   <Content v-else />

--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -39,9 +39,9 @@ provide('hero-image-slot-exists', heroImageSlotExists)
 <template>
   <div v-if="frontmatter.layout !== false" class="Layout">
     <slot name="layout-top" />
-    <VPSkipLink :inert="(isSidebarOpen || isScreenOpen) ? true : undefined" />
+    <VPSkipLink :inert="isSidebarOpen || isScreenOpen" />
     <VPBackdrop class="backdrop" :show="isSidebarOpen" @click="closeSidebar" />
-    <VPNav :inert="isSidebarOpen ? true : undefined">
+    <VPNav :inert="isSidebarOpen">
       <template #nav-bar-title-before><slot name="nav-bar-title-before" /></template>
       <template #nav-bar-title-after><slot name="nav-bar-title-after" /></template>
       <template #nav-bar-content-before><slot name="nav-bar-content-before" /></template>
@@ -49,14 +49,14 @@ provide('hero-image-slot-exists', heroImageSlotExists)
       <template #nav-screen-content-before><slot name="nav-screen-content-before" /></template>
       <template #nav-screen-content-after><slot name="nav-screen-content-after" /></template>
     </VPNav>
-    <VPLocalNav :inert="(isSidebarOpen || isScreenOpen) ? true : undefined" :open="isSidebarOpen" @open-menu="openSidebar" />
+    <VPLocalNav :inert="isSidebarOpen || isScreenOpen" :open="isSidebarOpen" @open-menu="openSidebar" />
 
-    <VPSidebar :inert="!isSidebarEnabled ? ((!isSidebarOpen || isScreenOpen) ? true : undefined) : undefined" :open="isSidebarOpen">
+    <VPSidebar :inert="!isSidebarEnabled && (!isSidebarOpen || isScreenOpen)" :open="isSidebarOpen">
       <template #sidebar-nav-before><slot name="sidebar-nav-before" /></template>
       <template #sidebar-nav-after><slot name="sidebar-nav-after" /></template>
     </VPSidebar>
 
-    <VPContent :inert="(isSidebarOpen || isScreenOpen) ? true : undefined">
+    <VPContent :inert="isSidebarOpen || isScreenOpen">
       <template #page-top><slot name="page-top" /></template>
       <template #page-bottom><slot name="page-bottom" /></template>
 
@@ -82,7 +82,7 @@ provide('hero-image-slot-exists', heroImageSlotExists)
       <template #aside-ads-after><slot name="aside-ads-after" /></template>
     </VPContent>
 
-    <VPFooter :inert="(isSidebarOpen || isScreenOpen) ? true : undefined" />
+    <VPFooter :inert="isSidebarOpen || isScreenOpen" />
     <slot name="layout-bottom" />
   </div>
   <Content v-else />

--- a/src/client/theme-default/components/VPSkipLink.vue
+++ b/src/client/theme-default/components/VPSkipLink.vue
@@ -27,14 +27,16 @@ function focusOnTargetAnchor({ target }: Event) {
 </script>
 
 <template>
-  <span ref="backToTop" tabindex="-1" />
-  <a
-    href="#VPContent"
-    class="VPSkipLink visually-hidden"
-    @click="focusOnTargetAnchor"
-  >
-    Skip to content
-  </a>
+  <div>
+    <span ref="backToTop" tabindex="-1" />
+    <a
+      href="#VPContent"
+      class="VPSkipLink visually-hidden"
+      @click="focusOnTargetAnchor"
+    >
+      Skip to content
+    </a>
+  </div>
 </template>
 
 <style scoped>

--- a/src/client/theme-default/composables/nav.ts
+++ b/src/client/theme-default/composables/nav.ts
@@ -1,9 +1,9 @@
 import { ref, watch } from 'vue'
 import { useRoute } from 'vitepress'
 
-export function useNav() {
-  const isScreenOpen = ref(false)
+const isScreenOpen = ref(false)
 
+export function useNav() {
   function openScreen() {
     isScreenOpen.value = true
     window.addEventListener('resize', closeScreenOnTabletWindow)


### PR DESCRIPTION
This PR includes `inert` attribute to prevent traverse content and menu on narrow sreens:
- moved `isScreenOpen` outside the composable
- included logic in `Layout` to deal with `inert` attribute, right now the attribute is not being handled by `vue`, if present handled as present (vue is rendering the attribute as `inert="false"`)

This PR fixes #1332 (closed by #1491, but not working in current version, check video)

https://streamable.com/tf9qtu

`inert` attribute supported by all major browsers: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert#browser_compatibility

~~TODO: remove `undefined` when https://github.com/vuejs/core/pull/8209 merged~~