### PR TITLE
fix(plugin): syntax conflict with highlightLinePlugin

### DIFF
--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -30,7 +30,7 @@ const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 10)
  *    [{ line: number, classes: string[] }]
  */
 const attrsToLines = (attrs: string): HtmlRendererOptions['lineOptions'] => {
-  attrs = attrs.replace(/^(?:\[.*?\])?.*?([\d,-]+).*/, '$1').trim()
+  attrs.replace(/^.*\s([\d,-]+)$/, '$1').trim()
   const result: number[] = []
   if (!attrs) {
     return []


### PR DESCRIPTION
fix bug of [#2450](https://github.com/vuejs/vitepress/issues/2450)