### PR TITLE
chore(build)!: drop cjs api

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -47,6 +47,12 @@ If using PNPM, you will notice a missing peer warning for `@docsearch/js`. This 
 
 :::
 
+::: tip NOTE
+
+VitePress is an ESM-only package. Don't use `require()` to import it, and make sure your nearest `package.json` contains `"type": "module"`, or change the file extension of your relevant files like `.vitepress/config.js` to `.mjs`/`.mts`. Refer [Vite's troubleshooting guide](http://vitejs.dev/guide/troubleshooting.html#this-package-is-esm-only) for more details. Also, inside async CJS contexts, you can use `await import('vitepress')` instead.
+
+:::
+
 ### Setup Wizard
 
 VitePress ships with a command line setup wizard that will help you scaffold a basic project. After installation, start the wizard by running:

--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -10,7 +10,7 @@ Site config is where you can define the global settings of the site. App config 
 
 ### Config Resolution
 
-The config file is always resolved from `<root>/.vitepress/config.[ext]`, where `<root>` is your VitePress [project root](../guide/routing#root-and-source-directory), and `[ext]` is one of the supported file extensions. TypeScript is supported out of the box. Supported extensions include `.js`, `.ts`, `.cjs`, `.mjs`, `.cts`, and `.mts`.
+The config file is always resolved from `<root>/.vitepress/config.[ext]`, where `<root>` is your VitePress [project root](../guide/routing#root-and-source-directory), and `[ext]` is one of the supported file extensions. TypeScript is supported out of the box. Supported extensions include `.js`, `.ts`, `.mjs`, and `.mts`.
 
 It is recommended to use ES modules syntax in config files. The config file should default export an object:
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/node/index.js",
-      "require": "./dist/node-cjs/index.cjs"
+      "default": "./dist/node/index.js"
     },
     "./dist/*": "./dist/*",
     "./package.json": "./package.json",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -62,21 +62,6 @@ const esmBuild: RollupOptions = {
   }
 }
 
-const cjsBuild: RollupOptions = {
-  input: [r('src/node/index.ts'), r('src/node/cli.ts')],
-  output: {
-    format: 'cjs',
-    dir: r('dist/node-cjs'),
-    entryFileNames: `[name].cjs`,
-    chunkFileNames: 'serve-[hash].cjs'
-  },
-  external,
-  plugins,
-  onwarn(warning, warn) {
-    if (warning.code !== 'EVAL') warn(warning)
-  }
-}
-
 const nodeTypes: RollupOptions = {
   input: r('src/node/index.ts'),
   output: {
@@ -110,11 +95,6 @@ const clientTypes: RollupOptions = {
 const config = defineConfig([])
 
 config.push(esmBuild)
-
-if (PROD) {
-  config.push(cjsBuild)
-}
-
 config.push(nodeTypes)
 config.push(clientTypes)
 

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -138,7 +138,7 @@ export async function resolveConfig(
   return config
 }
 
-const supportedConfigExtensions = ['js', 'ts', 'cjs', 'mjs', 'cts', 'mts']
+const supportedConfigExtensions = ['js', 'ts', 'mjs', 'mts']
 
 export async function resolveUserConfig(
   root: string,

--- a/theme-without-fonts.d.ts
+++ b/theme-without-fonts.d.ts
@@ -1,2 +1,2 @@
-export * from './theme'
-export { default } from './theme'
+export * from './theme.js'
+export { default } from './theme.js'


### PR DESCRIPTION
BREAKING CHANGE!

Drops Node CJS API. It is recommended to use 

`import {} from vitepress`

instead of 

`const {} = require('vitepress')`

and `"type": "module"` at the nearest `package.json`  or `.mjs`/`.mts` extension for defining config (or other files where vitepress' node API is being used).

Trying to use CJS build will yield error:

```
"vitepress" resolved to an ESM file. ESM file cannot be loaded by `require`. See http://vitejs.dev/guide/troubleshooting.html#this-package-is-esm-only for more details. [plugin externalize-deps]

...

  The plugin "externalize-deps" was triggered by this import

    .vitepress/config.js:1:281:
      1 │ ...foo/.vitepress/config.js";const __vite_injected_original_import_meta_url = "file:///Users/brc-dd/foo/.vitepress/config.js";import { defineConfig } from 'vitepress'
        ╵                                                                                                                                                            ~~~~~~~~~~~

failed to load config from /Users/brc-dd/foo/.vitepress/config.js
```

The link in the error message should be sufficient for resolving most cases. In case of any issues, post it in #2703 itself. That issue won't be locked.

closes #2703

<details>
  <summary>attw results</summary>

```
"vitepress"

node10: 🟢 
node16 (from CJS): ⚠️ ESM (dynamic import only)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"vitepress/package.json"

node10: 🟢 (JSON)
node16 (from CJS): 🟢 (JSON)
node16 (from ESM): 🟢 (JSON)
bundler: 🟢 (JSON)

***********************************

"vitepress/client"

node10: 🟢 
node16 (from CJS): ⚠️ ESM (dynamic import only)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"vitepress/theme"

node10: 🟢 
node16 (from CJS): ⚠️ ESM (dynamic import only)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"vitepress/theme-without-fonts"

node10: 🟢 
node16 (from CJS): ⚠️ ESM (dynamic import only)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************
```

</details>