### PR TITLE
fix: respect empty rel and target

### DIFF
--- a/src/client/theme-default/components/VPLink.vue
+++ b/src/client/theme-default/components/VPLink.vue
@@ -25,8 +25,8 @@ const isExternal = computed(() => props.href && EXTERNAL_URL_RE.test(props.href)
       'no-icon': noIcon
     }"
     :href="href ? normalizeLink(href) : undefined"
-    :target="target || (isExternal ? '_blank' : undefined)"
-    :rel="rel || (isExternal ? 'noreferrer' : undefined)"
+    :target="target ?? (isExternal ? '_blank' : undefined)"
+    :rel="rel ?? (isExternal ? 'noreferrer' : undefined)"
   >
     <slot />
   </component>


### PR DESCRIPTION
Currently if the `rel` or `target` is set to the empty string, it is treated as undefined, so there is no way to disable the default behavior without setting these properties to a truthy value. This change at least allows them to be set to the empty string.