### PR TITLE
fix: theme-without-fonts types for node

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "default": "./dist/client/theme-default/index.js"
     },
     "./theme-without-fonts": {
-      "types": "./theme.d.ts",
+      "types": "./theme-without-fonts.d.ts",
       "default": "./dist/client/theme-default/without-fonts.js"
     }
   },
@@ -36,7 +36,8 @@
     "types",
     "template",
     "client.d.ts",
-    "theme.d.ts"
+    "theme.d.ts",
+    "theme-without-fonts.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/theme-without-fonts.d.ts
+++ b/theme-without-fonts.d.ts
@@ -1,0 +1,1 @@
+export * from './theme'


### PR DESCRIPTION
This PR adds the types for node: check it here https://arethetypeswrong.github.io/?p=vitepress%401.0.0-beta.1

![imagen](https://github.com/vuejs/vitepress/assets/6311119/e2b1d020-eee2-4243-9601-10d2c8a1696a)

With this PR:

![imagen](https://github.com/vuejs/vitepress/assets/6311119/2e4449d6-8c4f-4d13-95d5-99a6ad414c7d)

closes #2415
