### PR TITLE
fix: code groups scroll reset

### DIFF
--- a/src/client/theme-default/styles/components/vp-code-group.css
+++ b/src/client/theme-default/styles/components/vp-code-group.css
@@ -33,8 +33,7 @@
 
 .vp-code-group .tabs input {
   position: absolute;
-  opacity: 0;
-  pointer-events: none;
+  display: none;
 }
 
 .vp-code-group .tabs label {


### PR DESCRIPTION
when code group tab is scrollable, click the label will cause the input focus, which is position at the lead of scroll position
this cause the strange behavior: click the label at offset position, and the tab scroll to lead

recurrence demo
[vitepress-codegroup-scroll-issue-izayl.vercel.app/markdown-examples.html](https://vitepress-codegroup-scroll-issue-izayl.vercel.app/markdown-examples.html)

https://user-images.githubusercontent.com/10740043/237601766-53fae0ce-e76b-4313-8d00-0927c5547d59.mov