### PR TITLE
fix(theme): hover color for code links inside custom containers

### DIFF
--- a/src/client/theme-default/styles/components/custom-block.css
+++ b/src/client/theme-default/styles/components/custom-block.css
@@ -18,7 +18,8 @@
   color: var(--vp-c-brand-1);
 }
 
-.custom-block.info a:hover {
+.custom-block.info a:hover,
+.custom-block.info a:hover > code {
   color: var(--vp-c-brand-2);
 }
 
@@ -37,7 +38,8 @@
   color: var(--vp-c-tip-1);
 }
 
-.custom-block.tip a:hover {
+.custom-block.tip a:hover,
+.custom-block.tip a:hover > code {
   color: var(--vp-c-tip-2);
 }
 
@@ -56,7 +58,8 @@
   color: var(--vp-c-warning-1);
 }
 
-.custom-block.warning a:hover {
+.custom-block.warning a:hover,
+.custom-block.warning a:hover > code {
   color: var(--vp-c-warning-2);
 }
 
@@ -75,7 +78,8 @@
   color: var(--vp-c-danger-1);
 }
 
-.custom-block.danger a:hover {
+.custom-block.danger a:hover,
+.custom-block.danger a:hover > code {
   color: var(--vp-c-danger-2);
 }
 
@@ -93,7 +97,8 @@
   color: var(--vp-c-brand-1);
 }
 
-.custom-block.details a:hover {
+.custom-block.details a:hover,
+.custom-block.details a:hover > code {
   color: var(--vp-c-brand-2);
 }
 


### PR DESCRIPTION
Custom containers set a different text `color` for `<a>` and `<code>` elements, depending on the type of container.

Currently the `a:hover` doesn't take account of a nested `code` tag. There's an existing selector for `.vp-doc a:hover > code` that sets `color: var(--vp-code-link-hover-color)`, which is ultimately one of the brand colors.

Hovered code in a link ends up purple. This screenshot comes from the VitePress docs (the mouse cursor isn't shown):

![Code link hover](https://github.com/vuejs/vitepress/assets/65301168/65b8fa4c-4629-45a6-ab2d-7bf668e2704f)

In practice, this only currently impacts `warning` and `danger` containers, as the other containers use the main brand colors anyway. I've applied the same fix to all containers for consistency.

I've used `a:hover > code` in the selectors, as that's what's used elsewhere, though I'm unsure whether the `>` is really necessary. These selectors won't work with more complex markdown, such as ``[***`Example`***](foo)``, but I've tried to remain consistent with the existing selectors, which also don't handle this.