### PR TITLE
fix: page not scroll when click on a same path hash in search box

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -269,15 +269,21 @@ export function scrollTo(el: Element, hash: string, smooth = false) {
       offset +
       targetPadding
     // only smooth scroll if distance is smaller than screen height.
-    if (!smooth || Math.abs(targetTop - window.scrollY) > window.innerHeight) {
-      window.scrollTo(0, targetTop)
-    } else {
-      window.scrollTo({
-        left: 0,
-        top: targetTop,
-        behavior: 'smooth'
-      })
+    function scrollToTarget() {
+      if (
+        !smooth ||
+        Math.abs(targetTop - window.scrollY) > window.innerHeight
+      ) {
+        window.scrollTo(0, targetTop)
+      } else {
+        window.scrollTo({
+          left: 0,
+          top: targetTop,
+          behavior: 'smooth'
+        })
+      }
     }
+    requestAnimationFrame(scrollToTarget)
   }
 }
 


### PR DESCRIPTION
![GIF 2023-6-20 10-33-27](https://github.com/vuejs/vitepress/assets/44596995/4e0c791d-355e-421e-8dae-77df3ad88b67)

In the same path, when clicking another hash path in the search box, the page does not scroll but the hash in the browser address bar changes.