### PR TITLE
feat(theme): allow using VPBadge classes in sidebar

### DIFF
--- a/src/client/theme-default/components/VPBadge.vue
+++ b/src/client/theme-default/components/VPBadge.vue
@@ -14,7 +14,7 @@ withDefaults(defineProps<Props>(), {
   </span>
 </template>
 
-<style scoped>
+<style>
 .VPBadge {
   display: inline-block;
   margin-left: 2px;
@@ -25,6 +25,16 @@ withDefaults(defineProps<Props>(), {
   font-size: 12px;
   font-weight: 500;
   transform: translateY(-2px);
+}
+
+.VPBadge.small {
+  padding: 0 6px;
+  line-height: 18px;
+  font-size: 11px;
+}
+
+.VPDocFooter .VPBadge {
+  display: none;
 }
 
 .vp-doc h1 > .VPBadge {


### PR DESCRIPTION
Config looks like this:

```ts
        { text: 'Foo <span class="VPBadge tip small">Bar</span>', link: '/foo' },
```

Can be easily overridden using CSS if you want to adjust styles.