### PR TITLE
fix(types): NavItem can only have either link or items

### DIFF
--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -154,6 +154,7 @@ export namespace DefaultTheme {
   export interface NavItemWithLink {
     text: string
     link: string
+    items?: never
 
     /**
      * `activeMatch` is expected to be a regex string. We can't use actual


### PR DESCRIPTION
Currently, if both `link` and `items` are provided for a navItem, `items` will not work(dropdown will not show).

![image](https://github.com/vuejs/vitepress/assets/55378595/f9c564be-38de-40b6-ba66-08614fd58a19)

The navItem should only have either `link` or `items` key, so it should throw error in ts when a navItem receives both `link` and `items`.
![image](https://github.com/vuejs/vitepress/assets/55378595/0685ff46-10a8-4218-a300-ab5ec6b27016)

[Conflict Example repo](https://stackblitz.com/edit/stackblitz-starters-8othsh?file=.vitepress%2Fconfig.ts)