### PR TITLE
fix: avoid history pushState triggering multiple times when click on same internal link

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -329,7 +329,7 @@ function shouldHotReload(payload: PageDataPayload): boolean {
 }
 
 function updateHistory(href: string) {
-  if (inBrowser && href !== normalizeHref(location.href)) {
+  if (inBrowser && href !== location.href) {
     // save scroll position before changing url
     history.replaceState({ scrollPosition: window.scrollY }, document.title)
     history.pushState(null, '', href)

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -329,7 +329,7 @@ function shouldHotReload(payload: PageDataPayload): boolean {
 }
 
 function updateHistory(href: string) {
-  if (inBrowser && href !== location.href) {
+  if (inBrowser && normalizeHref(href) !== normalizeHref(location.href)) {
     // save scroll position before changing url
     history.replaceState({ scrollPosition: window.scrollY }, document.title)
     history.pushState(null, '', href)


### PR DESCRIPTION
Clicking on the `a` tag of the same internal link, such as clicking on the same sidebar item or navBar title multiple times, will cause `history.pushState` to trigger multiple times, which normally shouldn't be triggered.