### PR TITLE
fix(hmr): allow disabling md cache during dev

### DIFF
--- a/src/node/markdown/env.ts
+++ b/src/node/markdown/env.ts
@@ -36,4 +36,5 @@ export interface MarkdownEnv {
   relativePath: string
   cleanUrls: boolean
   links?: string[]
+  includes?: string[]
 }

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -50,6 +50,7 @@ export interface MarkdownOptions extends MarkdownIt.Options {
   languages?: ILanguageRegistration[]
   toc?: TocPluginOptions
   externalLinks?: Record<string, string>
+  cache?: boolean
 }
 
 export type MarkdownRenderer = MarkdownIt

--- a/src/node/markdown/plugins/snippet.ts
+++ b/src/node/markdown/plugins/snippet.ts
@@ -140,15 +140,15 @@ export const snippetPlugin = (md: MarkdownIt, srcDir: string) => {
   const fence = md.renderer.rules.fence!
 
   md.renderer.rules.fence = (...args) => {
-    const [tokens, idx, , { loader }] = args
+    const [tokens, idx, , { includes }] = args
     const token = tokens[idx]
     // @ts-ignore
     const [src, regionName] = token.src ?? []
 
     if (!src) return fence(...args)
 
-    if (loader) {
-      loader.addDependency(src)
+    if (includes) {
+      includes.push(src)
     }
 
     const isAFile = fs.lstatSync(src).isFile()

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -67,10 +67,12 @@ export async function createMarkdownToVueRenderFn(
     const relativePath = slash(path.relative(srcDir, file))
     const cacheKey = JSON.stringify({ src, file })
 
-    const cached = cache.get(cacheKey)
-    if (cached) {
-      debug(`[cache hit] ${relativePath}`)
-      return cached
+    if (isBuild || options.cache !== false) {
+      const cached = cache.get(cacheKey)
+      if (cached) {
+        debug(`[cache hit] ${relativePath}`)
+        return cached
+      }
     }
 
     const start = Date.now()
@@ -125,7 +127,8 @@ export async function createMarkdownToVueRenderFn(
     const env: MarkdownEnv = {
       path: file,
       relativePath,
-      cleanUrls
+      cleanUrls,
+      includes
     }
     const html = md.render(src, env)
     const {
@@ -243,7 +246,9 @@ export async function createMarkdownToVueRenderFn(
       deadLinks,
       includes
     }
-    cache.set(cacheKey, result)
+    if (isBuild || options.cache !== false) {
+      cache.set(cacheKey, result)
+    }
     return result
   }
 }


### PR DESCRIPTION
closes #117

To make HMR work with markdown includes or imported code snippets, add this to your config file:

```ts
export default {
  markdown: {
    cache: false
  }
}
```

It won't affect build performance, but might degrade dev perf slightly (~100ms, if you do undo/redo multiple times).

Alternatively, you can just press <kbd>r</kbd> on the terminal. But it's not good DX as it performs full page reload.