### PR TITLE
feat(theme): add appearance transition feature

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -60,7 +60,9 @@ export default defineConfig({
       code: 'CEBDT27Y',
       placement: 'vuejsorg'
     }
-  }
+  },
+
+  appearanceTransition: true
 })
 
 function nav() {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -60,9 +60,7 @@ export default defineConfig({
       code: 'CEBDT27Y',
       placement: 'vuejsorg'
     }
-  },
-
-  appearanceTransition: true
+  }
 })
 
 function nav() {

--- a/src/client/theme-default/components/VPSwitchAppearance.vue
+++ b/src/client/theme-default/components/VPSwitchAppearance.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useData } from '../composables/data'
 import { APPEARANCE_KEY } from '../../shared'
 import VPSwitch from './VPSwitch.vue'
@@ -14,10 +14,8 @@ onMounted(() => {
   checked.value = document.documentElement.classList.contains('dark')
 })
 
-const isAppearanceTransition = computed(() => {
-  // @ts-expect-error: Transition API
-  return document.startViewTransition && site.value.appearanceTransition
-})
+// @ts-expect-error: Transition API
+const isAppearanceTransition = document.startViewTransition && site.value.appearanceTransition
 
 function useAppearance() {
   const query = window.matchMedia('(prefers-color-scheme: dark)')
@@ -38,7 +36,7 @@ function useAppearance() {
   }
 
   function toggle(event: MouseEvent) {
-    if (!isAppearanceTransition.value) {
+    if (!isAppearanceTransition) {
       setClass((isDark = !isDark))
 
       userPreference = isDark

--- a/src/client/theme-default/components/VPSwitchAppearance.vue
+++ b/src/client/theme-default/components/VPSwitchAppearance.vue
@@ -15,7 +15,9 @@ onMounted(() => {
 })
 
 // @ts-expect-error: Transition API
-const isAppearanceTransition = document.startViewTransition && site.value.appearanceTransition
+const isAppearanceTransition = document.startViewTransition &&
+  !window.matchMedia(`(prefers-reduced-motion: reduce)`).matches &&
+  site.value.appearanceTransition
 
 function useAppearance() {
   const query = window.matchMedia('(prefers-color-scheme: dark)')
@@ -77,7 +79,7 @@ function useAppearance() {
           clipPath: isDark ? clipPath : [...clipPath].reverse(),
         },
         {
-          duration: 500,
+          duration: 300,
           easing: 'ease-in',
           pseudoElement: isDark ? '::view-transition-new(root)' : '::view-transition-old(root)',
         },

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -220,6 +220,7 @@ export async function resolveSiteData(
     base: userConfig.base ? userConfig.base.replace(/([^/])$/, '$1/') : '/',
     head: resolveSiteDataHead(userConfig),
     appearance: userConfig.appearance ?? true,
+    appearanceTransition: userConfig.appearanceTransition ?? false,
     themeConfig: userConfig.themeConfig || {},
     locales: userConfig.locales || {},
     scrollOffset: userConfig.scrollOffset || 90,

--- a/src/node/siteConfig.ts
+++ b/src/node/siteConfig.ts
@@ -66,6 +66,7 @@ export interface UserConfig<ThemeConfig = any>
   locales?: LocaleConfig<ThemeConfig>
 
   appearance?: boolean | 'dark'
+  appearanceTransition?: boolean
   lastUpdated?: boolean
 
   /**

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -56,6 +56,7 @@ export interface SiteData<ThemeConfig = any> {
   description: string
   head: HeadConfig[]
   appearance: boolean | 'dark'
+  appearanceTransition: boolean
   themeConfig: ThemeConfig
   scrollOffset: number | string | string[]
   locales: LocaleConfig<ThemeConfig>


### PR DESCRIPTION
Use [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) to make appearance switch more dynamic.

![Kapture 2023-05-07 at 05 36 16](https://user-images.githubusercontent.com/1574903/236647688-fde15301-7d8c-440b-850d-5f0c5dba6240.gif)

But these APIs needs Chrome 111, so I added a configuration item `appearanceTransition` that can be selectively enabled.