### PR TITLE
feat(build): allow overriding vite config loading

### DIFF
--- a/src/node/build/bundle.ts
+++ b/src/node/build/bundle.ts
@@ -6,7 +6,7 @@ import {
   normalizePath,
   type BuildOptions,
   type Rollup,
-  type UserConfig as ViteUserConfig
+  type InlineConfig as ViteInlineConfig
 } from 'vite'
 import { APP_PATH } from '../alias'
 import type { SiteConfig } from '../config'
@@ -50,7 +50,9 @@ export async function bundle(
   // resolve options to pass to vite
   const { rollupOptions } = options
 
-  const resolveViteConfig = async (ssr: boolean): Promise<ViteUserConfig> => ({
+  const resolveViteConfig = async (
+    ssr: boolean
+  ): Promise<ViteInlineConfig> => ({
     root: config.srcDir,
     cacheDir: config.cacheDir,
     base: config.site.base,
@@ -136,7 +138,8 @@ export async function bundle(
               })
         }
       }
-    }
+    },
+    configFile: config.vite?.configFile
   })
 
   let clientResult!: Rollup.RollupOutput | null

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -23,6 +23,7 @@ export async function createServer(
     cacheDir: config.cacheDir,
     plugins: await createVitePressPlugin(config, false, {}, {}, recreateServer),
     server: serverOptions,
-    customLogger: config.logger
+    customLogger: config.logger,
+    configFile: config.vite?.configFile
   })
 }

--- a/src/node/siteConfig.ts
+++ b/src/node/siteConfig.ts
@@ -83,7 +83,7 @@ export interface UserConfig<ThemeConfig = any>
   /**
    * Vite config
    */
-  vite?: ViteConfig
+  vite?: ViteConfig & { configFile?: string | false }
 
   /**
    * Configure the scroll offset when the theme has a sticky header.


### PR DESCRIPTION
By default, Vite will load the `vite.config.{js,mjs,ts,mts}` from the `root`. One can disable this behavior by having some config like this:

```ts
// .vitepress/config.ts

export default {
  vite: {
    configFile: false
  }
}
```

One can also pass a string in `configFile` pointing to some different vite config file (resolved relative to `cwd`). But it is recommended to use the `vite` key in vitepress config file instead.

Disabling config auto loading will allow users to keep their vite and vitepress project at the same root.