### PR TITLE
feat(theme): add search insights boolean to algolia search

### DIFF
--- a/types/docsearch.d.ts
+++ b/types/docsearch.d.ts
@@ -6,6 +6,7 @@ export interface DocSearchProps {
   searchParameters?: SearchOptions
   disableUserPersonalization?: boolean
   initialQuery?: string
+  insights?: boolean
   translations?: DocSearchTranslations
 }
 


### PR DESCRIPTION
This PR adds the ability to [send events](https://docsearch.algolia.com/docs/docsearch-v3/#sending-events) to your algolia docsearch instance. 

These events could later be used to [enable more algolia features](https://www.algolia.com/doc/guides/sending-events/getting-started/)