### PR TITLE
fix(theme): code block style is broken inside custom block

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -226,11 +226,17 @@
 
 .vp-doc .custom-block div[class*='language-'] {
   margin: 8px 0;
+  border-radius: 8px;
 }
 
 .vp-doc .custom-block div[class*='language-'] code {
   font-weight: 400;
   background-color: transparent;
+}
+
+.vp-doc .custom-block .vp-code-group .tabs {
+  margin: 0;
+  border-radius: 8px 8px 0 0;
 }
 
 /**


### PR DESCRIPTION
## Smal screen:
before:
![Snipaste_2023-07-21_22-41-38](https://github.com/vuejs/vitepress/assets/45784210/22e11f46-3ed0-42ba-ab70-9d315765dcc5)
after:
![Snipaste_2023-07-21_22-41-44](https://github.com/vuejs/vitepress/assets/45784210/ec3420b2-d727-4274-a791-f0b1269778ff)

## Large screen (`>= 640px`)
The same as before (no need to fix):
![Snipaste_2023-07-21_22-42-12](https://github.com/vuejs/vitepress/assets/45784210/485830b6-947d-4a18-a9c6-d89945a974d7)
