### PR TITLE
fix(build): cannot handle file name containing single quote

### DIFF
--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -322,14 +322,16 @@ function injectPageDataCode(
       code +
         (hasDefaultExport
           ? ``
-          : `\nexport default {name:'${data.relativePath}'}`) +
+          : `\nexport default {name:${JSON.stringify(data.relativePath)}}`) +
         `</script>`
     )
   } else {
     tags.unshift(
-      `<script ${isUsingTS ? 'lang="ts"' : ''}>${code}\nexport default {name:'${
+      `<script ${
+        isUsingTS ? 'lang="ts"' : ''
+      }>${code}\nexport default {name:${JSON.stringify(
         data.relativePath
-      }'}</script>`
+      )}}</script>`
     )
   }
 


### PR DESCRIPTION
fix https://github.com/vuejs/vitepress/issues/2614

If the filename contains a single quote. Since the final characters of the `name:'${ data.relativePath }'` contains more than two single quotes, it doesn't compile through.