### PR TITLE
fix(types): add RegExp to markdown's allowed attributes

### DIFF
--- a/src/node/markdown/index.ts
+++ b/src/node/markdown/index.ts
@@ -43,7 +43,7 @@ export interface MarkdownOptions extends MarkdownIt.Options {
   attrs?: {
     leftDelimiter?: string
     rightDelimiter?: string
-    allowedAttributes?: string[]
+    allowedAttributes?: Array<string | RegExp>
     disable?: boolean
   }
   defaultHighlightLang?: string


### PR DESCRIPTION
While developing with Vitepress, I got an error when using RegExp in the allowed attributes:

<img width="994" alt="image" src="https://github.com/vuejs/vitepress/assets/3367820/1789e975-ad28-4af8-98e0-4760d14f4ced">


Other Reference: https://github.com/arve0/markdown-it-attrs#security

<img width="1036" alt="image" src="https://github.com/vuejs/vitepress/assets/3367820/6c67b293-c974-4f38-a4f0-bb8582f8472a">
