### PR TITLE
fix: add declaration type for exclude option

### DIFF
--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -362,6 +362,14 @@ export namespace DefaultTheme {
      * @deprecated Use `detailedView: false` instead.
      */
     disableDetailedView?: boolean
+    /**
+     * exclude page from search if it returns true
+     * @example
+     * ```javascript
+     * exclude(relativePath) => relativePath.startsWith('/excluded-pages')
+     * ```
+     */
+    exclude: (relativePath: string) => boolean
 
     /**
      * If `true`, the detailed view will be enabled by default.


### PR DESCRIPTION
Hi,

I propose this work to fix the type declaration of the `exclude` property.

![Capture d’écran du 2023-10-09 14-27-10](https://github.com/vuejs/vitepress/assets/23351988/9fdcfc77-db1f-4a5a-8560-1abab0f2c09c)

Here is the result after adding the type declaration:

![Capture d’écran du 2023-10-09 14-27-45](https://github.com/vuejs/vitepress/assets/23351988/c5a62db5-cce1-4ddf-b045-aabeb066c2ce)
