### PR TITLE
feat: rel for feature links

### DIFF
--- a/docs/reference/default-theme-home-page.md
+++ b/docs/reference/default-theme-home-page.md
@@ -140,9 +140,9 @@ interface Feature {
   // e.g. `Learn more`, `Visit page`, etc.
   linkText?: string
 
-  // Link rel attribute for with `link` option.
+  // Link rel attribute for the `link` option.
   //
-  // e.g. `external`, etc.
+  // e.g. `external`
   rel?: string
 }
 

--- a/docs/reference/default-theme-home-page.md
+++ b/docs/reference/default-theme-home-page.md
@@ -139,6 +139,11 @@ interface Feature {
   //
   // e.g. `Learn more`, `Visit page`, etc.
   linkText?: string
+
+  // Link rel attribute for with `link` option.
+  //
+  // e.g. `external`, etc.
+  rel?: string
 }
 
 type FeatureIcon =

--- a/src/client/theme-default/components/VPFeature.vue
+++ b/src/client/theme-default/components/VPFeature.vue
@@ -10,11 +10,12 @@ defineProps<{
   details?: string
   link?: string
   linkText?: string
+  rel?: string
 }>()
 </script>
 
 <template>
-  <VPLink class="VPFeature" :href="link" :no-icon="true" :tag="link ? 'a' : 'div'">
+  <VPLink class="VPFeature" :href="link" :rel="rel" :no-icon="true" :tag="link ? 'a' : 'div'">
     <article class="box">
       <VPImage
         v-if="typeof icon === 'object'"

--- a/src/client/theme-default/components/VPFeatures.vue
+++ b/src/client/theme-default/components/VPFeatures.vue
@@ -9,6 +9,7 @@ export interface Feature {
   details: string
   link?: string
   linkText?: string
+  rel?: string
 }
 
 const props = defineProps<{
@@ -48,6 +49,7 @@ const grid = computed(() => {
             :details="feature.details"
             :link="feature.link"
             :link-text="feature.linkText"
+            :rel="feature.rel"
           />
         </div>
       </div>


### PR DESCRIPTION
This allows the `rel` attribute on feature links to be overridden.