### PR TITLE
fix(theme): missing global properties in localSearch

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -161,6 +161,18 @@ debouncedWatch(
         // Silence warnings about missing components
         app.config.warnHandler = () => {}
         app.provide(dataSymbol, vitePressData)
+        Object.defineProperties(app.config.globalProperties, {
+          $frontmatter: {
+            get() {
+              return vitePressData.frontmatter.value
+            }
+          },
+          $params: {
+            get() {
+              return vitePressData.page.value.params
+            }
+          }
+        })
         const div = document.createElement('div')
         app.mount(div)
         const sections = div.innerHTML.split(headingRegex)


### PR DESCRIPTION
Fix the bug of the second point https://github.com/vuejs/vitepress/issues/2344.

![1684649445978](https://github.com/vuejs/vitepress/assets/44596995/ca5f0cfb-0dc2-470b-8edc-fe9257994bba)
