### PR TITLE
ci: don't run lock threads or release tag actions on forks

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   action:
+    if: github.repository == 'vuejs/vitepress'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v4

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'vuejs/vitepress'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Also prevents any irrelevant notifications to HEAD's author.