### PR TITLE
feat: highlight nav by default when one of the items is matched

### DIFF
--- a/src/client/theme-default/components/VPNavBarMenuGroup.vue
+++ b/src/client/theme-default/components/VPNavBarMenuGroup.vue
@@ -1,14 +1,29 @@
 <script lang="ts" setup>
 import type { DefaultTheme } from 'vitepress/theme'
+import { computed } from 'vue'
 import { useData } from '../composables/data'
 import { isActive } from '../../shared'
 import VPFlyout from './VPFlyout.vue'
 
-defineProps<{
+const props = defineProps<{
   item: DefaultTheme.NavItemWithChildren
 }>()
 
 const { page } = useData()
+
+const isChildActive = (navItem: DefaultTheme.NavItem) => {
+  if ('link' in navItem) {
+    return isActive(
+      page.value.relativePath,
+      navItem.link,
+      !!props.item.activeMatch
+    )
+  } else {
+    return navItem.items.some(isChildActive)
+  }
+}
+
+const childrenActive = computed(() => isChildActive(props.item))
 </script>
 
 <template>
@@ -19,7 +34,7 @@ const { page } = useData()
         page.relativePath,
         item.activeMatch,
         !!item.activeMatch
-      )
+      ) || childrenActive
     }"
     :button="item.text"
     :items="item.items"


### PR DESCRIPTION
Currently, you have to set `activeMatch` to highlight the navgroup, otherwise the nav will not be hightlighted when child item is active.
<img width="1386" alt="image" src="https://github.com/vuejs/vitepress/assets/55378595/9e4150df-244c-44c8-a296-3eb4eaea0ee0">

I personally think that it'll be better and more comprehensive to highlight the nav by default when one of the items is matched.

With this PR, nav can be highlighted even with nested items
<img width="1440" alt="image" src="https://github.com/vuejs/vitepress/assets/55378595/df61a569-fbfc-47ea-9cb4-c4a6174a84e9">
<img width="1312" alt="image" src="https://github.com/vuejs/vitepress/assets/55378595/649241d3-1578-4f66-9449-5d3d850a8fd8">
