### PR TITLE
fix(theme): revert 79 to 179 in yellow-soft

### DIFF
--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -62,7 +62,7 @@
   --vp-c-yellow-1: #915930;
   --vp-c-yellow-2: #946300;
   --vp-c-yellow-3: #9f6a00;
-  --vp-c-yellow-soft: rgba(234, 79, 8, 0.14);
+  --vp-c-yellow-soft: rgba(234, 179, 8, 0.14);
 
   --vp-c-red-1: #b8272c;
   --vp-c-red-2: #d5393e;


### PR DESCRIPTION
#2797 introduced `--vp-c-yellow-soft` for background yellow. In the dark theme this uses `rgba(234, 179, 8, 0.16)`, but for the light theme it is `rgba(234, 79, 8, 0.14)`. I believe that `79` is a typo and it should be `179` in both cases.

I don't see anything in the description of that PR that suggests the change from `179` to `79` was intentional. The new 'yellow' isn't actually yellow, despite the variable name.

This yellow background is used in a couple of places, most notably for warning containers. The picture below shows the impact of my change on the warning containers:

![VitePress containers](https://github.com/vuejs/vitepress/assets/65301168/076a79ef-8cf8-4a38-9564-8bcc03bb947f)
