### PR TITLE
fix: make pathname protocol respect base url

### DIFF
--- a/docs/guide/asset-handling.md
+++ b/docs/guide/asset-handling.md
@@ -76,3 +76,27 @@ const { theme } = useData()
   <img :src="withBase(theme.logoPath)" />
 </template>
 ```
+
+Also note `pathname://` will respect `base` config if the rest is an internal non-relative link.
+
+**Input**
+
+With `base` set to `"/docs/"`:
+
+```md
+[foo](pathname:///foo.html)
+[bar](pathname:///bar.html)
+[baz](pathname://baz.html)
+[qux](pathname://qux.html)
+```
+
+**Output**
+
+```html
+<p>
+  <a href="/docs/foo.html" target="_blank" rel="noreferrer">foo</a>
+  <a href="/docs/bar.html" target="_blank" rel="noreferrer">bar</a>
+  <a href="baz.html" target="_blank" rel="noreferrer">baz</a>
+  <a href="qux.html" target="_blank" rel="noreferrer">qux</a>
+</p>
+```

--- a/src/client/app/utils.ts
+++ b/src/client/app/utils.ts
@@ -22,8 +22,11 @@ export function joinPath(base: string, path: string) {
   return `${base}${path}`.replace(/\/+/g, '/')
 }
 
+/**
+ * Append base to internal (non-relative) urls
+ */
 export function withBase(path: string) {
-  return EXTERNAL_URL_RE.test(path) || path.startsWith('.')
+  return EXTERNAL_URL_RE.test(path) || !path.startsWith('/')
     ? path
     : joinPath(siteDataRef.value.base, path)
 }

--- a/src/client/theme-default/support/utils.ts
+++ b/src/client/theme-default/support/utils.ts
@@ -29,7 +29,11 @@ export function ensureStartingSlash(path: string): string {
 
 export function normalizeLink(url: string): string {
   if (isExternal(url)) {
-    return url.replace(PATHNAME_PROTOCOL_RE, '')
+    // respect base url when using pathname:// protocal
+    if (PATHNAME_PROTOCOL_RE.test(url)) {
+      return withBase(url.replace(PATHNAME_PROTOCOL_RE, ''))
+    }
+    return url
   }
 
   const { site } = useData()


### PR DESCRIPTION
## Problem:

Currently base url config is not applied when using `pathname://`,  which seems to be the wrong behavior.

Change this would:

1. matches [origin](https://github.com/facebook/docusaurus/blob/26ae4164d6f90c231c6687363a3907b5f9f172b8/packages/docusaurus/src/client/exports/Link.tsx#L81) behavior
2. since the idea of pathname protocol is to escape from spa (within the same site), prepending base url makes sense

## Current

with `base` set to `/docs/`:

`[foo](pathname:///foo)` renders to `/foo`

## Expect

`[foo](pathname:///foo)` renders to `/docs/foo`
