### PR TITLE
fix: optimize the writing of import types

### DIFF
--- a/src/client/theme-default/composables/local-nav.ts
+++ b/src/client/theme-default/composables/local-nav.ts
@@ -1,5 +1,5 @@
 import { onContentUpdated } from 'vitepress'
-import { type DefaultTheme } from 'vitepress/theme'
+import type { DefaultTheme } from 'vitepress/theme'
 import { computed, shallowRef } from 'vue'
 import { getHeaders, type MenuItem } from '../composables/outline'
 import { useData } from './data'


### PR DESCRIPTION
In typescript,  `import { type A } from 'module'` will emit `import {} from 'module'`, 
If we only need to import the type, we should use `import type { A } from 'module'`.

fix #3411