### PR TITLE
refactor: use stringified deserializeFunctions util

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -176,7 +176,7 @@ function generateMetadataScript(
 
   const metadataContent = `window.__VP_HASH_MAP__=JSON.parse(${hashMapString});${
     siteDataString.includes('_vp-fn_')
-      ? `${deserializeFunctions.toString()};window.__VP_SITE_DATA__=deserializeFunctions(JSON.parse(${siteDataString}));`
+      ? `${deserializeFunctions};window.__VP_SITE_DATA__=deserializeFunctions(JSON.parse(${siteDataString}));`
       : `window.__VP_SITE_DATA__=JSON.parse(${siteDataString});`
   }`
 

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -172,8 +172,7 @@ export async function createVitePressPlugin(
           }
         }
         data = serializeFunctions(data)
-        return `${deserializeFunctions.toString()}
-        export default deserializeFunctions(JSON.parse(${JSON.stringify(
+        return `${deserializeFunctions};export default deserializeFunctions(JSON.parse(${JSON.stringify(
           JSON.stringify(data)
         )}))`
       }

--- a/src/node/utils/fnSerialize.ts
+++ b/src/node/utils/fnSerialize.ts
@@ -20,6 +20,7 @@ export function serializeFunctions(value: any, key?: string): any {
   }
 }
 
+/*
 export function deserializeFunctions(value: any): any {
   if (Array.isArray(value)) {
     return value.map(deserializeFunctions)
@@ -34,3 +35,7 @@ export function deserializeFunctions(value: any): any {
     return value
   }
 }
+*/
+
+export const deserializeFunctions =
+  'function deserializeFunctions(r){return Array.isArray(r)?r.map(deserializeFunctions):typeof r=="object"&&r!==null?Object.keys(r).reduce((t,n)=>(t[n]=deserializeFunctions(r[n]),t),{}):typeof r=="string"&&r.startsWith("_vp-fn_")?new Function(`return ${r.slice(7)}`)():r}'


### PR DESCRIPTION
Bun currently has a bug that prevents that function from being properly serialized. Other than that a simple app seems to work fine.

To run use:

```sh
bun add -d vitepress

bunx --bun vitepress
NODE_ENV=production bunx --bun vitepress build
bunx --bun vitepress preview
```

Note that there might still be some rough edges. But we will be trying to fix whatever we can at the project level.

Some bugs that I saw currently with Bun:
- terminal shortcuts don't work
- manually need to specify NODE_ENV for build -- we have an override in the cli but that doesn't work yet in bun

There are already issues open at bun's side for these. Hopefully some of them will be addressed before their v1 release planned next month.