### PR TITLE
feat: expose `shikijiSetup` hook

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -107,7 +107,7 @@ export interface MarkdownOptions extends MarkdownIt.Options {
   /**
    * Setup Shikiji instance
    */
-  shikijiSetup?: (shikiji: Highlighter) => Promise<void>
+  shikijiSetup?: (shikiji: Highlighter) => void | Promise<void>
 
   /* ==================== Markdown It Plugins ==================== */
 

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -31,7 +31,8 @@ import type {
   ThemeRegistration,
   BuiltinTheme,
   LanguageInput,
-  ShikijiTransformer
+  ShikijiTransformer,
+  Highlighter
 } from 'shikiji'
 
 export type { Header } from '../shared'
@@ -103,6 +104,10 @@ export interface MarkdownOptions extends MarkdownIt.Options {
    * @see https://github.com/antfu/shikiji#hast-transformers
    */
   codeTransformers?: ShikijiTransformer[]
+  /**
+   * Setup Shikiji instance
+   */
+  shikijiSetup?: (shikiji: Highlighter) => Promise<void>
 
   /* ==================== Markdown It Plugins ==================== */
 
@@ -176,16 +181,7 @@ export const createMarkdownRenderer = async (
   const md = MarkdownIt({
     html: true,
     linkify: true,
-    highlight:
-      options.highlight ||
-      (await highlight(
-        theme,
-        options.languages,
-        options.defaultHighlightLang,
-        logger,
-        options.codeTransformers,
-        options.languageAlias
-      )),
+    highlight: options.highlight || (await highlight(theme, options, logger)),
     ...options
   })
 


### PR DESCRIPTION
Similar to the markdown-it config hooks: https://github.com/vuejs/vitepress/blob/5968502a6e3d3af2b8ca9dcc0ab18568b33dc0ea/src/node/markdown/markdown.ts#L51-L58, this would allow users to have a chance to get the highlighter instance and load more custom themes etc.

I am building the docs for Shikiji itself using VitePress, where I need to load all the themes for demonstrating purposes. Before this, it's only possible to load up to two themes.