### PR TITLE
chore: upgrade shikiji to v0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,9 +102,9 @@
     "focus-trap": "^7.5.4",
     "mark.js": "8.11.1",
     "minisearch": "^6.3.0",
-    "shikiji": "^0.9.19",
-    "shikiji-core": "^0.9.19",
-    "shikiji-transformers": "^0.9.19",
+    "shikiji": "^0.10.0",
+    "shikiji-core": "^0.10.0",
+    "shikiji-transformers": "^0.10.0",
     "vite": "^5.0.11",
     "vue": "^3.4.14"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,14 +42,14 @@ importers:
         specifier: ^6.3.0
         version: 6.3.0
       shikiji:
-        specifier: ^0.9.19
-        version: 0.9.19
+        specifier: ^0.10.0
+        version: 0.10.0
       shikiji-core:
-        specifier: ^0.9.19
-        version: 0.9.19
+        specifier: ^0.10.0
+        version: 0.10.0
       shikiji-transformers:
-        specifier: ^0.9.19
-        version: 0.9.19
+        specifier: ^0.10.0
+        version: 0.10.0
       vite:
         specifier: ^5.0.11
         version: 5.0.12(@types/node@20.11.2)
@@ -4160,20 +4160,20 @@ packages:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
     dev: true
 
-  /shikiji-core@0.9.19:
-    resolution: {integrity: sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw==}
+  /shikiji-core@0.10.0:
+    resolution: {integrity: sha512-imG+bvRkuNlZUi2q9tMVfegRRouTpDxMFejpfF/6J+bFX3NDKtlW9T9iIAkBYnw4pcCtSwirW0AvkwlQR4wyxg==}
     dev: false
 
-  /shikiji-transformers@0.9.19:
-    resolution: {integrity: sha512-lGLI7Z8frQrIBbhZ74/eiJtxMoCQRbpaHEB+gcfvdIy+ZFaAtXncJGnc52932/UET+Y4GyKtwwC/vjWUCp+c/Q==}
+  /shikiji-transformers@0.10.0:
+    resolution: {integrity: sha512-x9oYybeF/XOrIc6Mm8G1gU5ezunMxdgD4WwBTKrZ5tAmFFaNIWCjwZENgRt1uR4iMi0+pGH0g9bmrbraSC41nA==}
     dependencies:
-      shikiji: 0.9.19
+      shikiji: 0.10.0
     dev: false
 
-  /shikiji@0.9.19:
-    resolution: {integrity: sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==}
+  /shikiji@0.10.0:
+    resolution: {integrity: sha512-1dAzIOWbtM7B4Sem5BvE+CEdsebDsRA34SfCxM4qJ4PLgR73ZD92VEtNfbcoZ3xOLSqvtV0J9i4WpCgVsmQteg==}
     dependencies:
-      shikiji-core: 0.9.19
+      shikiji-core: 0.10.0
     dev: false
 
   /side-channel@1.0.4:


### PR DESCRIPTION
This release improves a lot by the accuracy and TwoSlash integrations: https://github.com/antfu/shikiji/releases/tag/v0.10.0

It should be a non-breaking change for end-users.