### PR TITLE
refactor: use rollup type from vite

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -4,9 +4,8 @@ import { createRequire } from 'module'
 import path from 'path'
 import { packageDirectorySync } from 'pkg-dir'
 import { rimraf } from 'rimraf'
-import type { OutputAsset, OutputChunk } from 'rollup'
 import { pathToFileURL } from 'url'
-import type { BuildOptions } from 'vite'
+import type { BuildOptions, Rollup } from 'vite'
 import { resolveConfig, type SiteConfig } from '../config'
 import { slash, type HeadConfig } from '../shared'
 import { deserializeFunctions, serializeFunctions } from '../utils/fnSerialize'
@@ -57,13 +56,13 @@ export async function build(
             chunk.type === 'chunk' &&
             chunk.isEntry &&
             chunk.facadeModuleId?.endsWith('.js')
-        ) as OutputChunk)
+        ) as Rollup.OutputChunk)
 
       const cssChunk = (
         siteConfig.mpa ? serverResult : clientResult!
       ).output.find(
         (chunk) => chunk.type === 'asset' && chunk.fileName.endsWith('.css')
-      ) as OutputAsset
+      ) as Rollup.OutputAsset
 
       const assets = (siteConfig.mpa ? serverResult : clientResult!).output
         .filter(

--- a/src/node/build/buildMPAClient.ts
+++ b/src/node/build/buildMPAClient.ts
@@ -1,5 +1,4 @@
-import { build } from 'vite'
-import type { RollupOutput } from 'rollup'
+import { build, type Rollup } from 'vite'
 import type { SiteConfig } from '..'
 
 const virtualEntry = 'client.js'
@@ -7,7 +6,7 @@ const virtualEntry = 'client.js'
 export async function buildMPAClient(
   js: Record<string, string>,
   config: SiteConfig
-): Promise<RollupOutput> {
+): Promise<Rollup.RollupOutput> {
   const files = Object.keys(js)
   const themeFiles = files.filter((f) => !f.endsWith('.md'))
   const pages = files.filter((f) => f.endsWith('.md'))
@@ -43,5 +42,5 @@ export async function buildMPAClient(
         }
       }
     ]
-  }) as Promise<RollupOutput>
+  }) as Promise<Rollup.RollupOutput>
 }

--- a/src/node/build/bundle.ts
+++ b/src/node/build/bundle.ts
@@ -1,11 +1,11 @@
 import fs from 'fs-extra'
 import path from 'path'
-import type { GetModuleInfo, RollupOutput } from 'rollup'
 import { fileURLToPath } from 'url'
 import {
   build,
   normalizePath,
   type BuildOptions,
+  type Rollup,
   type UserConfig as ViteUserConfig
 } from 'vite'
 import { APP_PATH } from '../alias'
@@ -28,8 +28,8 @@ export async function bundle(
   config: SiteConfig,
   options: BuildOptions
 ): Promise<{
-  clientResult: RollupOutput | null
-  serverResult: RollupOutput
+  clientResult: Rollup.RollupOutput | null
+  serverResult: Rollup.RollupOutput
   pageToHashMap: Record<string, string>
 }> {
   const pageToHashMap = Object.create(null)
@@ -139,14 +139,16 @@ export async function bundle(
     }
   })
 
