### PR TITLE
fix:when running npx vitepress init, devDependencies cannot be create

### DIFF
--- a/src/node/init/init.ts
+++ b/src/node/init/init.ts
@@ -205,7 +205,15 @@ export function scaffold({
       'docs:build': `vitepress build${dir}`,
       'docs:preview': `vitepress preview${dir}`
     }
+
+    const devDependencies = {
+      vitepress: 'lastest'
+    }
     Object.assign(userPkg.scripts || (userPkg.scripts = {}), scripts)
+    Object.assign(
+      userPkg.devDependencies || (userPkg.devDependencies = {}),
+      devDependencies
+    )
     fs.writeFileSync(pkgPath, JSON.stringify(userPkg, null, 2))
     return `Done! Now run ${cyan(
       `${getPackageManger()} run docs:dev`


### PR DESCRIPTION
To enhance (#3256)

I don't think it's reasonable for init to have only scripts. Users Need to be manually install vitepress, and we can add it when we create it. But for other unnecessary support, keep it concise.