### PR TITLE
docs: add root path to gitignore suggestion

### DIFF
--- a/src/node/init/init.ts
+++ b/src/node/init/init.ts
@@ -159,6 +159,7 @@ export function scaffold({
 
   const dir =
     root === './' ? `` : ` ${root.replace(/^\.\//, '').replace(/[/\\]$/, '')}`
+  const gitignorePrefix = dir ? `${dir}/.vitepress` : '.vitepress'
 
   const pkgPath = path.resolve('package.json')
   const userPkg = fs.existsSync(pkgPath)
@@ -168,8 +169,9 @@ export function scaffold({
   const tips = []
   if (fs.existsSync('.git')) {
     tips.push(
-      `Make sure to add ${cyan(`.vitepress/dist`)} and ` +
-        `${cyan(`.vitepress/cache`)} to your ${cyan(`.gitignore`)} file.`
+      `Make sure to add ${cyan(`${gitignorePrefix}/dist`)} and ` +
+        `${cyan(`${gitignorePrefix}/cache`)} to your ` +
+        `${cyan(`.gitignore`)} file.`
     )
   }
   if (


### PR DESCRIPTION
We currently suggest the user to add the `.vitepress/dist` and `.vitepress/cache` folders to their `.gitignore` file, but if they just copy-paste these values, it won't work. They will either need to prefix this path with the vitepress root folder, or use `**/.vitepress/dist`.

I've implemented the formal option in this PR, but happy change it to the latter if that sounds better to you guys.

Before:
![image](https://github.com/vuejs/vitepress/assets/31937175/01e6435c-906e-4c7f-b858-088d958d3ab5)

After:
![image](https://github.com/vuejs/vitepress/assets/31937175/4e601c4b-3b12-493c-850a-1596125e2a85)
