### PR TITLE
Revert "fix: createContentLoader generates invalid url when sets `base`"

### DIFF
--- a/docs/guide/data-loading.md
+++ b/docs/guide/data-loading.md
@@ -99,7 +99,8 @@ The loaded data will be an array with the type of `ContentData[]`:
 
 ```ts
 interface ContentData {
-  // mapped absolute URL for the page. e.g. /posts/hello.html
+  // mapped URL for the page. e.g. /posts/hello.html (does not include base)
+  // manually iterate or use custom `transform` to normalize the paths
   url: string
   // frontmatter data of the page
   frontmatter: Record<string, any>

--- a/src/node/contentLoader.ts
+++ b/src/node/contentLoader.ts
@@ -140,7 +140,7 @@ export function createContentLoader<T = ContentData[]>(
               : { excerpt: renderExcerpt }
           )
           const url =
-            config.site.base +
+            '/' +
             normalizePath(path.relative(config.srcDir, file))
               .replace(/(^|\/)index\.md$/, '$1')
               .replace(/\.md$/, config.cleanUrls ? '' : '.html')


### PR DESCRIPTION
Reverts vuejs/vitepress#2714
closes #2862

If the user wants the `base` to be prepended, they can manually do so using the `transform` function in `createContentLoader`.