### PR TITLE
feat(theme): add frontmatter.navbar config

### DIFF
--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -38,7 +38,7 @@ provide('hero-image-slot-exists', heroImageSlotExists)
     <slot name="layout-top" />
     <VPSkipLink />
     <VPBackdrop class="backdrop" :show="isSidebarOpen" @click="closeSidebar" />
-    <VPNav>
+    <VPNav v-if="frontmatter.navbar !== false">
       <template #nav-bar-title-before><slot name="nav-bar-title-before" /></template>
       <template #nav-bar-title-after><slot name="nav-bar-title-after" /></template>
       <template #nav-bar-content-before><slot name="nav-bar-content-before" /></template>


### PR DESCRIPTION
I wrote a document using vitepress, and then I need to present it online to my colleagues. I want them to focus more on the content of the document, rather than the sidebar, aside, and navbar. I can configure frontmatter to hide sidebar and side, but there is no option to configure navbar. So I hope to add a frontmatter configuration to hide Navbar

I don't think it's good enough

![image](https://github.com/vuejs/vitepress/assets/77321887/2d27e3dd-095e-4f55-b650-097bd900a05f)

i think good

![image](https://github.com/vuejs/vitepress/assets/77321887/36cfcd41-78e5-4c94-bd37-466616731c38)
