### PR TITLE
feat: allow ignoring node in header

### DIFF
--- a/src/client/theme-default/composables/outline.ts
+++ b/src/client/theme-default/composables/outline.ts
@@ -44,7 +44,8 @@ function serializeHeader(h: Element): string {
     if (node.nodeType === 1) {
       if (
         (node as Element).classList.contains('VPBadge') ||
-        (node as Element).classList.contains('header-anchor')
+        (node as Element).classList.contains('header-anchor') ||
+        (node as Element).classList.contains('ignore-header')
       ) {
         continue
       }


### PR DESCRIPTION
This pull request adds a `ignore-header` marker class that allows ignoring a node when serializing a header.

This allows userland implementation of the same functionality as `VPBadge` without having to update `.VPBadge`-related CSS. This way, `<Badge />` can also still be used alongside the other implementation.