### PR TITLE
fix: customizing the starting line number even if globally set

### DIFF
--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -87,13 +87,18 @@ export async function highlight(
   const styleRE = /<pre[^>]*(style=".*?")/
   const preRE = /^<pre(.*?)>/
   const vueRE = /-vue$/
+  const lineNoStartRE = /=(\d*)/
   const lineNoRE = /:(no-)?line-numbers(=\d*)?$/
   const mustacheRE = /\{\{.*?\}\}/g
 
   return (str: string, lang: string, attrs: string) => {
     const vPre = vueRE.test(lang) ? '' : 'v-pre'
     lang =
-      lang.replace(lineNoRE, '').replace(vueRE, '').toLowerCase() || defaultLang
+      lang
+        .replace(lineNoStartRE, '')
+        .replace(lineNoRE, '')
+        .replace(vueRE, '')
+        .toLowerCase() || defaultLang
 
     if (lang) {
       const langLoaded = highlighter.getLoadedLanguages().includes(lang as any)

--- a/src/node/markdown/plugins/lineNumbers.ts
+++ b/src/node/markdown/plugins/lineNumbers.ts
@@ -19,7 +19,7 @@ export const lineNumberPlugin = (md: MarkdownIt, enable = false) => {
     }
 
     let startLineNumber = 1
-    const matchStartLineNumber = info.match(/:line-numbers=(\d*)/)
+    const matchStartLineNumber = info.match(/=(\d*)/)
     if (matchStartLineNumber && matchStartLineNumber[1]) {
       startLineNumber = parseInt(matchStartLineNumber[1])
     }

--- a/src/node/markdown/plugins/preWrapper.ts
+++ b/src/node/markdown/plugins/preWrapper.ts
@@ -40,6 +40,7 @@ export function extractTitle(info: string, html = false) {
 function extractLang(info: string) {
   return info
     .trim()
+    .replace(/=(\d*)/, '')
     .replace(/:(no-)?line-numbers({| |$|=\d*).*/, '')
     .replace(/(-vue|{| ).*$/, '')
     .replace(/^vue-html$/, 'template')


### PR DESCRIPTION
We cannot customize the starting line number when line number is globally set `true` and we don't set explicitly such as `:line-numbers` .
So I fixed [this PR](https://github.com/vuejs/vitepress/pull/2917).