### PR TITLE
docs(search): update the link to MiniSearch's docs

### DIFF
--- a/docs/reference/default-theme-search.md
+++ b/docs/reference/default-theme-search.md
@@ -96,7 +96,7 @@ export default defineConfig({
 })
 ```
 
-Learn more in [MiniSearch docs](https://lucaong.github.io/minisearch/classes/_minisearch_.minisearch.html).
+Learn more in [MiniSearch docs](https://lucaong.github.io/minisearch/classes/MiniSearch.MiniSearch.html).
 
 ### Custom content renderer
 


### PR DESCRIPTION
The original link <https://lucaong.github.io/minisearch/classes/_minisearch_.minisearch.html> is outdated.