### PR TITLE
fix: double-slash format url should be external link

### DIFF
--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -14,7 +14,7 @@ export type {
   SiteData
 } from '../../types/shared'
 
-export const EXTERNAL_URL_RE = /^[a-z]+:/i
+export const EXTERNAL_URL_RE = /^(?:[a-z]+:|\/\/)/i
 export const APPEARANCE_KEY = 'vitepress-theme-appearance'
 export const HASH_RE = /#.*$/
 export const EXT_RE = /(index)?\.(md|html)$/


### PR DESCRIPTION
A link of the form `//github.com` should also be a valid external link.