### PR TITLE
revert!: sync defineConfig types with vite

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -38,7 +38,7 @@ export type UserConfigExport<ThemeConfig> =
 /**
  * Type config helper
  */
-export function defineConfig(config: UserConfigExport<DefaultTheme.Config>) {
+export function defineConfig(config: UserConfig<DefaultTheme.Config>) {
   return config
 }
 
@@ -46,7 +46,7 @@ export function defineConfig(config: UserConfigExport<DefaultTheme.Config>) {
  * Type config helper for custom theme config
  */
 export function defineConfigWithTheme<ThemeConfig>(
-  config: UserConfigExport<ThemeConfig>
+  config: UserConfig<ThemeConfig>
 ) {
   return config
 }


### PR DESCRIPTION
closes #2524 

It looks like these changes broke many other projects. Especially the projects using something like this for i18n:

```ts
export const sharedConfig = defineConfig({...})
```

Not removing `UserConfigFn` and `UserConfigExport` types for now as some plugins like vite-pwa have started using them.