### PR TITLE
feat(theme): add custom label for social links

### DIFF
--- a/docs/reference/default-theme-config.md
+++ b/docs/reference/default-theme-config.md
@@ -214,7 +214,9 @@ export default {
         icon: {
           svg: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Dribbble</title><path d="M12...6.38z"/></svg>'
         },
-        link: '...'
+        link: '...',
+        // You can include a custom label for accessibility.
+        label: 'cool link'
       }
     ]
   }
@@ -225,6 +227,7 @@ export default {
 interface SocialLink {
   icon: SocialLinkIcon
   link: string
+  label?: string
 }
 
 type SocialLinkIcon =

--- a/src/client/theme-default/components/VPSocialLink.vue
+++ b/src/client/theme-default/components/VPSocialLink.vue
@@ -6,6 +6,7 @@ import { icons } from '../support/socialIcons'
 const props = defineProps<{
   icon: DefaultTheme.SocialLinkIcon
   link: string
+  label?: string
 }>()
 
 const svg = computed(() => {
@@ -18,7 +19,7 @@ const svg = computed(() => {
   <a
     class="VPSocialLink"
     :href="link"
-    :aria-label="typeof icon === 'string' ? icon : ''"
+    :aria-label="label || (typeof icon === 'string' ? icon : '')"
     target="_blank"
     rel="noopener"
     v-html="svg"

--- a/src/client/theme-default/components/VPSocialLinks.vue
+++ b/src/client/theme-default/components/VPSocialLinks.vue
@@ -10,10 +10,11 @@ defineProps<{
 <template>
   <div class="VPSocialLinks">
     <VPSocialLink
-      v-for="{ link, icon } in links"
+      v-for="{ link, icon, label } in links"
       :key="link"
       :icon="icon"
       :link="link"
+      :label="label"
     />
   </div>
 </template>

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -251,6 +251,7 @@ export namespace DefaultTheme {
   export interface SocialLink {
     icon: SocialLinkIcon
     link: string
+    label?: string
   }
 
   export type SocialLinkIcon =


### PR DESCRIPTION
Currently, the accessibility label for social links is derived from the icon name. When using a custom icon with an SVG, the aria-label is empty. 

This PR adds an optional field to SocialLink called `label`.

When a SocialLink includes the `label` string, it will be used as the aria-label. This allows custom icons to have a label and improve accessibility, and also to overwrite the default labels if so desired.

Behaviour is unchanged if the new optional field is not present.

This PR also updates the documentation and includes an example.

I understand that the word label might be confusing and users could be expecting the default theme to render this label as an icon subtext instead of it being an accessibility label. Please let me know if you think a different name would be more suitable.