### PR TITLE
fix: "VPNavScreenMenuGroup" component HTML not supported

### DIFF
--- a/src/client/theme-default/components/VPNavScreenMenuGroup.vue
+++ b/src/client/theme-default/components/VPNavScreenMenuGroup.vue
@@ -28,7 +28,7 @@ function toggle() {
       :aria-expanded="isOpen"
       @click="toggle"
     >
-      <span class="button-text">{{ text }}</span>
+      <span class="button-text" v-html="text"></span>
       <VPIconPlus class="button-icon" />
     </button>
 


### PR DESCRIPTION
For the visitor VitePress on the desktop, the TEXT of NAV written by NAV supports any HTML tags, which can make us achieve some simple effects, such as bold and corner markers

![Snipaste_2023-10-28_04-22-07](https://github.com/vuejs/vitepress/assets/33272184/c4534d4d-d3ca-4191-95a0-15409261fe61)

But when accessing on the mobile terminal, HTML was showed out

![Snipaste_2023-10-28_04-21-54](https://github.com/vuejs/vitepress/assets/33272184/09c6cdf0-03de-4475-b6c4-440b61fc0e6c)

This PR keeps them consistent