### PR TITLE
fix(theme): use brand color in skip link in dark theme

### DIFF
--- a/src/client/theme-default/components/VPSkipLink.vue
+++ b/src/client/theme-default/components/VPSkipLink.vue
@@ -59,10 +59,6 @@ function focusOnTargetAnchor({ target }: Event) {
   clip-path: none;
 }
 
-.dark .VPSkipLink {
-  color: var(--vp-c-green);
-}
-
 @media (min-width: 1280px) {
   .VPSkipLink {
     top: 14px;


### PR DESCRIPTION
The "Skip to content" button in the light theme currently uses the `var(--vp-c-brand)` color and `var(--vp-c-green)` in the dark theme.

`var(--vp-c-brand)` equals `var(--vp-c-green)` by default.

I use default VitePress theme and I customize `var(--vp-c-brand)`, but I don't want to set `var(--vp-c-green)` because that color is used in the Tip container.

The current implementation looks like a bug.