### PR TITLE
perf: overall prevention of duplicate rendering in localSearch

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -28,6 +28,7 @@ import {
   watchEffect,
   type Ref
 } from 'vue'
+import { LRUCache } from 'lru-cache'
 import type { ModalTranslations } from '../../../../types/local-search'
 import { pathToFile } from '../../app/utils'
 import { useData } from '../composables/data'
@@ -142,7 +143,7 @@ const mark = computedAsync(async () => {
   return markRaw(new Mark(resultsEl.value))
 }, null)
 
-const cache = new Map<string, Map<string, string>>()
+const cache = new LRUCache<string, Map<string, string>>({ max: 256 })
 
 debouncedWatch(
   () => [searchIndex.value, filterText.value, showDetailedList.value] as const,

--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -31,6 +31,7 @@ import {
 import type { ModalTranslations } from '../../../../types/local-search'
 import { pathToFile } from '../../app/utils'
 import { useData } from '../composables/data'
+import { LRUCache } from '../support/lru'
 import { createTranslate } from '../support/translation'
 
 const emit = defineEmits<{
@@ -142,7 +143,7 @@ const mark = computedAsync(async () => {
   return markRaw(new Mark(resultsEl.value))
 }, null)
 
-const cache = new Map<string, Map<string, string>>()
+const cache = new LRUCache<string, Map<string, string>>(16) // 16 files
 
 debouncedWatch(
   () => [searchIndex.value, filterText.value, showDetailedList.value] as const,

--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -28,7 +28,6 @@ import {
   watchEffect,
   type Ref
 } from 'vue'
-import { LRUCache } from 'lru-cache'
 import type { ModalTranslations } from '../../../../types/local-search'
 import { pathToFile } from '../../app/utils'
 import { useData } from '../composables/data'
@@ -143,7 +142,7 @@ const mark = computedAsync(async () => {
   return markRaw(new Mark(resultsEl.value))
 }, null)
 
-const cache = new LRUCache<string, Map<string, string>>({ max: 256 })
+const cache = new Map<string, Map<string, string>>()
 
 debouncedWatch(
   () => [searchIndex.value, filterText.value, showDetailedList.value] as const,

--- a/src/client/theme-default/support/lru.ts
+++ b/src/client/theme-default/support/lru.ts
@@ -1,0 +1,31 @@
+export class LRUCache<K, V> {
+  private max: number
+  private cache: Map<K, V>
+
+  constructor(max: number = 10) {
+    this.max = max
+    this.cache = new Map<K, V>()
+  }
+
+  get(key: K): V | undefined {
+    let item = this.cache.get(key)
+    if (item !== undefined) {
+      // refresh key
+      this.cache.delete(key)
+      this.cache.set(key, item)
+    }
+    return item
+  }
+
+  set(key: K, val: V): void {
+    // refresh key
+    if (this.cache.has(key)) this.cache.delete(key)
+    // evict oldest
+    else if (this.cache.size === this.max) this.cache.delete(this.first()!)
+    this.cache.set(key, val)
+  }
+
+  first(): K | undefined {
+    return this.cache.keys().next().value
+  }
+}

--- a/src/client/theme-default/support/lru.ts
+++ b/src/client/theme-default/support/lru.ts
@@ -1,3 +1,5 @@
+// adapted from https://stackoverflow.com/a/46432113/11613622
+
 export class LRUCache<K, V> {
   private max: number
   private cache: Map<K, V>


### PR DESCRIPTION
The cache should be defined outside of `debouncedWatch`, otherwise a new cache will be redefined every time when `debouncedWatch` is retriggered. It's a bit of a waste of performance.