### PR TITLE
Provide a property "target" for setting the redirect action for featu…

### DIFF
--- a/src/client/theme-default/components/VPFeature.vue
+++ b/src/client/theme-default/components/VPFeature.vue
@@ -18,7 +18,7 @@ defineProps<{
 <template>
   <VPLink class="VPFeature" :href="link"
     :rel="rel"
-    :target="target ? '_blank' : ''"
+    :target="target"
     :no-icon="true"
     :tag="link ? 'a' : 'div'"
   >

--- a/src/client/theme-default/components/VPFeature.vue
+++ b/src/client/theme-default/components/VPFeature.vue
@@ -16,7 +16,9 @@ defineProps<{
 </script>
 
 <template>
-  <VPLink class="VPFeature" :href="link"
+  <VPLink
+    class="VPFeature"
+    :href="link"
     :rel="rel"
     :target="target"
     :no-icon="true"

--- a/src/client/theme-default/components/VPFeature.vue
+++ b/src/client/theme-default/components/VPFeature.vue
@@ -11,11 +11,17 @@ defineProps<{
   link?: string
   linkText?: string
   rel?: string
+  target?: string
 }>()
 </script>
 
 <template>
-  <VPLink class="VPFeature" :href="link" :rel="rel" :no-icon="true" :tag="link ? 'a' : 'div'">
+  <VPLink class="VPFeature" :href="link"
+    :rel="rel"
+    :target="target ? '_blank' : ''"
+    :no-icon="true"
+    :tag="link ? 'a' : 'div'"
+  >
     <article class="box">
       <VPImage
         v-if="typeof icon === 'object'"

--- a/src/client/theme-default/components/VPFeatures.vue
+++ b/src/client/theme-default/components/VPFeatures.vue
@@ -10,6 +10,7 @@ export interface Feature {
   link?: string
   linkText?: string
   rel?: string
+  target?: string
 }
 
 const props = defineProps<{
@@ -50,6 +51,7 @@ const grid = computed(() => {
             :link="feature.link"
             :link-text="feature.linkText"
             :rel="feature.rel"
+            :target="feature.target"
           />
         </div>
       </div>


### PR DESCRIPTION
Resolves https://github.com/vuejs/vitepress/issues/2896.

This allows you to redirect new a tab page when clicking on a feature item.

Examples:

Set `target: _blank` for "Guide" feature item, and set nothing for "Reference" item. When click on "Guide" feature item, it will open a new tab page and redirect to it, while reflash in self page when click on "Reference" page.

```md
---
layout: home

title: VitePress
titleTemplate: Vite & Vue Powered Static Site Generator

hero:
  name: VitePress
  text: Vite & Vue Powered Static Site Generator
  tagline: Simple, powerful, and fast. Meet the modern SSG framework you've always wanted.
  actions:
    - theme: brand
      text: Get Started
      link: /guide/getting-started
    - theme: alt
      text: View on GitHub
      link: https://github.com/vuejs/vitepress
  image:
    src: /vitepress-logo-large.webp
    alt: VitePress

features:
  - title: Guide
    link: /guide/what-is-vitepress
    target: _blank
  - title: Reference
    link: /Reference/site-config
---
```

![result](https://github.com/vuejs/vitepress/assets/56240054/df8ce70a-a7eb-48a8-8d89-d9e2809c9b9d)
