### PR TITLE
feat(template): add types for theme config

### DIFF
--- a/template/.vitepress/theme/index.js
+++ b/template/.vitepress/theme/index.js
@@ -1,22 +1,22 @@
 // https://vitepress.dev/guide/custom-theme
-<% if (!defaultTheme) { %>import Layout from './Layout.vue'
-<% if (useTs) { %>import type { Theme } from 'vitepress'<% } %>
+<% if (!defaultTheme) { %>import Layout from './Layout.vue'<% if (useTs) { %>
+import type { Theme } from 'vitepress'<% } %>
 import './style.css'
 
-<% if (!useTs) { %>/** @type {import('vitepress').Theme} */<% } %>
-export default {
+<% if (!useTs) { %>/** @type {import('vitepress').Theme} */
+<% } %>export default {
   Layout,
   enhanceApp({ app, router, siteData }) {
     // ...
   }
 }<% if (useTs) { %> satisfies Theme<% } %>
-<% } else { %>import { h } from 'vue'
-<% if (useTs) { %>import type { Theme } from 'vitepress'<% } %>
+<% } else { %>import { h } from 'vue'<% if (useTs) { %>
+import type { Theme } from 'vitepress'<% } %>
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
 
-<% if (!useTs) { %>/** @type {import('vitepress').Theme} */<% } %>
-export default {
+<% if (!useTs) { %>/** @type {import('vitepress').Theme} */
+<% } %>export default {
   extends: DefaultTheme,
   Layout: () => {
     return h(DefaultTheme.Layout, null, {

--- a/template/.vitepress/theme/index.js
+++ b/template/.vitepress/theme/index.js
@@ -1,25 +1,29 @@
 // https://vitepress.dev/guide/custom-theme
 <% if (!defaultTheme) { %>import Layout from './Layout.vue'
+<% if (useTs) { %>import type { Theme } from 'vitepress'<% } %>
 import './style.css'
 
+<% if (!useTs) { %>/** @type {import('vitepress').Theme} */<% } %>
 export default {
   Layout,
   enhanceApp({ app, router, siteData }) {
     // ...
   }
-}
+}<% if (useTs) { %> satisfies Theme<% } %>
 <% } else { %>import { h } from 'vue'
-import Theme from 'vitepress/theme'
+<% if (useTs) { %>import type { Theme } from 'vitepress'<% } %>
+import DefaultTheme from 'vitepress/theme'
 import './style.css'
 
+<% if (!useTs) { %>/** @type {import('vitepress').Theme} */<% } %>
 export default {
-  extends: Theme,
+  extends: DefaultTheme,
   Layout: () => {
-    return h(Theme.Layout, null, {
+    return h(DefaultTheme.Layout, null, {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
     })
   },
   enhanceApp({ app, router, siteData }) {
     // ...
   }
-}<% } %>
+}<% if (useTs) { %> satisfies Theme<% } %><% } %>


### PR DESCRIPTION
Updated also default theme name to match docs (`Theme` => `DefaultTheme`).

There is some extra line in the imports (JS) and between imports and `export default` (TS).

**JS**:
![imagen](https://github.com/vuejs/vitepress/assets/6311119/dcd87dea-3f5e-4c4c-856b-e4c66eb2f940)

**TS**:
![imagen](https://github.com/vuejs/vitepress/assets/6311119/9f0c365d-0432-48a6-8c00-0f9c23acc4a2)


closes #3116