### PR TITLE
feat(config): add `themeDir` option

### DIFF
--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -437,6 +437,19 @@ export default {
 }
 ```
 
+### themeDir
+
+- Type: `string`
+- Default: `./.vitepress/theme` if exists, otherwise [Default Theme](../guide/extending-default-theme) path.
+
+The directory of the [theme entry file](../guide/custom-theme#theme-resolving), relative to [project root](../guide/routing#root-and-source-directory).
+
+```ts
+export default {
+  themeDir: './awesome-theme'
+}
+```
+
 ### ignoreDeadLinks
 
 - Type: `boolean | 'localhostLinks' | (string | RegExp | ((link: string) => boolean))[]`

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -97,7 +97,10 @@ export async function resolveConfig(
   }
 
   // resolve theme path
-  const userThemeDir = resolve(root, 'theme')
+  const userThemeDir = userConfig.themeDir
+    ? normalizePath(path.resolve(root, userConfig.themeDir))
+    : resolve(root, 'theme')
+
   const themeDir = (await fs.pathExists(userThemeDir))
     ? userThemeDir
     : DEFAULT_THEME_PATH

--- a/src/node/siteConfig.ts
+++ b/src/node/siteConfig.ts
@@ -64,6 +64,7 @@ export interface UserConfig<ThemeConfig = any>
   outDir?: string
   assetsDir?: string
   cacheDir?: string
+  themeDir?: string
 
   shouldPreload?: (link: string, page: string) => boolean
 


### PR DESCRIPTION
Together with #3290 I want to achieve project structure like the following:
```
.
├─ docs                    # project root
│  ├─ src
│  │  └─ theme
│  │     └─ index.js       # theme entry
│  ├─ vitepress.config.ts  # config file
│  └─ index.md
└─ package.json
```

The main motivation: working with private folder (`.vitepress`) cause a-lot of issues with TypeScript and eslint (like motioned in #1047), even when you get the typechecker and the linter to work with `.vitepress`, the code editor (VSCode) fails to evaluate the the files correctly.


Also, the above structure is more familiar to Vite, I hope it would be the default for VitePress