### PR TITLE
fix(build): use vue dev build when DEBUG is truthy

### DIFF
--- a/src/node/alias.ts
+++ b/src/node/alias.ts
@@ -18,10 +18,9 @@ export const DEFAULT_THEME_PATH = join(DIST_CLIENT_PATH, 'theme-default')
 export const SITE_DATA_ID = '@siteData'
 export const SITE_DATA_REQUEST_PATH = '/' + SITE_DATA_ID
 
-const vueRuntimePath =
-  process.env.DEBUG || process.env.NODE_ENV !== 'production'
-    ? 'vue/dist/vue.runtime.esm-browser.js'
-    : 'vue/dist/vue.runtime.esm-browser.prod.js'
+const vueRuntimePath = process.env.DEBUG
+  ? 'vue/dist/vue.runtime.esm-browser.js'
+  : 'vue/dist/vue.runtime.esm-browser.prod.js'
 
 export function resolveAliases(
   { root, themeDir }: SiteConfig,

--- a/src/node/alias.ts
+++ b/src/node/alias.ts
@@ -20,8 +20,8 @@ export const SITE_DATA_REQUEST_PATH = '/' + SITE_DATA_ID
 
 const vueRuntimePath =
   process.env.DEBUG || process.env.NODE_ENV !== 'production'
-    ? 'vue/dist/vue.esm-browser.js'
-    : 'vue/dist/vue.esm-browser.prod.js'
+    ? 'vue/dist/vue.runtime.esm-browser.js'
+    : 'vue/dist/vue.runtime.esm-browser.prod.js'
 
 export function resolveAliases(
   { root, themeDir }: SiteConfig,

--- a/src/node/alias.ts
+++ b/src/node/alias.ts
@@ -18,7 +18,10 @@ export const DEFAULT_THEME_PATH = join(DIST_CLIENT_PATH, 'theme-default')
 export const SITE_DATA_ID = '@siteData'
 export const SITE_DATA_REQUEST_PATH = '/' + SITE_DATA_ID
 
-const vueRuntimePath = 'vue/dist/vue.runtime.esm-bundler.js'
+const vueRuntimePath =
+  process.env.DEBUG || process.env.NODE_ENV !== 'production'
+    ? 'vue/dist/vue.esm-browser.js'
+    : 'vue/dist/vue.esm-browser.prod.js'
 
 export function resolveAliases(
   { root, themeDir }: SiteConfig,


### PR DESCRIPTION
Running build like this `DEBUG=true vitepress build docs` will now use dev builds. Helpful for debugging hydration errors that are not caused by settings at hosting level.