### PR TITLE
refactor(theme): remove redundant computed properties

### DIFF
--- a/src/client/theme-default/components/VPLink.vue
+++ b/src/client/theme-default/components/VPLink.vue
@@ -11,7 +11,6 @@ const props = defineProps<{
   rel?: string
 }>()
 
-const tag = computed(() => props.tag ?? (props.href ? 'a' : 'span'))
 const isExternal = computed(() => props.href && EXTERNAL_URL_RE.test(props.href))
 </script>
 


### PR DESCRIPTION
https://github.com/vuejs/vitepress/blob/51f28bfac96bbb14ea0175c796e0d18fff3b2cc5/src/client/theme-default/components/VPFeature.vue#L17

Since the `tag` attribute will definitely pass a value to the `VPLink` component, there is no need to use the computed attribute again.