### PR TITLE
fix(build): uniform handling of windows slash in localSearchPlugin

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -29,7 +29,6 @@ import {
 import type { ModalTranslations } from '../../../../types/local-search'
 import { dataSymbol } from '../../app/data'
 import { pathToFile } from '../../app/utils'
-import { slash } from '../../shared'
 import { useData } from '../composables/data'
 import { createTranslate } from '../support/translation'
 
@@ -218,7 +217,7 @@ debouncedWatch(
 )
 
 async function fetchExcerpt(id: string) {
-  const file = pathToFile(slash(id.slice(0, id.indexOf('#'))))
+  const file = pathToFile(id.slice(0, id.indexOf('#')))
   try {
     return { id, mod: await import(/*@vite-ignore*/ file) }
   } catch (e) {

--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -60,7 +60,7 @@ export async function localSearchPlugin(
   }
 
   function getLocaleForPath(file: string) {
-    const relativePath = path.relative(siteConfig.srcDir, file)
+    const relativePath = slash(path.relative(siteConfig.srcDir, file))
     const siteData = resolveSiteDataByRoute(siteConfig.site, relativePath)
     return siteData?.localeIndex ?? 'root'
   }
@@ -97,7 +97,7 @@ export async function localSearchPlugin(
   function getDocId(file: string) {
     let relFile = slash(path.relative(siteConfig.srcDir, file))
     relFile = siteConfig.rewrites.map[relFile] || relFile
-    let id = path.join(siteConfig.site.base, relFile)
+    let id = slash(path.join(siteConfig.site.base, relFile))
     id = id.replace(/\/index\.md$/, '/')
     id = id.replace(/\.md$/, siteConfig.cleanUrls ? '' : '.html')
     return id


### PR DESCRIPTION
1. After turning on local search, the href address in the search box is displayed incorrectly in windows.
2. After this change, there is no need to handle windows slash in `VPLocalSearchBox.vue`.

![1683706157670](https://github.com/vuejs/vitepress/assets/44596995/a32ac4a1-35a3-47cb-a9f4-896608d799eb)
