### PR TITLE
feat(theme): prevent closing local search box on key enter

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -307,7 +307,15 @@ onKeyStroke('ArrowDown', (event) => {
 
 const router = useRouter()
 
-onKeyStroke('Enter', () => {
+onKeyStroke('Enter', (e) => {
+  if (e.target instanceof HTMLButtonElement && e.target.type !== 'submit')
+    return
+
+  if (e.target instanceof HTMLInputElement) {
+    e.preventDefault()
+    return
+  }
+
   const selectedPackage = results.value[selectedIndex.value]
   if (selectedPackage) {
     router.go(selectedPackage.id)
@@ -464,6 +472,7 @@ function formMarkRegex(terms: Set<string>) {
             <button
               v-if="!disableDetailedView"
               class="toggle-layout-button"
+              type="button"
               :class="{ 'detailed-list': showDetailedList }"
               :title="$t('modal.displayDetails')"
               @click="


### PR DESCRIPTION
The local search dialog shouldn't be closed when:
- key enter on input search
- key enter on details button
- key enter on reset search button