### PR TITLE
fix(theme): mobile and theme switcher

### DIFF
--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -175,6 +175,12 @@ const classes = computed(() => ({
   }
 }
 
+@media (max-width: 768px) {
+  .content-body {
+    column-gap: 0.5rem;
+  }
+}
+
 .menu + .translations::before,
 .menu + .appearance::before,
 .menu + .social-links::before,

--- a/src/client/theme-default/components/VPNavBarSearchButton.vue
+++ b/src/client/theme-default/components/VPNavBarSearchButton.vue
@@ -61,7 +61,7 @@ defineProps<{
   align-items: center;
   margin: 0;
   padding: 0;
-  width: 32px;
+  width: 48px;
   height: 55px;
   background: transparent;
   transition: border-color 0.25s;

--- a/src/client/theme-default/components/VPSwitchAppearance.vue
+++ b/src/client/theme-default/components/VPSwitchAppearance.vue
@@ -75,16 +75,15 @@ watch(checked, (newIsDark) => {
 </script>
 
 <template>
-  <label title="toggle dark mode">
-    <VPSwitch
-      class="VPSwitchAppearance"
-      :aria-checked="checked"
-      @click="toggle"
-    >
-      <VPIconSun class="sun" />
-      <VPIconMoon class="moon" />
-    </VPSwitch>
-  </label>
+  <VPSwitch
+    class="VPSwitchAppearance"
+    :aria-checked="checked"
+    aria-label="toggle dark mode"
+    @click="toggle"
+  >
+    <VPIconSun class="sun" />
+    <VPIconMoon class="moon" />
+  </VPSwitch>
 </template>
 
 <style scoped>

--- a/src/client/theme-default/components/VPSwitchAppearance.vue
+++ b/src/client/theme-default/components/VPSwitchAppearance.vue
@@ -76,9 +76,9 @@ watch(checked, (newIsDark) => {
 
 <template>
   <VPSwitch
+    title="toggle dark mode"
     class="VPSwitchAppearance"
     :aria-checked="checked"
-    aria-label="toggle dark mode"
     @click="toggle"
   >
     <VPIconSun class="sun" />


### PR DESCRIPTION
This PR includes (LightHouse complains):
- NavBar content-body: add 0.5rem column gap in narrow/mobile screens (<=768px), search and hamburger buttons overlap
- set 48px to search button
- remove label wrapper in VPSwitchAppearance.vue

![imagen](https://github.com/vuejs/vitepress/assets/6311119/547661db-ebed-4f5d-91bf-dbe3452a4d37)

![imagen](https://github.com/vuejs/vitepress/assets/6311119/7c493db4-4c20-41bd-bde3-2520c4e78023)
