### PR TITLE
fix(theme): theme switch is not hidden on force-dark

### DIFF
--- a/src/client/theme-default/components/VPNavBarExtra.vue
+++ b/src/client/theme-default/components/VPNavBarExtra.vue
@@ -28,7 +28,7 @@ const hasExtraContent = computed(
       </template>
     </div>
 
-    <div v-if="site.appearance" class="group">
+    <div v-if="site.appearance && site.appearance !== 'force-dark'" class="group">
       <div class="item appearance">
         <p class="label">
           {{ theme.darkModeSwitchLabel || 'Appearance' }}

--- a/src/client/theme-default/components/VPNavScreenAppearance.vue
+++ b/src/client/theme-default/components/VPNavScreenAppearance.vue
@@ -6,7 +6,7 @@ const { site, theme } = useData()
 </script>
 
 <template>
-  <div v-if="site.appearance" class="VPNavScreenAppearance">
+  <div v-if="site.appearance && site.appearance !== 'force-dark'" class="VPNavScreenAppearance">
     <p class="text">
       {{ theme.darkModeSwitchLabel || 'Appearance' }}
     </p>


### PR DESCRIPTION
When Appearance is 'force-dark', the theme switch is not hidden on small screen.