### PR TITLE
fix(theme): support missing meta description tag

### DIFF
--- a/src/client/app/composables/head.ts
+++ b/src/client/app/composables/head.ts
@@ -37,9 +37,15 @@ export function useUpdateHead(route: Route, siteDataByRouteRef: Ref<SiteData>) {
     // update title and description
     document.title = createTitle(siteData, pageData)
 
-    document
-      .querySelector(`meta[name=description]`)!
-      .setAttribute('content', pageDescription || siteData.description)
+    const description = pageDescription || siteData.description
+    let metaDescriptionElement = document.querySelector(
+      `meta[name=description]`
+    )
+    if (metaDescriptionElement) {
+      metaDescriptionElement.setAttribute('content', description)
+    } else {
+      createHeadElement(['meta', { name: 'description', content: description }])
+    }
 
     updateHeadTags(
       mergeHead(siteData.head, filterOutHeadDescription(frontmatterHead))


### PR DESCRIPTION
As vitepress provide a way to completely rewrite the head content through the `transformHtml` nothing guarantee the presence of  `<meta name="description">` in the head of the page.
In case of the first page does not contain this tag, when the user clicks to navigate he gets a `TypeError: document.querySelector(...) is null` 

This PR relaxes this part of the code and make it more flexible by creating it if needed