### PR TITLE
perf(build): speed up copying of shared and client files

### DIFF
--- a/scripts/copyClient.js
+++ b/scripts/copyClient.js
@@ -5,10 +5,9 @@ function toDest(file) {
   return file.replace(/^src\//, 'dist/')
 }
 
-const copyPromises = []
-fg.stream('src/client/**').on('data', (file) => {
-  if (/(\.ts|tsconfig\.json)$/.test(file)) return
-  copyPromises.push(copy(file, toDest(file)))
-})
-
-await Promise.all(copyPromises)
+await Promise.all(
+  fg.sync('src/client/**').map((file) => {
+    if (/(\.ts|tsconfig\.json)$/.test(file)) return
+    return copy(file, toDest(file))
+  })
+)

--- a/scripts/copyClient.js
+++ b/scripts/copyClient.js
@@ -5,7 +5,10 @@ function toDest(file) {
   return file.replace(/^src\//, 'dist/')
 }
 
-fg.sync('src/client/**').forEach((file) => {
+const copyPromises = []
+fg.stream('src/client/**').on('data', (file) => {
   if (/(\.ts|tsconfig\.json)$/.test(file)) return
-  copy(file, toDest(file))
+  copyPromises.push(copy(file, toDest(file)))
 })
+
+await Promise.all(copyPromises)

--- a/scripts/copyShared.js
+++ b/scripts/copyShared.js
@@ -1,12 +1,12 @@
 import { copy } from 'fs-extra'
 import fg from 'fast-glob'
 
-const copyPromises = []
-fg.stream('src/shared/**/*.ts').on('data', (file) => {
-  copyPromises.push(
-    copy(file, file.replace(/^src\/shared\//, 'src/node/')),
-    copy(file, file.replace(/^src\/shared\//, 'src/client/'))
-  )
-})
-
-await Promise.all(copyPromises)
+await Promise.all(
+  fg
+    .sync('src/shared/**/*.ts')
+    .map((file) => [
+      copy(file, file.replace(/^src\/shared\//, 'src/node/')),
+      copy(file, file.replace(/^src\/shared\//, 'src/client/'))
+    ])
+    .flat()
+)

--- a/scripts/copyShared.js
+++ b/scripts/copyShared.js
@@ -1,9 +1,12 @@
 import { copy } from 'fs-extra'
 import fg from 'fast-glob'
 
-fg.sync('src/shared/**/*.ts').forEach(async (file) => {
-  await Promise.all([
+const copyPromises = []
+fg.stream('src/shared/**/*.ts').on('data', (file) => {
+  copyPromises.push(
     copy(file, file.replace(/^src\/shared\//, 'src/node/')),
     copy(file, file.replace(/^src\/shared\//, 'src/client/'))
-  ])
+  )
 })
+
+await Promise.all(copyPromises)


### PR DESCRIPTION
1.Use `fast-glob` stream mode instead of synchronous mode. Synchronous mode blocks the main thread and affects performance.
2.Use `Promise.all` to copy files in parallel, not sequentially.
3.This code has some performance issues, using `await Promise.all` in the `forEach` will still block the thread.
https://github.com/vuejs/vitepress/blob/86a3c24d2a0efee2df4a742c7d5c329a0b6e4b10/scripts/copyShared.js#L4-L9

After each five times of docs-build time test, the build time without optimization is:
 1. 11.84s
 2. 12.5s
 3. 12.94s
 4. 12.56s
 5. 11.76s

the build time after optimization is:
1. 10.25s
2. 11.81s
3. 11.73s
4. 10.04s
5. 10.36s

windows 10
node v16.14.0