### PR TITLE
feat: skip rendering if env.BUNDLE_ONLY is truthy

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -45,6 +45,10 @@ export async function build(
       buildOptions
     )
 
+    if (process.env.BUNDLE_ONLY) {
+      return
+    }
+
     const entryPath = path.join(siteConfig.tempDir, 'app.js')
     const { render } = await import(pathToFileURL(entryPath).toString())
 


### PR DESCRIPTION
closes #2878

usage: `BUNDLE_ONLY=true vitepress build`, use cross-env (or `shell-emulator=true` in npmrc if using pnpm) on Windows