### PR TITLE
fix(types): export duplicate type `Sidebar`

### DIFF
--- a/docs/reference/default-theme-sidebar.md
+++ b/docs/reference/default-theme-sidebar.md
@@ -186,7 +186,7 @@ export default {
 Returns sidebar-related data. The returned object has the following type:
 
 ```ts
-export interface Sidebar {
+export interface DocSidebar {
   isOpen: Ref<boolean>
   sidebar: ComputedRef<DefaultTheme.SidebarItem[]>
   sidebarGroups: ComputedRef<DefaultTheme.SidebarItem[]>

--- a/theme.d.ts
+++ b/theme.d.ts
@@ -20,4 +20,4 @@ declare const theme: {
 export default theme
 export type { DefaultTheme } from './types/default-theme.js'
 
-export const useSidebar: () => DefaultTheme.SideBar
+export const useSidebar: () => DefaultTheme.DocSideBar

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -1,3 +1,4 @@
+import { type ComputedRef, type Ref } from 'vue'
 import type { DocSearchProps } from './docsearch.js'
 import type { LocalSearchTranslations } from './local-search.js'
 import type { PageData } from './shared.js'
@@ -222,7 +223,7 @@ export namespace DefaultTheme {
   /**
    * ReturnType of `useSidebar`
    */
-  export interface Sidebar {
+  export interface DocSidebar {
     isOpen: Ref<boolean>
     sidebar: ComputedRef<SidebarItem[]>
     sidebarGroups: ComputedRef<SidebarItem[]>


### PR DESCRIPTION
https://github.com/vuejs/vitepress/blob/03d93da227b9c98e06f52724b8647ed18da1d2f1/types/default-theme.d.ts#L190

https://github.com/vuejs/vitepress/blob/03d93da227b9c98e06f52724b8647ed18da1d2f1/types/default-theme.d.ts#L225-L236

The `default-theme.d.ts` file exports two `Sidebar` types with the same name, which will then cause `config.ts` to report a typescript error.