### PR TITLE
fix: textual code copy/paste feature

### DIFF
--- a/src/client/app/composables/copyCode.ts
+++ b/src/client/app/composables/copyCode.ts
@@ -23,6 +23,10 @@ export function useCopyCode() {
           .forEach((node) => (text += (node.textContent || '') + '\n'))
         text = text.slice(0, -1)
 
+        if (text.length === 0) {
+          text = sibling.textContent
+        }
+
         if (isShell) {
           text = text.replace(/^ *(\$|>) /gm, '').trim()
         }

--- a/src/client/app/composables/copyCode.ts
+++ b/src/client/app/composables/copyCode.ts
@@ -24,7 +24,7 @@ export function useCopyCode() {
         text = text.slice(0, -1)
 
         if (text.length === 0) {
-          text = sibling.textContent
+          text = sibling.textContent || ''
         }
 
         if (isShell) {


### PR DESCRIPTION
This PR fixes the copy/paste functionality for `text`ual codeblocks.

See [broken example](https://stackblitz.com/edit/vite-tcb2bk?file=docs%2Findex.md) - this PR fixes it.