### PR TITLE
fix(client): No onAfterRouteChanged called after popstate

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -226,8 +226,9 @@ export function createRouter(
       loadPage(
         normalizeHref(location.href),
         (e.state && e.state.scrollPosition) || 0
-      )
-      router.onAfterRouteChanged?.(location.href)
+      ).then(() => {
+        router.onAfterRouteChanged?.(location.href)
+      })
     })
 
     window.addEventListener('hashchange', (e) => {

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -227,6 +227,7 @@ export function createRouter(
         normalizeHref(location.href),
         (e.state && e.state.scrollPosition) || 0
       )
+      router.onAfterRouteChanged?.(location.href)
     })
 
     window.addEventListener('hashchange', (e) => {

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -222,13 +222,12 @@ export function createRouter(
       { capture: true }
     )
 
-    window.addEventListener('popstate', (e) => {
-      loadPage(
+    window.addEventListener('popstate', async (e) => {
+      await loadPage(
         normalizeHref(location.href),
         (e.state && e.state.scrollPosition) || 0
-      ).then(() => {
-        router.onAfterRouteChanged?.(location.href)
-      })
+      )
+      router.onAfterRouteChanged?.(location.href)
     })
 
     window.addEventListener('hashchange', (e) => {


### PR DESCRIPTION
This Pull Request Fix issue #3226: No onAfterRouteChanged called after popstate

In `src/client/app/router.ts` popstate eventListener, it should call `onAfterRouteChanged` hook after `loadPage`,
but it is missing.

```diff
...
    window.addEventListener('popstate', (e) => {
      loadPage(
        normalizeHref(location.href),
        (e.state && e.state.scrollPosition) || 0
-      )
+      ).then(() => {
+        router.onAfterRouteChanged?.(location.href)
+      })
    })
...
```

Before Fix:
<img width="466" alt="Screenshot 2023-11-20 at 9 26 52 PM" src="https://github.com/vuejs/vitepress/assets/84657208/e47fa757-2d48-4ed6-90af-54ca4a6ebe67">

After Fix:
<img width="443" alt="Screenshot 2023-11-20 at 9 29 02 PM" src="https://github.com/vuejs/vitepress/assets/84657208/cc4440dd-e8fd-45fc-96a9-03a6e030283d">