### PR TITLE
fix: make algolia search work with indices that don't return absolute urls

### DIFF
--- a/src/client/theme-default/components/VPAlgoliaSearchBox.vue
+++ b/src/client/theme-default/components/VPAlgoliaSearchBox.vue
@@ -84,8 +84,8 @@ function initialize(userOptions: DefaultTheme.AlgoliaSearchOptions) {
   docsearch(options)
 }
 
-function getRelativePath(absoluteUrl: string) {
-  const { pathname, hash } = new URL(absoluteUrl)
+function getRelativePath(url: string) {
+  const { pathname, hash } = new URL(url, location.origin)
   return (
     pathname.replace(
       /\.html$/,


### PR DESCRIPTION
this enables the algolia search plugin to work also with indices crawled by the [netlify algolia plugin](https://www.algolia.com/doc/tools/crawler/netlify-plugin/quick-start/) which, depending on the configuration, can crawl pages with relative paths
| relative paths | absolute urls |
| --- | --- |
| <img width="321" alt="image" src="https://github.com/vuejs/vitepress/assets/7444615/ab25b5f6-ddde-4b07-988c-52ee0fed8095"> | <img width="321" alt="image" src="https://github.com/vuejs/vitepress/assets/7444615/b8b2b705-1bac-4c33-9b73-0b9b75a50cc8"> |


without the fix, using the algolia search plugin leads to
```
VPAlgoliaSearchBox.vue:88 Uncaught (in promise) TypeError: Failed to construct 'URL': Invalid URL
   at getRelativePath (VPAlgoliaSearchBox.vue:88:30)
```

when absolute URLs are provided the fix doesn't change the outcome because
```js
new URL('https://vitepress.dev/guide/what-is-vitepress#what-is-vitepress', 'https://github.com').origin
// 'https://vitepress.dev'
```