### PR TITLE
docs: update reference documentation to reflect type definition correctly

### DIFF
--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -480,7 +480,7 @@ interface MarkdownOptions extends MarkdownIt.Options {
 
   // Add support for your own languages.
   // https://github.com/shikijs/shiki/blob/main/docs/languages.md#supporting-your-own-languages-with-shiki
-  languages?: Shiki.ILanguageRegistration
+  languages?: Shiki.ILanguageRegistration[]
 
   // markdown-it-anchor plugin options.
   // See: https://github.com/valeriangalliat/markdown-it-anchor#usage

--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -531,7 +531,7 @@ interface MarkdownOptions extends MarkdownIt.Options {
   // You need to install `markdown-it-mathjax3` and set `math` to `true` to enable it.
   // You can also pass options to `markdown-it-mathjax3` here.
   // See: https://github.com/tani/markdown-it-mathjax3#customization
-  math?: any
+  math?: boolean | any
 
   // Global custom container titles
   container?: {

--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -504,7 +504,7 @@ interface MarkdownOptions extends MarkdownIt.Options {
 
   // @mdit-vue/plugin-headers plugin options.
   // See: https://github.com/mdit-vue/mdit-vue/tree/main/packages/plugin-headers#options
-  headers?: HeadersPluginOptions
+  headers?: HeadersPluginOptions | boolean
 
   // @mdit-vue/plugin-sfc plugin options.
   // See: https://github.com/mdit-vue/mdit-vue/tree/main/packages/plugin-sfc#options

--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -491,7 +491,7 @@ interface MarkdownOptions extends MarkdownIt.Options {
   attrs?: {
     leftDelimiter?: string
     rightDelimiter?: string
-    allowedAttributes?: string[]
+    allowedAttributes?: Array<string | RegExp>
     disable?: boolean
   }
 


### PR DESCRIPTION
Hi Vitepress team. Thank you for this wonderful project!

I found some differences between [Site Config](https://vitepress.dev/reference/site-config) reference documentation and its actual type definition while reading the document, so I made changes to reflect the differences.

For example:

Document:
https://github.com/vuejs/vitepress/blob/7dbeac6df0dfc0da74dffc79998a85a3afa86874/docs/reference/site-config.md?plain=1#L483
Actual type:
https://github.com/vuejs/vitepress/blob/7dbeac6df0dfc0da74dffc79998a85a3afa86874/src/node/markdown/markdown.ts#L54

Document:
https://github.com/vuejs/vitepress/blob/7dbeac6df0dfc0da74dffc79998a85a3afa86874/docs/reference/site-config.md?plain=1#L494
Actual type:
https://github.com/vuejs/vitepress/blob/7dbeac6df0dfc0da74dffc79998a85a3afa86874/src/node/markdown/markdown.ts#L46

Document:
https://github.com/vuejs/vitepress/blob/7dbeac6df0dfc0da74dffc79998a85a3afa86874/docs/reference/site-config.md?plain=1#L507
Actual type:
https://github.com/vuejs/vitepress/blob/7dbeac6df0dfc0da74dffc79998a85a3afa86874/src/node/markdown/markdown.ts#L51

Document:
https://github.com/vuejs/vitepress/blob/7dbeac6df0dfc0da74dffc79998a85a3afa86874/docs/reference/site-config.md?plain=1#L534
Actual type:
https://github.com/vuejs/vitepress/blob/7dbeac6df0dfc0da74dffc79998a85a3afa86874/src/node/markdown/markdown.ts#L59

Regards.