### PR TITLE
docs(i18n): fix chinese translation for default-theme-config.md

### DIFF
--- a/docs/zh/reference/default-theme-config.md
+++ b/docs/zh/reference/default-theme-config.md
@@ -29,7 +29,7 @@ export default {
 
 - 类型：`ThemeableImage`
 
-导航栏上显示的 Logo，位于站点标题右侧。可以接受一个路径字符串，或者一个对象来设置在浅色/深色模式下不同的 Logo。
+导航栏上显示的 Logo，位于站点标题前。可以接受一个路径字符串，或者一个对象来设置在浅色/深色模式下不同的 Logo。
 
 ```ts
 export default {


### PR DESCRIPTION
`right before the site title`错误地翻译成了`位于站点标题右侧`，实际应该是`位于站点标题前`或者`位于站点标题左侧`