### PR TITLE
fix: createContentLoader generates invalid url when sets `base`

### DIFF
--- a/src/node/contentLoader.ts
+++ b/src/node/contentLoader.ts
@@ -140,7 +140,7 @@ export function createContentLoader<T = ContentData[]>(
               : { excerpt: renderExcerpt }
           )
           const url =
-            '/' +
+            config.site.base +
             normalizePath(path.relative(config.srcDir, file))
               .replace(/(^|\/)index\.md$/, '$1')
               .replace(/\.md$/, config.cleanUrls ? '' : '.html')


### PR DESCRIPTION
fix https://github.com/vuejs/vitepress/issues/2710