### PR TITLE
fix(theme): fix doc footer's prev & next's size difference

### DIFF
--- a/src/client/theme-default/components/VPDocFooter.vue
+++ b/src/client/theme-default/components/VPDocFooter.vue
@@ -41,20 +41,20 @@ const showFooter = computed(() => {
       </div>
     </div>
 
-    <div v-if="control.prev?.link || control.next?.link" class="prev-next">
+    <nav v-if="control.prev?.link || control.next?.link" class="prev-next">
       <div class="pager">
         <a v-if="control.prev?.link" class="pager-link prev" :href="normalizeLink(control.prev.link)">
           <span class="desc" v-html="theme.docFooter?.prev || 'Previous page'"></span>
           <span class="title" v-html="control.prev.text"></span>
         </a>
       </div>
-      <div class="pager" :class="{ 'has-prev': control.prev?.link }">
+      <div class="pager">
         <a v-if="control.next?.link" class="pager-link next" :href="normalizeLink(control.next.link)">
           <span class="desc" v-html="theme.docFooter?.next || 'Next page'"></span>
           <span class="title" v-html="control.next.text"></span>
         </a>
       </div>
-    </div>
+    </nav>
   </footer>
 </template>
 
@@ -101,29 +101,14 @@ const showFooter = computed(() => {
 .prev-next {
   border-top: 1px solid var(--vp-c-divider);
   padding-top: 24px;
+  display: grid;
+  grid-row-gap: 8px;
 }
 
 @media (min-width: 640px) {
   .prev-next {
-    display: flex;
-  }
-}
-
-.pager.has-prev {
-  padding-top: 8px;
-}
-
-@media (min-width: 640px) {
-  .pager {
-    display: flex;
-    flex-direction: column;
-    flex-shrink: 0;
-    width: 50%;
-  }
-
-  .pager.has-prev {
-    padding-top: 0;
-    padding-left: 16px;
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 16px;
   }
 }
 


### PR DESCRIPTION
Since users are most likely developers / IT-guy, so using `grid` should be safe here in my opinion.

Before:
![Snipaste_2023-07-11_19-03-05](https://github.com/vuejs/vitepress/assets/45784210/4e085623-776a-4542-90c3-b8b40897d52b)
After:
![Snipaste_2023-07-11_19-03-12](https://github.com/vuejs/vitepress/assets/45784210/fd930a83-81ac-4dac-aee0-e1f8add1c58e)
The small screen works well too (the same as before):
![Snipaste_2023-07-11_19-03-31](https://github.com/vuejs/vitepress/assets/45784210/fa71ae23-5d12-431b-888c-64e687c7ce5d)

If you are not happy with `grid`, I can achieve the same thing using `flex`, but `grid` is just my personal go-to option.