### PR TITLE
fix: simple-git-hooks not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "docs-debug": "node --inspect-brk ./bin/vitepress dev docs",
     "docs-build": "run-s build docs-build-only",
     "docs-build-only": "node ./bin/vitepress build docs",
-    "docs-preview": "node ./bin/vitepress preview docs"
+    "docs-preview": "node ./bin/vitepress preview docs",
+    "postinstall": "simple-git-hooks"
   },
   "dependencies": {
     "@docsearch/css": "^3.5.0",


### PR DESCRIPTION
It's not clear from which version my local `simple-git-hooks` is not working, I need to update `simple-git-hooks` manually by myself.

So add postinstall script, copied from [vue-core](https://github.com/vuejs/core/blob/d2c3d8b70b2df6e16f053a7ac58e6b04e7b2078f/package.json#LL39C6-L39C17)