### PR TITLE
Update markdown.md

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -420,7 +420,7 @@ Note that only one space is required after `!code`, here are two to prevent proc
 export default {
   data () {
     return {
-      msg: 'Focused!' // [!code  focus]
+      msg: 'Focused!' // [!code focus]
     }
   }
 }
@@ -452,8 +452,8 @@ Note that only one space is required after `!code`, here are two to prevent proc
 export default {
   data () {
     return {
-      msg: 'Removed' // [!code  --]
-      msg: 'Added' // [!code  ++]
+      msg: 'Removed' // [!code --]
+      msg: 'Added' // [!code ++]
     }
   }
 }
@@ -486,8 +486,8 @@ Note that only one space is required after `!code`, here are two to prevent proc
 export default {
   data () {
     return {
-      msg: 'Error', // [!code  error]
-      msg: 'Warning' // [!code  warning]
+      msg: 'Error', // [!code error]
+      msg: 'Warning' // [!code warning]
     }
   }
 }


### PR DESCRIPTION
Removed double spaces in some of the `[!code` tags, as when copying from the docs, it doesn't work, as there are two spaces.