### PR TITLE
fix(theme): improve contrast of search highlight text

### DIFF
--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -508,5 +508,5 @@
   --vp-local-search-result-selected-bg: var(--vp-c-bg);
   --vp-local-search-result-selected-border: var(--vp-c-brand-1);
   --vp-local-search-highlight-bg: var(--vp-c-green-1);
-  --vp-local-search-highlight-text: var(--vp-c-black);
+  --vp-local-search-highlight-text: var(--vp-c-neutral-inverse);
 }


### PR DESCRIPTION
This PR changes the text `color` used for highlights within the local search. This is to improve the contrast in light mode.

The screenshot below shows:
1. First row - prior to #2797. Note that the `background-color` for highlights is the same for both light and dark mode.
2. Second row - current VitePress theme. The `background-color` is using the green theme, which varies between dark and light mode. In light mode, both the text and background are dark.
3. Third row - this PR. The `color` for the text in light mode is now white, for greater contrast with the background.

![image](https://github.com/vuejs/vitepress/assets/65301168/827f84d1-3c20-491b-9b47-278eb0c37cac)

I've used `--vp-c-neutral-inverse` for the text. I'm unclear if this is the correct variable, but it gives the desired result of black or white, depending on the current theme mode.