### PR TITLE
docs: update github workflow example

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -153,18 +153,18 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
        runs-on: ubuntu-latest
        steps:
          - name: Checkout
-           uses: actions/checkout@v3
+           uses: actions/checkout@v4
            with:
              fetch-depth: 0 # Not needed if lastUpdated is not enabled
          # - uses: pnpm/action-setup@v2 # Uncomment this if you're using pnpm
          # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
          - name: Setup Node
-           uses: actions/setup-node@v3
+           uses: actions/setup-node@v4
            with:
              node-version: 18
              cache: npm # or pnpm / yarn
          - name: Setup Pages
-           uses: actions/configure-pages@v3
+           uses: actions/configure-pages@v4
          - name: Install dependencies
            run: npm ci # or pnpm install / yarn install / bun install
          - name: Build with VitePress
@@ -172,7 +172,7 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
              npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
              touch docs/.vitepress/dist/.nojekyll
          - name: Upload artifact
-           uses: actions/upload-pages-artifact@v2
+           uses: actions/upload-pages-artifact@v3
            with:
              path: docs/.vitepress/dist
 
@@ -182,12 +182,15 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
          name: github-pages
          url: ${{ steps.deployment.outputs.page_url }}
        needs: build
+       permissions:
+         pages: write
+         id-token: write
        runs-on: ubuntu-latest
        name: Deploy
        steps:
          - name: Deploy to GitHub Pages
            id: deployment
-           uses: actions/deploy-pages@v2
+           uses: actions/deploy-pages@v4
    ```
 
    ::: warning

--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -161,7 +161,7 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
          - name: Setup Node
            uses: actions/setup-node@v4
            with:
-             node-version: 18
+             node-version: 20
              cache: npm # or pnpm / yarn
          - name: Setup Pages
            uses: actions/configure-pages@v4

--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -182,9 +182,6 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
          name: github-pages
          url: ${{ steps.deployment.outputs.page_url }}
        needs: build
-       permissions:
-         pages: write
-         id-token: write
        runs-on: ubuntu-latest
        name: Deploy
        steps:


### PR DESCRIPTION
The current [example](https://vitepress.dev/guide/deploy#github-pages) provided for GitHub Pages uses actions that trigger a [Node 16 deprecation warning](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) when ran. I have bumped the versions of the actions and the Node version to 20 to resolve this warning.

Additionally, I added the permissions required for deploying pages with `actions/deploy-pages@v4` [see example](actions/configure-pages).

The changes were tested on a personal repository [before](https://github.com/LiamEderzeel/valideer/actions/runs/7680847537) and [after](https://github.com/LiamEderzeel/valideer/actions/runs/7685380902).

Please let me know if any further changes are needed or if more information is required.
