### PR TITLE
fix(theme): fix ineffective activeMatch configuration

### DIFF
--- a/src/client/theme-default/components/VPNavBarMenuGroup.vue
+++ b/src/client/theme-default/components/VPNavBarMenuGroup.vue
@@ -24,17 +24,21 @@ const isChildActive = (navItem: DefaultTheme.NavItem) => {
 }
 
 const childrenActive = computed(() => isChildActive(props.item))
+
+const menuActive = computed(() => {
+  const { activeMatch } = props.item
+  if (activeMatch)
+    return isActive(page.value.relativePath, activeMatch, true)
+  else
+    return childrenActive.value
+})
 </script>
 
 <template>
   <VPFlyout
     :class="{
       VPNavBarMenuGroup: true,
-      active: isActive(
-        page.relativePath,
-        item.activeMatch,
-        !!item.activeMatch
-      ) || childrenActive
+      active: menuActive
     }"
     :button="item.text"
     :items="item.items"


### PR DESCRIPTION
In the settings of the default theme's Navbar, we can set the `activeMatch` for Navbar items with children. However, when the regular expression does not match and one of the links in the children matches the current page, it will be highlighted incorrectly.

This is the definition of NavItemWithChildren in the default theme:

```ts
  export interface NavItemWithChildren {
    text?: string
    items: (NavItemChildren | NavItemWithLink)[]

    /**
     * `activeMatch` is expected to be a regex string. We can't use actual
     * RegExp object here because it isn't serializable
     */
    activeMatch?: string
  }
```