### PR TITLE
chore(theme): add default type export

### DIFF
--- a/theme-without-fonts.d.ts
+++ b/theme-without-fonts.d.ts
@@ -1,1 +1,2 @@
 export * from './theme'
+export { default } from './theme'


### PR DESCRIPTION
When I using different fonts, I get a type error because the default type export is not provided.

here is my code：
``` vue
<script setup lang="ts">
import DefaultTheme from 'vitepress/theme-without-fonts'

// I wana fix type errors next line
const Layout = DefaultTheme.Layout
</script>

<template>
  <Layout></Layout>
</template>
```