### PR TITLE
feat(theme/i18n): allow customizing sponsor link's text

### DIFF
--- a/docs/reference/default-theme-team-page.md
+++ b/docs/reference/default-theme-team-page.md
@@ -212,6 +212,9 @@ interface TeamMember {
 
   // URL for the sponsor page for the member.
   sponsor?: string
+
+  // Text for the sponsor link. Defaults to 'Sponsor'.
+  actionText?: string
 }
 ```
 

--- a/src/client/theme-default/components/VPTeamMembersItem.vue
+++ b/src/client/theme-default/components/VPTeamMembersItem.vue
@@ -47,7 +47,7 @@ withDefaults(defineProps<Props>(), {
     </div>
     <div v-if="member.sponsor" class="sp">
       <VPLink class="sp-link" :href="member.sponsor" no-icon>
-        <VPIconHeart class="sp-icon" /> {{ member.sponsor_text || "Sponsor" }}
+        <VPIconHeart class="sp-icon" /> {{ member.actionText || 'Sponsor' }}
       </VPLink>
     </div>
   </article>

--- a/src/client/theme-default/components/VPTeamMembersItem.vue
+++ b/src/client/theme-default/components/VPTeamMembersItem.vue
@@ -47,7 +47,7 @@ withDefaults(defineProps<Props>(), {
     </div>
     <div v-if="member.sponsor" class="sp">
       <VPLink class="sp-link" :href="member.sponsor" no-icon>
-        <VPIconHeart class="sp-icon" /> Sponsor
+        <VPIconHeart class="sp-icon" /> {{ member.sponsor_text || "Sponsor" }}
       </VPLink>
     </div>
   </article>

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -345,6 +345,7 @@ export namespace DefaultTheme {
     desc?: string
     links?: SocialLink[]
     sponsor?: string
+    sponsor_text?: string
   }
 
   // outline -------------------------------------------------------------------

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -345,7 +345,7 @@ export namespace DefaultTheme {
     desc?: string
     links?: SocialLink[]
     sponsor?: string
-    sponsor_text?: string
+    actionText?: string
   }
 
   // outline -------------------------------------------------------------------


### PR DESCRIPTION
closes #3273

Add sponsor_text 
![Снимок экрана от 2023-11-30 06-17-47](https://github.com/vuejs/vitepress/assets/72319244/444c80e7-c6f2-4113-968d-e45d40748d85)
