### PR TITLE
docs: always use 'extends' to extend themes

### DIFF
--- a/docs/guide/extending-default-theme.md
+++ b/docs/guide/extending-default-theme.md
@@ -135,7 +135,7 @@ import DefaultTheme from 'vitepress/theme'
 import MyLayout from './MyLayout.vue'
 
 export default {
-  ...DefaultTheme,
+  extends: DefaultTheme,
   // override the Layout with a wrapper component that
   // injects the slots
   Layout: MyLayout
@@ -168,7 +168,7 @@ import DefaultTheme from 'vitepress/theme'
 import MyComponent from './MyComponent.vue'
 
 export default {
-  ...DefaultTheme,
+  extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
       'aside-outline-before': () => h(MyComponent)

--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -82,7 +82,7 @@ However, VitePress won't redirect `/` to `/en/` by default. You'll need to confi
 import DefaultTheme from 'vitepress/theme'
 
 export default {
-  ...DefaultTheme,
+  extends: DefaultTheme,
   setup() {
     const { lang } = useData()
     watchEffect(() => {


### PR DESCRIPTION
These 3 examples were still using `...DefaultTheme` to extend the default theme, rather than `extends: DefaultTheme`.

These examples aren't using `enhanceApp`, so they do work in isolation, but the use of `...DefaultTheme` makes it less clear how to combine the various examples into a single configuration.

I'm not aware of any reason why we'd want to show `...DefaultTheme` in the docs.