### PR TITLE
feat: update shikiji, support twoslash

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
     "mark.js": "8.11.1",
     "minisearch": "^6.3.0",
     "mrmime": "^1.0.1",
-    "shikiji": "^0.7.4",
-    "shikiji-transformers": "^0.7.4",
+    "shikiji": "^0.9.2",
+    "shikiji-transformers": "^0.9.2",
     "vite": "^5.0.2",
     "vue": "^3.3.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,11 +45,11 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       shikiji:
-        specifier: ^0.7.4
-        version: 0.7.4
+        specifier: ^0.9.2
+        version: 0.9.2
       shikiji-transformers:
-        specifier: ^0.7.4
-        version: 0.7.4
+        specifier: ^0.9.2
+        version: 0.9.2
       vite:
         specifier: ^5.0.2
         version: 5.0.5(@types/node@20.10.0)
@@ -4170,14 +4170,14 @@ packages:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
     dev: true
 
-  /shikiji-transformers@0.7.4:
-    resolution: {integrity: sha512-oykilNekcW2FnRGbvZm+RNWHYroSeCVMOaMMwAbxozZgpTdcJtHoA+1+MDFw6/o2hCkX88kKbxG6FwAZoUZ6WQ==}
+  /shikiji-transformers@0.9.2:
+    resolution: {integrity: sha512-WEBeNm+oUL/4OTENjnZ5G29ErNM2cPGJHRRhqjwoTFkHnsJsACtTluTaYjPEppCl46Vo3M4TV9GwrMxz2WeCSg==}
     dependencies:
-      shikiji: 0.7.4
+      shikiji: 0.9.2
     dev: false
 
-  /shikiji@0.7.4:
-    resolution: {integrity: sha512-N5dmPvyhH/zfcsuWysUEAMwRJDMz26LUns2VEUs5y4Ozbf5jkAODU0Yswjcf/tZAwpFnk5x3y34dupFMnF2+NA==}
+  /shikiji@0.9.2:
+    resolution: {integrity: sha512-bxXd5iOVvuPj0NVFWQG3YMNLAGkWHyjTGixM7wLzqJNz3WMaeiOZbOP12gjQWKMJg+Ca4jmgATrUWu/rFb3B8A==}
     dependencies:
       hast-util-to-html: 9.0.0
     dev: false

--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -163,6 +163,9 @@ export async function highlight(
         transformerCompactLineOptions(lineOptions),
         ...userTransformers
       ],
+      meta: {
+        __raw: attrs,
+      },
       ...(typeof theme === 'string' || 'name' in theme
         ? { theme }
         : {

--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -164,7 +164,7 @@ export async function highlight(
         ...userTransformers
       ],
       meta: {
-        __raw: attrs,
+        __raw: attrs
       },
       ...(typeof theme === 'string' || 'name' in theme
         ? { theme }


### PR DESCRIPTION
This allows https://github.com/antfu/shikiji/tree/main/packages/shikiji-twoslash to work with VitePress. It has [a trigger usage](https://github.com/antfu/shikiji/tree/main/packages/shikiji-twoslash#explicit-trigger) that reads the attrs of the code block, where we didn't pass in before

Breaking changes between 0.7 and 0.9 are only about internal APIs.