### PR TITLE
fix: add ?import for vite-ignore import for md files

### DIFF
--- a/src/client/app/utils.ts
+++ b/src/client/app/utils.ts
@@ -40,7 +40,7 @@ export function pathToFile(path: string) {
   pagePath = pagePath.replace(/\/$/, '/index') // /foo/ -> /foo/index
   if (import.meta.env.DEV) {
     // always force re-fetch content in dev
-    pagePath += `.md?t=${Date.now()}`
+    pagePath += `.md?${__IS_VITE_4__ ? '' : 'import&'}t=${Date.now()}`
   } else {
     // in production, each .md file is built into a .md.js file following
     // the path conversion scheme.

--- a/src/client/shim.d.ts
+++ b/src/client/shim.d.ts
@@ -4,6 +4,7 @@ declare const __ALGOLIA__: boolean
 declare const __CARBON__: boolean
 declare const __VUE_PROD_DEVTOOLS__: boolean
 declare const __ASSETS_DIR__: string
+declare const __IS_VITE_4__: boolean
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -3,6 +3,7 @@ import c from 'picocolors'
 import {
   mergeConfig,
   searchForWorkspaceRoot,
+  version,
   type ModuleNode,
   type Plugin,
   type ResolvedConfig,
@@ -153,7 +154,8 @@ export async function createVitePressPlugin(
             site.themeConfig?.search?.provider === 'algolia' ||
             !!site.themeConfig?.algolia, // legacy
           __CARBON__: !!site.themeConfig?.carbonAds,
-          __ASSETS_DIR__: JSON.stringify(siteConfig.assetsDir)
+          __ASSETS_DIR__: JSON.stringify(siteConfig.assetsDir),
+          __IS_VITE_4__: version.split('.')[0] === '4'
         },
         optimizeDeps: {
           // force include vue to avoid duplicated copies when linked + optimized


### PR DESCRIPTION
Vite no longer prepends `?import` for dynamic imports with `vite-ignore`: https://github.com/vitejs/vite/pull/14851

I'm not sure if we want to go this way so I'll put this in draft for now.
