### PR TITLE
perf: fix race conditions with cache

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -56,12 +56,12 @@ export async function build(
         ) as OutputChunk)
 
       const cssChunk = (
-        siteConfig.mpa ? serverResult : clientResult
+        siteConfig.mpa ? serverResult : clientResult!
       ).output.find(
         (chunk) => chunk.type === 'asset' && chunk.fileName.endsWith('.css')
       ) as OutputAsset
 
-      const assets = (siteConfig.mpa ? serverResult : clientResult).output
+      const assets = (siteConfig.mpa ? serverResult : clientResult!).output
         .filter(
           (chunk) => chunk.type === 'asset' && !chunk.fileName.endsWith('.css')
         )

--- a/src/node/build/bundle.ts
+++ b/src/node/build/bundle.ts
@@ -31,7 +31,7 @@ export async function bundle(
   config: SiteConfig,
   options: BuildOptions
 ): Promise<{
-  clientResult: RollupOutput
+  clientResult: RollupOutput | null
   serverResult: RollupOutput
   pageToHashMap: Record<string, string>
 }> {
@@ -142,16 +142,16 @@ export async function bundle(
     }
   })
 
-  let clientResult: RollupOutput
+  let clientResult: RollupOutput | null
   let serverResult: RollupOutput
 
   const spinner = ora()
   spinner.start('building client + server bundles...')
   try {
-    ;[clientResult, serverResult] = await (Promise.all([
-      config.mpa ? null : build(await resolveViteConfig(false)),
-      build(await resolveViteConfig(true))
-    ]) as Promise<[RollupOutput, RollupOutput]>)
+    clientResult = config.mpa
+      ? null
+      : ((await build(await resolveViteConfig(false))) as RollupOutput)
+    serverResult = (await build(await resolveViteConfig(true))) as RollupOutput
   } catch (e) {
     spinner.stopAndPersist({
       symbol: failMark

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -24,8 +24,8 @@ export async function renderPage(
   config: SiteConfig,
   page: string, // foo.md
   result: RollupOutput | null,
-  appChunk: OutputChunk | undefined,
-  cssChunk: OutputAsset | undefined,
+  appChunk: OutputChunk | null,
+  cssChunk: OutputAsset | null,
   assets: string[],
   pageToHashMap: Record<string, string>,
   hashMapString: string,


### PR DESCRIPTION
improves build perf up to 20%
earlier the cache was not getting hit in most of the cases as both client and server builds were happening at the same time.