### PR TITLE
Fix transparent nav bar

### DIFF
--- a/docs/reference/frontmatter-config.md
+++ b/docs/reference/frontmatter-config.md
@@ -124,6 +124,20 @@ navbar: false
 ---
 ```
 
+
+### transparentNavBar
+
+- Type: `boolean`
+- Default: `false`
+
+Whether to display the navigation bar as transparent when the scroll distance is 0. It is used by default when [`layout: home`](./default-theme-layout) is set. It can be added to other pages if needed.
+
+```yaml
+---
+transparentNavBar: true
+---
+```
+
 ### sidebar
 
 - Type: `boolean`

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -27,9 +27,10 @@ const { frontmatter } = useData()
 const classes = ref<Record<string, boolean>>({})
 
 watchPostEffect(() => {
+  const isTransparentPage = frontmatter.value.transparentNavBar || frontmatter.value.layout === 'home' 
   classes.value = {
     'has-sidebar': hasSidebar.value,
-    top: frontmatter.value.layout === 'home' && y.value === 0,
+    top: isTransparentPage && y.value === 0,
   }
 })
 </script>


### PR DESCRIPTION
## Background

When I upgraded from version beta.1 to rc.33, I found that the transparent navigation bar on the custom homepage (`layout: page`) was missing. I then looked in the changelog and found that [this PR -- dont show transparent navbar other than home](https://github.com/vuejs/vitepress/pull/2742/files) affected my display effect.

## Feature Implementation

Before: Users could use the transparent navigation bar when `layout: home`, but not on other pages.

After: Users can configure the `transparentNavBar` option in the page `frontmatter`. If set to `true`, the transparent navigation bar will be used.

## Other

The description of this option has been added to the documentation.

