### PR TITLE
fix(theme): unresponsive back button with empty input in search box

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -421,7 +421,7 @@ function formMarkRegex(terms: Set<string>) {
             <button
               class="back-button"
               :title="$t('modal.backButtonTitle')"
-              @click="selectedIndex > -1 && $emit('close')"
+              @click="$emit('close')"
             >
               <svg
                 width="18"


### PR DESCRIPTION
Steps to Reproduce:

1. Navigate to the page with the local search functionality (not Algolia).
2. Make sure the screen size is small or use a mobile phone.
3. Click on the search box to open it.
4. Without entering any text, click the back button.
5. Observe that the search box does not close.