### PR TITLE
fix: CSS missing after build

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -346,6 +346,10 @@ export async function createVitePressPlugin(
             bundle[name + '-lean'] = {
               ...chunk,
               fileName: chunk.fileName.replace(/\.js$/, '.lean.js'),
+              preliminaryFileName: chunk.preliminaryFileName.replace(
+                /\.js$/,
+                '.lean.js'
+              ),
               code: chunk.code.replace(staticStripRE, `""`)
             }
 


### PR DESCRIPTION
Vite expects each chunk in the bundle has a different `preliminaryFileName` here.
https://github.com/vitejs/vite/blob/cc980feb556bda324f1da7162a571150fcbaebed/packages/vite/src/node/plugins/css.ts#L781-L785
`preliminaryFileName` matches the value of `fileName` in `renderChunk` hook and `fileName` is unique in that hook, therefore `preliminaryFileName` should be unique.

https://discordapp.com/channels/804011606160703521/831456449632534538/1175056771384086651
