### PR TITLE
docs: fix typo

### DIFF
--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -384,7 +384,7 @@ export default {
 
     // adjust how header anchors are generated,
     // useful for integrating with tools that use different conventions
-    anchors: {
+    anchor: {
       slugify(str) {
         return encodeURIComponent(str)
       }


### PR DESCRIPTION
fix markdown config example