### PR TITLE
fix(theme): link hover color inside a custom block

### DIFF
--- a/src/client/theme-default/styles/components/custom-block.css
+++ b/src/client/theme-default/styles/components/custom-block.css
@@ -18,6 +18,10 @@
   color: var(--vp-c-brand-1);
 }
 
+.custom-block.info a:hover {
+  color: var(--vp-c-brand-2);
+}
+
 .custom-block.info code {
   background-color: var(--vp-custom-block-info-code-bg);
 }
@@ -31,6 +35,10 @@
 .custom-block.tip a,
 .custom-block.tip code {
   color: var(--vp-c-brand-1);
+}
+
+.custom-block.tip a:hover {
+  color: var(--vp-c-brand-2);
 }
 
 .custom-block.tip code {
@@ -48,6 +56,10 @@
   color: var(--vp-c-warning-1);
 }
 
+.custom-block.warning a:hover {
+  color: var(--vp-c-warning-2);
+}
+
 .custom-block.warning code {
   background-color: var(--vp-custom-block-warning-code-bg);
 }
@@ -63,6 +75,10 @@
   color: var(--vp-c-danger-1);
 }
 
+.custom-block.danger a:hover {
+  color: var(--vp-c-danger-2);
+}
+
 .custom-block.danger code {
   background-color: var(--vp-custom-block-danger-code-bg);
 }
@@ -75,6 +91,10 @@
 
 .custom-block.details a {
   color: var(--vp-c-brand-1);
+}
+
+.custom-block.details a:hover {
+  color: var(--vp-c-brand-2);
 }
 
 .custom-block.details code {


### PR DESCRIPTION
This PR explicitly sets the `a:hover` style for links inside custom blocks.

A link inside a `warning` block uses the yellow theme, but the `:hover` uses the brand theme:

![Custom block link](https://github.com/vuejs/vitepress/assets/65301168/7f5029b4-87af-4fa0-a83c-05219ecbc4da)

There's a similar problem for `danger` blocks.

It's a bit more complicated for `tip`, `info` and `details` blocks. In theory, they have the same problem. However, the current CSS overrides for those 3 custom blocks set the link `color` to `--vp-c-brand-1`, which is what it would be anyway. As a result, there isn't a visual inconsistency on `:hover`, as it just inherits the default `color` of `--vp-c-brand-2`. I've chosen to include an explicit `:hover` override for those 3 custom blocks too. It seems inconsistent to set the `color` for `a` but not `a:hover`.