### PR TITLE
fix(docs): wrong code example in data-loading.md

### DIFF
--- a/docs/guide/data-loading.md
+++ b/docs/guide/data-loading.md
@@ -230,7 +230,7 @@ export { data }
 
 export default defineLoader({
   // type checked loader options
-  glob: ['...'],
+  watch: ['...'],
   async load(): Promise<Data> {
     // ...
   }


### PR DESCRIPTION
The code example in data-loading.md is wrong.
The key should `watch`, not `glob`.


see: [type definition of defineLoader and LoaderModule](https://github.com/vuejs/vitepress/blob/c4abc950af7061611e3b5eff93e767706bd12396/src/node/plugins/staticDataPlugin.ts#L15C1-L25C2)