### PR TITLE
add support for script boolean attribute

### DIFF
--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -249,6 +249,9 @@ function renderHead(head: HeadConfig[]): Promise<string> {
 function renderAttrs(attrs: Record<string, string>): string {
   return Object.keys(attrs)
     .map((key) => {
+      if (key == 'async' || key == 'defer') {
+        return ` ${key}`
+      }
       return ` ${key}="${escape(attrs[key])}"`
     })
     .join('')


### PR DESCRIPTION
as mentioned in #1131 

```javascript
 [
    'script',
   { async: true, src: 'https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX' }
   { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX' }
 ]
```

both of the approach will result 

```javascript
<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
```