### PR TITLE
fix(mpa): properly emit assets in mpa mode

### DIFF
--- a/src/node/build/bundle.ts
+++ b/src/node/build/bundle.ts
@@ -70,6 +70,7 @@ export async function bundle(
       ...options,
       emptyOutDir: true,
       ssr,
+      ssrEmitAssets: config.mpa,
       // minify with esbuild in MPA mode (for CSS)
       minify: ssr
         ? config.mpa


### PR DESCRIPTION
closes #1401

looks like I was wrong at https://github.com/vuejs/vitepress/issues/848#issuecomment-1166348478, it indeed was caused by some changes in vite 1/2 to vite 3.

x-ref: https://github.com/vitejs/vite/pull/11430

`build.ssrEmitAssets` is still experimental - https://github.com/vitejs/vite/discussions/13808 - but so is our 0 JS support. So, I'm fine even if ssrEmitAssets gets dropped. Will probably need to switch to some custom implementation then.