### PR TITLE
fix(build): force assets to go through vite pipeline during dev too

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -95,6 +95,22 @@ export async function createVitePressPlugin(
     }
   }
 
+  const getMergedAssetUrlOptions = () => {
+    const { transformAssetUrls } = userVuePluginOptions?.template ?? {}
+    const assetUrlOptions = { includeAbsolute: true }
+
+    if (transformAssetUrls && typeof transformAssetUrls === 'object') {
+      // presence of array fields means this is raw tags config
+      if (Object.values(transformAssetUrls).some((val) => Array.isArray(val))) {
+        return { ...assetUrlOptions, tags: transformAssetUrls as any }
+      } else {
+        return { ...assetUrlOptions, ...transformAssetUrls }
+      }
+    } else {
+      return assetUrlOptions
+    }
+  }
+
   // lazy require plugin-vue to respect NODE_ENV in @vue/compiler-x
   const vuePlugin = await import('@vitejs/plugin-vue').then((r) =>
     r.default({
@@ -105,7 +121,8 @@ export async function createVitePressPlugin(
         compilerOptions: {
           ...userVuePluginOptions?.template?.compilerOptions,
           isCustomElement
-        }
+        },
+        transformAssetUrls: getMergedAssetUrlOptions()
       }
     })
   )


### PR DESCRIPTION
closes #3239 -- temp fix till this gets sorted at vite-plugin-vue. I'm not sure if their current behavior is expected or not.