### PR TITLE
feat: allow explicitly mark code element as `.vp-copy-ignore`

### DIFF
--- a/src/client/app/composables/copyCode.ts
+++ b/src/client/app/composables/copyCode.ts
@@ -16,13 +16,18 @@ export function useCopyCode() {
           parent.className
         )
 
-        let text = ''
+        const ignoredNodes = [
+          '.vp-copy-ignore',
+          '.diff.remove'
+        ]
 
-        sibling
-          .querySelectorAll('span.line:not(.diff.remove)')
-          .forEach((node) => (text += (node.textContent || '') + '\n'))
+        // Clone the node and remove the ignored nodes
+        const clone = sibling.cloneNode(true) as HTMLElement
+        clone
+          .querySelectorAll(ignoredNodes.join(','))
+          .forEach((node) => node.remove())
 
-        text = (text || sibling.textContent || '').slice(0, -1)
+        let text = clone.textContent || ''
 
         if (isShell) {
           text = text.replace(/^ *(\$|>) /gm, '').trim()

--- a/src/client/app/composables/copyCode.ts
+++ b/src/client/app/composables/copyCode.ts
@@ -16,10 +16,7 @@ export function useCopyCode() {
           parent.className
         )
 
-        const ignoredNodes = [
-          '.vp-copy-ignore',
-          '.diff.remove'
-        ]
+        const ignoredNodes = ['.vp-copy-ignore', '.diff.remove']
 
         // Clone the node and remove the ignored nodes
         const clone = sibling.cloneNode(true) as HTMLElement


### PR DESCRIPTION
When we enabled TwoSlash, it injected some elements to provide the type information inline. It works great until you copy the code (you can try on https://shikiji.netlify.app/packages/twoslash).

I didn't find a good and agnostic way to opt-out elements from being printed in `.textContent,` so I guess actually removing those elements before grabbing the content might be a more solid idea.

I picked a kinda natural selector, `.vp-copy-ignore`, so in Shikiji integration, I could provide an option for users to inset that class. On another pov, I am not sure how much VitePress would be interested in document the usage of twoslash or even ship it as a feature.