### PR TITLE
fix: avoid word breaks in replace strings

### DIFF
--- a/src/node/markdown/plugins/link.ts
+++ b/src/node/markdown/plugins/link.ts
@@ -56,7 +56,7 @@ export const linkPlugin = (
 
       // encode vite-specific replace strings in case they appear in URLs
       // this also excludes them from build-time replacements (which injects
-      // <wbr/> and will break URLs)
+      // <span/> and will break URLs)
       hrefAttr[1] = hrefAttr[1]
         .replace(/\bimport\.meta/g, 'import%2Emeta')
         .replace(/\bprocess\.env/g, 'process%2Eenv')

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -234,7 +234,7 @@ const scriptClientRE = /<\s*script[^>]*\bclient\b[^>]*/
 const defaultExportRE = /((?:^|\n|;)\s*)export(\s*)default/
 const namedDefaultExportRE = /((?:^|\n|;)\s*)export(.+)as(\s*)default/
 const jsStringBreaker = '\u200b'
-const vueTemplateBreaker = '<wbr>'
+const vueTemplateBreaker = '<span/>'
 
 function genReplaceRegexp(
   userDefines: Record<string, any> = {},
@@ -257,7 +257,7 @@ function genReplaceRegexp(
 /**
  * To avoid env variables being replaced by vite:
  * - insert `'\u200b'` char into those strings inside js string (page data)
- * - insert `<wbr>` tag into those strings inside html string (vue template)
+ * - insert `<span/>` tag into those strings inside html string (vue template)
  *
  * @see https://vitejs.dev/guide/env-and-mode.html#production-replacement
  */


### PR DESCRIPTION
VitePress currently inserts a `<wbr>` into `import.meta` and `process.env`. This can lead to problems. The pictures below are taken from the live Vite docs:

---

![work break](https://github.com/vuejs/vitepress/assets/65301168/b4317c76-71d3-4dc0-846d-366dd5301fb7)

![word break](https://github.com/vuejs/vitepress/assets/65301168/65a9dbbf-7949-4321-aced-56d6b2363b79)

---

Notice the `i` at the end of the line, separate from the `mport.meta`.

This occurs because `<wbr>` allows for a line break. My proposed fix just changes to using `<span/>` instead, which doesn't introduce a line-break opportunity.

The [Vite docs](https://vitejs.dev/guide/env-and-mode.html#production-replacement) suggest using a `<wbr>`:

> For Vue templates or other HTML that gets compiled into JavaScript strings, you can use the `<wbr>` tag, e.g. `import.meta.<wbr>env.MODE`.

However, I think it's important to notice that the example puts the `<wbr>` after the `import.meta.`, which puts the line-break opportunity in a sensible place, not between the first two characters.

I considered some other approaches:

- Moving the `<wbr>` later in the string, like in the example. That is viable, but it'd need extra effort to get it working. The replacement code isn't just used for `import.meta` and `process.env`, it also replaces values specified by the config.
- I tried using HTML entities to escape the values, but that doesn't work because the template gets parsed by Vue before Vite performs the replacements. By the time the JS strings reach Vite the entities are no longer entities.
- I tried using `{{ ... }}` text interpolation. That works well in most cases, but fails for code blocks due to the `v-pre`.

It might be possible to fix this other ways with more effort, but switching `<wbr>` to `<span/>` seemed like a relatively low-risk way to fix the wrapping.

---

As a side note, inserting an element doesn't work for text in attributes. There's already special handling for `<a href>`, but it's a problem more generally. For example, the following markdown won't render correctly:

```md
![Example](/image.png "How to use process.env.NODE_DEV with Vite")
```

This will become:

```html
<img src="/image.png" alt="Example" title="How to use p<span/>rocess.env.NODE_DEV with Vite">
```

The `<span/>` (or `<wbr>`) will be visible in the tooltip.