### PR TITLE
fix(theme): table row background-color in custom containers

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -164,6 +164,7 @@
 }
 
 .vp-doc tr {
+  background-color: var(--vp-c-bg);
   border-top: 1px solid var(--vp-c-divider);
   transition: background-color 0.5s;
 }


### PR DESCRIPTION
I've changed the `background-color` for table rows in the default theme. Rather than being transparent, it now matches the page background.

This matters for tables inside custom containers, so that the container background doesn't leak into the table.

Before and after:

![before and after](https://github.com/vuejs/vitepress/assets/65301168/8a5d9f3d-7377-46c7-abc5-71d49d20939b)

I set the `background-color` on the `<tr>`. It could have been set on the `<table>` instead. It wasn't clear to me which was better.

I've marked this as a `fix` in the commit message, but I'm not sure whether that's really correct in this case.