### PR TITLE
docs: correct robots.txt

### DIFF
--- a/docs/guide/asset-handling.md
+++ b/docs/guide/asset-handling.md
@@ -18,7 +18,7 @@ All **static** path references, including absolute paths, should be based on you
 
 ## The Public Directory
 
-Sometimes you may need to provide static assets that are not directly referenced in any of your Markdown or theme components, or you may want to serve certain files with the original filename. Examples of such files include `robot.txt`, favicons, and PWA icons.
+Sometimes you may need to provide static assets that are not directly referenced in any of your Markdown or theme components, or you may want to serve certain files with the original filename. Examples of such files include `robots.txt`, favicons, and PWA icons.
 
 You can place these files in the `public` directory under the [source directory](./routing#source-directory). For example, if your project root is `./docs` and using default source directory location, then your public directory will be `./docs/public`.
 


### PR DESCRIPTION
`robots.txt` is typically what would go in a public folder: https://developers.google.com/search/docs/crawling-indexing/robots/intro