### PR TITLE
fix(theme): nav height cannot be a fixed number

### DIFF
--- a/src/client/theme-default/components/VPLocalNav.vue
+++ b/src/client/theme-default/components/VPLocalNav.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useWindowScroll } from '@vueuse/core'
 import { onContentUpdated } from 'vitepress'
-import { computed, shallowRef } from 'vue'
+import { computed, shallowRef, ref, onMounted } from 'vue'
 import { useData } from '../composables/data'
 import { useSidebar } from '../composables/sidebar'
 import { getHeaders, type MenuItem } from '../composables/outline'
@@ -16,15 +16,20 @@ defineEmits<{
   (e: 'open-menu'): void
 }>()
 
-const navHeight = getComputedStyle(document.documentElement).getPropertyValue(
-  '--vp-nav-height'
-)
-
 const { theme, frontmatter } = useData()
 const { hasSidebar } = useSidebar()
 const { y } = useWindowScroll()
 
 const headers = shallowRef<MenuItem[]>([])
+const navHeight = ref(0)
+
+onMounted(() => {
+  navHeight.value = parseInt(
+    getComputedStyle(document.documentElement).getPropertyValue(
+      '--vp-nav-height'
+    )
+  )
+})
 
 onContentUpdated(() => {
   headers.value = getHeaders(frontmatter.value.outline ?? theme.value.outline)
@@ -38,14 +43,14 @@ const classes = computed(() => {
   return {
     VPLocalNav: true,
     fixed: empty.value,
-    'reached-top': y.value >= parseInt(navHeight)
+    'reached-top': y.value >= navHeight.value
   }
 })
 </script>
 
 <template>
   <div
-    v-if="frontmatter.layout !== 'home' && (!empty || y >= parseInt(navHeight))"
+    v-if="frontmatter.layout !== 'home' && (!empty || y >= navHeight)"
     :class="classes"
   >
     <button
@@ -61,7 +66,7 @@ const classes = computed(() => {
       </span>
     </button>
 
-    <VPLocalNavOutlineDropdown :headers="headers" />
+    <VPLocalNavOutlineDropdown :headers="headers" :navHeight="navHeight" />
   </div>
 </template>
 

--- a/src/client/theme-default/components/VPLocalNav.vue
+++ b/src/client/theme-default/components/VPLocalNav.vue
@@ -16,6 +16,10 @@ defineEmits<{
   (e: 'open-menu'): void
 }>()
 
+const navHeight = getComputedStyle(document.documentElement).getPropertyValue(
+  '--vp-nav-height'
+)
+
 const { theme, frontmatter } = useData()
 const { hasSidebar } = useSidebar()
 const { y } = useWindowScroll()
@@ -34,14 +38,14 @@ const classes = computed(() => {
   return {
     VPLocalNav: true,
     fixed: empty.value,
-    'reached-top': y.value >= 64
+    'reached-top': y.value >= parseInt(navHeight)
   }
 })
 </script>
 
 <template>
   <div
-    v-if="frontmatter.layout !== 'home' && (!empty || y >= 64)"
+    v-if="frontmatter.layout !== 'home' && (!empty || y >= parseInt(navHeight))"
     :class="classes"
   >
     <button

--- a/src/client/theme-default/components/VPLocalNavOutlineDropdown.vue
+++ b/src/client/theme-default/components/VPLocalNavOutlineDropdown.vue
@@ -6,13 +6,10 @@ import { resolveTitle, type MenuItem } from '../composables/outline'
 import VPDocOutlineItem from './VPDocOutlineItem.vue'
 import VPIconChevronRight from './icons/VPIconChevronRight.vue'
 
-defineProps<{
+const props = defineProps<{
   headers: MenuItem[]
+  navHeight: number
 }>()
-
-const navHeight = getComputedStyle(document.documentElement).getPropertyValue(
-  '--vp-nav-height'
-)
 
 const { theme } = useData()
 const open = ref(false)
@@ -25,8 +22,7 @@ onContentUpdated(() => {
 
 function toggle() {
   open.value = !open.value
-  vh.value =
-    window.innerHeight + Math.min(window.scrollY - parseInt(navHeight), 0)
+  vh.value = window.innerHeight + Math.min(window.scrollY - props.navHeight, 0)
 }
 
 function onItemClick(e: Event) {

--- a/src/client/theme-default/components/VPLocalNavOutlineDropdown.vue
+++ b/src/client/theme-default/components/VPLocalNavOutlineDropdown.vue
@@ -10,6 +10,10 @@ defineProps<{
   headers: MenuItem[]
 }>()
 
+const navHeight = getComputedStyle(document.documentElement).getPropertyValue(
+  '--vp-nav-height'
+)
+
 const { theme } = useData()
 const open = ref(false)
 const vh = ref(0)
@@ -21,7 +25,8 @@ onContentUpdated(() => {
 
 function toggle() {
   open.value = !open.value
-  vh.value = window.innerHeight + Math.min(window.scrollY - 64, 0)
+  vh.value =
+    window.innerHeight + Math.min(window.scrollY - parseInt(navHeight), 0)
 }
 
 function onItemClick(e: Event) {


### PR DESCRIPTION
If I customize the height of `--vp-nav-height` to `80`, but the existing version uses a fixed nav height of `64`, some of the styles will be problematic.