-  let clientResult!: RollupOutput | null
-  let serverResult!: RollupOutput
+  let clientResult!: Rollup.RollupOutput | null
+  let serverResult!: Rollup.RollupOutput
 
   await task('building client + server bundles', async () => {
     clientResult = config.mpa
       ? null
-      : ((await build(await resolveViteConfig(false))) as RollupOutput)
-    serverResult = (await build(await resolveViteConfig(true))) as RollupOutput
+      : ((await build(await resolveViteConfig(false))) as Rollup.RollupOutput)
+    serverResult = (await build(
+      await resolveViteConfig(true)
+    )) as Rollup.RollupOutput
   })
 
   if (config.mpa) {
@@ -180,7 +182,7 @@ const cache = new Map<string, boolean>()
 /**
  * Check if a module is statically imported by at least one entry.
  */
-function isEagerChunk(id: string, getModuleInfo: GetModuleInfo) {
+function isEagerChunk(id: string, getModuleInfo: Rollup.GetModuleInfo) {
   if (
     id.includes('node_modules') &&
     !/\.css($|\\?)/.test(id) &&
@@ -192,7 +194,7 @@ function isEagerChunk(id: string, getModuleInfo: GetModuleInfo) {
 
 function staticImportedByEntry(
   id: string,
-  getModuleInfo: GetModuleInfo,
+  getModuleInfo: Rollup.GetModuleInfo,
   cache: Map<string, boolean>,
   importStack: string[] = []
 ): boolean {

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -2,9 +2,8 @@ import { isBooleanAttr } from '@vue/shared'
 import escape from 'escape-html'
 import fs from 'fs-extra'
 import path from 'path'
-import type { OutputAsset, OutputChunk, RollupOutput } from 'rollup'
 import { pathToFileURL } from 'url'
-import { normalizePath, transformWithEsbuild } from 'vite'
+import { normalizePath, transformWithEsbuild, type Rollup } from 'vite'
 import type { SiteConfig } from '../config'
 import {
   EXTERNAL_URL_RE,
@@ -23,9 +22,9 @@ export async function renderPage(
   render: (path: string) => Promise<SSGContext>,
   config: SiteConfig,
   page: string, // foo.md
-  result: RollupOutput | null,
-  appChunk: OutputChunk | null,
-  cssChunk: OutputAsset | null,
+  result: Rollup.RollupOutput | null,
+  appChunk: Rollup.OutputChunk | null,
+  cssChunk: Rollup.OutputAsset | null,
   assets: string[],
   pageToHashMap: Record<string, string>,
   metadataScript: { html: string; inHead: boolean },
@@ -137,7 +136,7 @@ export async function renderPage(
       (chunk) =>
         chunk.type === 'chunk' &&
         chunk.facadeModuleId === slash(path.join(config.srcDir, page))
-    ) as OutputChunk
+    ) as Rollup.OutputChunk
     if (matchingChunk) {
       if (!matchingChunk.code.includes('import')) {
         inlinedScript = `<script type="module">${matchingChunk.code}</script>`
@@ -198,8 +197,8 @@ export async function renderPage(
 function resolvePageImports(
   config: SiteConfig,
   page: string,
-  result: RollupOutput,
-  appChunk: OutputChunk
+  result: Rollup.RollupOutput,
+  appChunk: Rollup.OutputChunk
 ) {
   page = config.rewrites.inv[page] || page
   // find the page's js chunk and inject script tags for its imports so that
@@ -214,7 +213,7 @@ function resolvePageImports(
   srcPath = normalizePath(srcPath)
   const pageChunk = result.output.find(
     (chunk) => chunk.type === 'chunk' && chunk.facadeModuleId === srcPath
-  ) as OutputChunk
+  ) as Rollup.OutputChunk
   return [
     ...appChunk.imports,
     ...appChunk.dynamicImports,

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -1,11 +1,11 @@
 import path from 'path'
 import c from 'picocolors'
-import type { OutputAsset, OutputChunk } from 'rollup'
 import {
   mergeConfig,
   searchForWorkspaceRoot,
   type Plugin,
   type ResolvedConfig,
+  type Rollup,
   type UserConfig
 } from 'vite'
 import {
@@ -46,8 +46,8 @@ const staticRestoreRE = /__VP_STATIC_(START|END)__/g
 const scriptClientRE = /<script\b[^>]*client\b[^>]*>([^]*?)<\/script>/
 
 const isPageChunk = (
-  chunk: OutputAsset | OutputChunk
-): chunk is OutputChunk & { facadeModuleId: string } =>
+  chunk: Rollup.OutputAsset | Rollup.OutputChunk
+): chunk is Rollup.OutputChunk & { facadeModuleId: string } =>
   !!(
     chunk.type === 'chunk' &&
     chunk.isEntry &&
@@ -266,7 +266,7 @@ export async function createVitePressPlugin(
     },
 
     renderChunk(code, chunk) {
-      if (!ssr && isPageChunk(chunk as OutputChunk)) {
+      if (!ssr && isPageChunk(chunk as Rollup.OutputChunk)) {
         // For each page chunk, inject marker for start/end of static strings.
         // we do this here because in generateBundle the chunks would have been
         // minified and we won't be able to safely locate the strings.


### PR DESCRIPTION
Use the `Rollup` type from Vite so future Rollup upgrades within Vite won't have potential mismatch issues, as different Rollup versions' types are sometimes incompatible with each other.