### PR TITLE
feat(theme):make external link icon with <a> content in one line

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -539,6 +539,10 @@
   max-width: calc((100% - 24px) / 2) !important;
 }
 
+.external-link-icon-enabled a{
+  white-space:nowrap;
+}
+
 /* prettier-ignore */
 :is(.vp-external-link-icon, .vp-doc a[href*='://'], .vp-doc a[target='_blank']):not(.no-icon)::after {
   display: inline-block;


### PR DESCRIPTION
To fix #3061 
But, I'm not sure whether this feature can make the doc's style more beautiful for link with too much words.

Link with too much words:
Before:
![微信截图_20231023113943](https://github.com/vuejs/vitepress/assets/96763582/e653adee-4675-4d2f-87b8-2082af09f2e0)


After:
![微信截图_20231023113853](https://github.com/vuejs/vitepress/assets/96763582/d2f34ecd-e21d-490e-8405-3b796a7d256f)

But it works fine for short link:
Before:
![Snipaste_2023-10-23_11-57-30](https://github.com/vuejs/vitepress/assets/96763582/58e74ae5-eab0-473f-b412-5954aee83f1b)

After:
![Snipaste_2023-10-23_11-57-38](https://github.com/vuejs/vitepress/assets/96763582/5a3578fa-1542-4380-ac92-1534d6757e7a)
