### PR TITLE
feat(node): cli shortcuts add restart command

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -34,7 +34,7 @@ if (!command || command === 'dev') {
     await server.listen()
     logVersion(server.config.logger)
     server.printUrls()
-    bindShortcuts(server)
+    bindShortcuts(server, createDevServer)
   }
   createDevServer().catch((err) => {
     createLogger().error(

--- a/src/node/shortcuts.ts
+++ b/src/node/shortcuts.ts
@@ -64,6 +64,13 @@ export function bindShortcuts(server: ViteDevServer): void {
 
 const SHORTCUTS: CLIShortcut[] = [
   {
+    key: 'r',
+    description: 'restart the server',
+    async action(server) {
+      await server.restart()
+    }
+  },
+  {
     key: 'u',
     description: 'show server url',
     action(server) {

--- a/src/node/shortcuts.ts
+++ b/src/node/shortcuts.ts
@@ -1,5 +1,6 @@
-import colors from 'picocolors'
 import type { ViteDevServer } from 'vite'
+import c from 'picocolors'
+import { clearCache } from './markdownToVue'
 
 type CreateDevServer = () => Promise<void>
 
@@ -21,10 +22,10 @@ export function bindShortcuts(
   }
 
   server.config.logger.info(
-    colors.dim(colors.green('  ➜')) +
-      colors.dim('  press ') +
-      colors.bold('h') +
-      colors.dim(' to show help')
+    c.dim(c.green('  ➜')) +
+      c.dim('  press ') +
+      c.bold('h') +
+      c.dim(' to show help')
   )
 
   let actionRunning = false
@@ -42,12 +43,12 @@ export function bindShortcuts(
       server.config.logger.info(
         [
           '',
-          colors.bold('  Shortcuts'),
+          c.bold('  Shortcuts'),
           ...SHORTCUTS.map(
             (shortcut) =>
-              colors.dim('  press ') +
-              colors.bold(shortcut.key) +
-              colors.dim(` to ${shortcut.description}`)
+              c.dim('  press ') +
+              c.bold(shortcut.key) +
+              c.dim(` to ${shortcut.description}`)
           )
         ].join('\n')
       )
@@ -75,6 +76,11 @@ const SHORTCUTS: CLIShortcut[] = [
     key: 'r',
     description: 'restart the server',
     async action(server, createDevServer) {
+      server.config.logger.info(c.green(`restarting server...\n`), {
+        clear: true,
+        timestamp: true
+      })
+      clearCache()
       await server.close()
       await createDevServer()
     }

--- a/src/node/shortcuts.ts
+++ b/src/node/shortcuts.ts
@@ -1,13 +1,21 @@
 import colors from 'picocolors'
 import type { ViteDevServer } from 'vite'
 
+type CreateDevServer = () => Promise<void>
+
 export type CLIShortcut = {
   key: string
   description: string
-  action(server: ViteDevServer): void | Promise<void>
+  action(
+    server: ViteDevServer,
+    createDevServer: CreateDevServer
+  ): void | Promise<void>
 }
 
-export function bindShortcuts(server: ViteDevServer): void {
+export function bindShortcuts(
+  server: ViteDevServer,
+  createDevServer: CreateDevServer
+): void {
   if (!server.httpServer || !process.stdin.isTTY || process.env.CI) {
     return
   }
@@ -49,7 +57,7 @@ export function bindShortcuts(server: ViteDevServer): void {
     if (!shortcut) return
 
     actionRunning = true
-    await shortcut.action(server)
+    await shortcut.action(server, createDevServer)
     actionRunning = false
   }
 
@@ -66,8 +74,9 @@ const SHORTCUTS: CLIShortcut[] = [
   {
     key: 'r',
     description: 'restart the server',
-    async action(server) {
-      await server.restart()
+    async action(server, createDevServer) {
+      await server.close()
+      await createDevServer()
     }
   },
   {


### PR DESCRIPTION
add `restart` shortcut, copied from [vite](https://github.com/vitejs/vite/blob/e444375d34db1e1902f06ab223e51d2d63cd10de/packages/vite/src/node/shortcuts.ts#L85-L91)