### PR TITLE
feat: set markdown-it-attrs plugin default delimiter options

### DIFF
--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -433,8 +433,8 @@ interface MarkdownOptions extends MarkdownIt.Options {
   // markdown-it-attrs plugin options.
   // See: https://github.com/arve0/markdown-it-attrs
   attrs?: {
-    leftDelimiter?: string
-    rightDelimiter?: string
+    leftDelimiter?: string // default '%{'
+    rightDelimiter?: string // default '}%'
     allowedAttributes?: string[]
     disable?: boolean
   }

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -96,7 +96,11 @@ export const createMarkdownRenderer = async (
 
   // 3rd party plugins
   if (!options.attrs?.disable) {
-    md.use(attrsPlugin, options.attrs)
+    md.use(attrsPlugin, {
+      leftDelimiter: '%{',
+      rightDelimiter: '}%',
+      ...options.attrs
+    })
   }
   md.use(emojiPlugin)
 


### PR DESCRIPTION
https://github.com/vuejs/vitepress/issues/2634
https://github.com/vuejs/vitepress/issues/2440
https://github.com/vuejs/vitepress/issues/2046

These issues are experiencing similar problem, and I think it's necessary to set the markdown-it-attrs plugin's options regarding delimiters to a specific one character, rather than simply `{` and `}`, otherwise the compiled code can easily break vue syntax and crash the page.

For example, if the text is `{ minRows: 6, maxRows: 6 }`, will cause the page to crash.