### PR TITLE
fix: custom home page with setting `logoLink` leads to 404 page

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -183,7 +183,10 @@ export function createRouter(
           )
 
           // temporary fix for #3264
-          if (siteDataRef.value.themeConfig?.logoLink === origin) return
+          if (
+            siteDataRef.value.themeConfig?.logoLink === href.replace(/\/$/, '')
+          )
+            return
 
           const currentUrl = window.location
           const mimeType = lookup(pathname)

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -166,11 +166,6 @@ export function createRouter(
         const button = (e.target as Element).closest('button')
         if (button) return
 
-        // temporary fix for #3264
-        const currentUrl = window.location
-        if (siteDataRef.value.themeConfig?.logoLink === currentUrl.origin)
-          return
-
         const link = (e.target as Element | SVGElement).closest<
           HTMLAnchorElement | SVGAElement
         >('a')
@@ -186,6 +181,11 @@ export function createRouter(
               : link.href,
             link.baseURI
           )
+
+          // temporary fix for #3264
+          if (siteDataRef.value.themeConfig?.logoLink === origin) return
+
+          const currentUrl = window.location
           const mimeType = lookup(pathname)
           // only intercept inbound links
           if (

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -166,6 +166,11 @@ export function createRouter(
         const button = (e.target as Element).closest('button')
         if (button) return
 
+        // temporary fix for #3264
+        const currentUrl = window.location
+        if (siteDataRef.value.themeConfig?.logoLink === currentUrl.origin)
+          return
+
         const link = (e.target as Element | SVGElement).closest<
           HTMLAnchorElement | SVGAElement
         >('a')
@@ -181,7 +186,6 @@ export function createRouter(
               : link.href,
             link.baseURI
           )
-          const currentUrl = window.location
           const mimeType = lookup(pathname)
           // only intercept inbound links
           if (


### PR DESCRIPTION
temporary fix for #3264

We can circumvent this case in the `router`, which is that when using a custom homepage and `themeConfig.logoLink` is set to that custom homepage, clicking on the logo does not try to load the vitepress-generated homepage, but instead jumps directly to the custom homepage.