### PR TITLE
fix: scroll-to-top in iOS when opens sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@vue/devtools-api": "^6.5.0",
     "@vueuse/core": "^10.3.0",
     "@vueuse/integrations": "^10.3.0",
-    "body-scroll-lock": "4.0.0-beta.0",
+    "body-scroll-lock": "3.1.5",
     "focus-trap": "^7.5.2",
     "mark.js": "8.11.1",
     "minisearch": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^10.3.0
         version: 10.3.0(focus-trap@7.5.2)(vue@3.3.4)
       body-scroll-lock:
-        specifier: 4.0.0-beta.0
-        version: 4.0.0-beta.0
+        specifier: 3.1.5
+        version: 3.1.5
       focus-trap:
         specifier: ^7.5.2
         version: 7.5.2
@@ -1835,8 +1835,8 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
-  /body-scroll-lock@4.0.0-beta.0:
-    resolution: {integrity: sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==}
+  /body-scroll-lock@3.1.5:
+    resolution: {integrity: sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==}
     dev: false
 
   /brace-expansion@1.1.11:


### PR DESCRIPTION
https://github.com/vuejs/vitepress/assets/44596995/3ba55be6-c47a-41ae-9732-d47355890838

Scrolling to the top of the document when clicking on the menu button to open the sidebar in iOS. It's a bug.
Since `body-scroll-lock` has not been maintained for a long time since version `4.0.0-beta.0`. I think it's possible to downgrade to version `3.1.5` as many developers using this library verified the feasibility in https://github.com/willmcpo/body-scroll-lock/issues/237.

![image](https://github.com/vuejs/vitepress/assets/44596995/ebeeb64d-45b0-43d7-9513-78563bb295fb)

Version `3.1.5` has more weekly npm downloads than version `4.0.0-beta.0`.

IOS version: 16.3
Browser: Safari