### PR TITLE
feat(theme): don't print navbar when disabled in frontmatter (narrow screens)

### DIFF
--- a/src/client/theme-default/components/VPDocOutlineDropdown.vue
+++ b/src/client/theme-default/components/VPDocOutlineDropdown.vue
@@ -23,7 +23,7 @@ onContentUpdated(() => {
 </script>
 
 <template>
-  <div class="VPDocOutlineDropdown" v-if="headers.length > 0">
+  <div v-if="headers.length > 0" class="VPDocOutlineDropdown" :class="{ 'screen-only': frontmatter.navbar === false }">
     <button @click="open = !open" :class="{ open }">
       {{ resolveTitle(theme) }}
       <VPIconChevronRight class="icon" />

--- a/src/client/theme-default/components/VPLocalNav.vue
+++ b/src/client/theme-default/components/VPLocalNav.vue
@@ -45,7 +45,7 @@ const classes = computed(() => {
     VPLocalNav: true,
     fixed: empty.value,
     'reached-top': y.value >= navHeight.value,
-    'screen-only': frontmatter.value.navbar === false,
+    'screen-only': frontmatter.value.navbar === false
   }
 })
 </script>

--- a/src/client/theme-default/components/VPLocalNav.vue
+++ b/src/client/theme-default/components/VPLocalNav.vue
@@ -44,7 +44,8 @@ const classes = computed(() => {
   return {
     VPLocalNav: true,
     fixed: empty.value,
-    'reached-top': y.value >= navHeight.value
+    'reached-top': y.value >= navHeight.value,
+    'screen-only': frontmatter.value.navbar === false,
   }
 })
 </script>

--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -250,9 +250,3 @@ mjx-container {
 mjx-container > svg {
   margin: auto;
 }
-
-@media print {
-  .screen-only {
-    display: none !important;
-  }
-}

--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -250,3 +250,9 @@ mjx-container {
 mjx-container > svg {
   margin: auto;
 }
+
+@media print {
+  .screen-only {
+    display: none !important;
+  }
+}

--- a/src/client/theme-default/styles/utils.css
+++ b/src/client/theme-default/styles/utils.css
@@ -7,3 +7,9 @@
   clip-path: inset(50%);
   overflow: hidden;
 }
+
+@media print {
+  .screen-only {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
This PR includes a global style for `screen-only`: we cannot hide `VPLocalNav`  on narrow screens (we lost the navigation), `screen-only` class added when disabled in frontmatter `navbar: false`.

**missing navbar**
![imagen](https://github.com/vuejs/vitepress/assets/6311119/fb8f2cdd-bf10-41d8-96ec-17f59b4a0ab3)

**navbar: false**
![imagen](https://github.com/vuejs/vitepress/assets/6311119/abd7904a-f291-4bf1-b89f-36e192ca0b74)


closes #3086