### PR TITLE
feat(client): add onBeforePageLoad hook for router

### DIFF
--- a/docs/reference/runtime-api.md
+++ b/docs/reference/runtime-api.md
@@ -86,8 +86,27 @@ Returns the VitePress router instance so you can programmatically navigate to an
 
 ```ts
 interface Router {
+  /**
+   * Current route.
+   */
   route: Route
-  go: (href?: string) => Promise<void>
+  /**
+   * Navigate to a new URL.
+   */
+  go: (to?: string) => Promise<void>
+  /**
+   * Called before the route changes. Return `false` to cancel the navigation.
+   */
+  onBeforeRouteChange?: (to: string) => Awaitable<void | boolean>
+  /**
+   * Called before the page component is loaded (after the history state is
+   * updated). Return `false` to cancel the navigation.
+   */
+  onBeforePageLoad?: (to: string) => Awaitable<void | boolean>
+  /**
+   * Called after the route changes.
+   */
+  onAfterRouteChanged?: (to: string) => Awaitable<void>
 }
 ```
 

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -23,12 +23,12 @@ export interface Router {
   /**
    * Called before the route changes. Return false to cancel the navigation.
    */
-  onBeforeRouteChange?: (to: string) => Awaitable<void | false>
+  onBeforeRouteChange?: (to: string) => Awaitable<void | boolean>
   /**
    * Called before the page component is loaded (after the history state is
    * updated). Return false to cancel the navigation.
    */
-  onBeforePageLoad?: (to: string) => Awaitable<void | false>
+  onBeforePageLoad?: (to: string) => Awaitable<void | boolean>
   /**
    * Called after the route changes.
    */

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -16,7 +16,7 @@ export interface Router {
   go: (href?: string) => Promise<void>
   onBeforeRouteChange?: (to: string) => Awaitable<void>
   onAfterRouteChanged?: (to: string) => Awaitable<void>
-  onBeforeRoutePageLoad?: (to: string) => Awaitable<void>
+  onBeforeRoutePageLoad?: (to: string) => Awaitable<boolean | void>
 }
 
 export const RouterSymbol: InjectionKey<Router> = Symbol()
@@ -70,7 +70,11 @@ export function createRouter(
   let latestPendingPath: string | null = null
 
   async function loadPage(href: string, scrollPosition = 0, isRetry = false) {
-    await router.onBeforeRoutePageLoad?.(href)
+    const isLoad = await router.onBeforeRoutePageLoad?.(href)
+    // if isLoad is false, should stop load the page
+    if (typeof isLoad === 'boolean' && !isLoad) {
+      return
+    }
     const targetLoc = new URL(href, fakeHost)
     const pendingPath = (latestPendingPath = targetLoc.pathname)
     try {

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -21,12 +21,12 @@ export interface Router {
    */
   go: (to?: string) => Promise<void>
   /**
-   * Called before the route changes. Return false to cancel the navigation.
+   * Called before the route changes. Return `false` to cancel the navigation.
    */
   onBeforeRouteChange?: (to: string) => Awaitable<void | boolean>
   /**
    * Called before the page component is loaded (after the history state is
-   * updated). Return false to cancel the navigation.
+   * updated). Return `false` to cancel the navigation.
    */
   onBeforePageLoad?: (to: string) => Awaitable<void | boolean>
   /**

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -16,6 +16,7 @@ export interface Router {
   go: (href?: string) => Promise<void>
   onBeforeRouteChange?: (to: string) => Awaitable<void>
   onAfterRouteChanged?: (to: string) => Awaitable<void>
+  onBeforeRoutePageLoad?: (to: string) => Awaitable<void>
 }
 
 export const RouterSymbol: InjectionKey<Router> = Symbol()
@@ -69,6 +70,7 @@ export function createRouter(
   let latestPendingPath: string | null = null
 
   async function loadPage(href: string, scrollPosition = 0, isRetry = false) {
+    await router.onBeforeRoutePageLoad?.(href)
     const targetLoc = new URL(href, fakeHost)
     const pendingPath = (latestPendingPath = targetLoc.pathname)
     try {


### PR DESCRIPTION
I am using [fullpage.js](https://github.com/alvarotrigo/fullPage.js), but it doesn't work properly in `vitepress` because it uses `location.href` for anchors internally, which causes the page to be reloaded in `vitepress`. Therefore, I want to add an `onBeforeRoutePageLoad` hook to control the timing of page reloading.

https://github.com/vuejs/vitepress/assets/39730999/ba3a1e52-85e6-4fc3-9475-aefa1adb6ea4

`docs/components/ComponentInHeader.vue`:
```vue
<template>
  <span @click="handleClick">&#x26A1;</span>
</template>

<script setup lang="ts">
import { onMounted } from "vue";
import { useRouter } from 'vitepress'

const router = useRouter()

onMounted(() => {
  console.log('ComponentInHeader onMounted')
})

router.onBeforeRouteChange = ((to) => {
  console.log('onBeforeRouteChange',to) 
})

const handleClick = () => {
  location.href = '#escaping' 
  // const section = document.querySelector('#escaping')!;
  // section.scrollIntoView({ behavior: 'smooth' }); // 平滑滚动到元素位置
}
</script>
```

