### PR TITLE
docs: add a canonical URL `<link>` example

### DIFF
--- a/docs/reference/site-config.md
+++ b/docs/reference/site-config.md
@@ -645,6 +645,23 @@ export default {
 }
 ```
 
+#### Example: Adding a canonical URL `<link>`  
+
+```ts
+export default {
+  transformHead({ page }) {
+    // Skip the 404 page
+    if (page !== '404.md') {
+      const canonicalUrl = `https://example.com/${page}`
+        .replace(/index\.md$/, '')
+        .replace(/\.md$/, '.html')
+
+      return [['link', { rel: 'canonical', href: canonicalUrl }]]
+    }
+  }
+}
+```
+
 ### transformHtml
 
 - Type: `(code: string, id: string, context: TransformContext) => Awaitable<string | void>`


### PR DESCRIPTION
It took me a bit of searching and experimenting to figure out how to add `<link>` tags for the canonical URL. Eventually I found https://github.com/vuejs/vitepress/pull/588#issuecomment-1406030394, which seems to be the right way to do it.

While VitePress doesn't have direct support for canonical URLs, they can be added using `transformHead`.

This example should allow anyone searching for `canonical` in the docs to find what they need.

It would need adapting if `base` or `cleanUrls` are set, but I didn't think that was worth mentioning in the example itself.