### PR TITLE
fix: markdown-it-attrs behaviour in pre wrapper plugin

### DIFF
--- a/src/node/markdown/plugins/highlightLines.ts
+++ b/src/node/markdown/plugins/highlightLines.ts
@@ -14,11 +14,22 @@ export const highlightLinePlugin = (md: MarkdownIt) => {
 
     // due to use of markdown-it-attrs, the {0} syntax would have been
     // converted to attrs on the token
-    const attr = token.attrs && token.attrs[0]
+    let highlightLineAttr
+    if (token.attrs) {
+      token.attrs = token.attrs.filter((x) => {
+        const isHighlightLineAttr = /^[\d,-]+$/.test(x[0])
+
+        if (isHighlightLineAttr) {
+          highlightLineAttr = x
+        }
+
+        return !isHighlightLineAttr
+      })
+    }
 
     let lines = null
 
-    if (!attr) {
+    if (!highlightLineAttr) {
       // markdown-it-attrs maybe disabled
       const rawInfo = token.info
 
@@ -35,7 +46,7 @@ export const highlightLinePlugin = (md: MarkdownIt) => {
     }
 
     if (!lines) {
-      lines = attr![0]
+      lines = highlightLineAttr![0]
 
       if (!lines || !/[\d,-]+/.test(lines)) {
         return fence(...args)

--- a/src/node/markdown/plugins/preWrapper.ts
+++ b/src/node/markdown/plugins/preWrapper.ts
@@ -26,9 +26,7 @@ export function preWrapperPlugin(md: MarkdownIt, options: Options) {
     if (classAttr != null) {
       classAttr[1] = `${classes}  ${classAttr[1]}`
     } else {
-      const attrs: Array<[string, string]> = [['class', classes]]
-
-      token.attrs = token.attrs ? token.attrs.concat(attrs) : attrs
+      token.attrJoin('class', classes)
     }
 
     const rawCode = fence(...args)

--- a/src/node/markdown/plugins/preWrapper.ts
+++ b/src/node/markdown/plugins/preWrapper.ts
@@ -18,13 +18,24 @@ export function preWrapperPlugin(md: MarkdownIt, options: Options) {
     token.info = token.info.replace(/ active$/, '').replace(/ active /, ' ')
 
     const lang = extractLang(token.info)
+    const classes = `language-${lang}${getAdaptiveThemeMarker(
+      options
+    )}${active}`
+    const classAttr = token.attrs && token.attrs.find((x) => x[0] === 'class')
 
+    if (classAttr != null) {
+      classAttr[1] = `${classes}  ${classAttr[1]}`
+    } else {
+      const attrs: Array<[string, string]> = [['class', classes]]
+
+      token.attrs = token.attrs ? token.attrs.concat(attrs) : attrs
+    }
+
+    const rawCode = fence(...args)
     return (
-      `<div class="language-${lang}${getAdaptiveThemeMarker(options)}${active}">` +
+      `<div ${md.renderer.renderAttrs(token)}>` +
       `<button title="${options.codeCopyButtonTitle}" class="copy"></button>` +
-      `<span class="lang">${lang}</span>` +
-      fence(...args) +
-      '</div>'
+      `<span class="lang">${lang}</span>${rawCode}</div>`
     )
   }
 }


### PR DESCRIPTION
I noticed that the `markdown-it-attrs` did not work on fences with ` ```md`. It was also mentioned in #826. The proposed changes could resolve this issue.

I tested the changes on the following markdown and also checked for compatibility with the highligh lines syntax.


`````md
<style>
.yellow {
  background-color: yellow !important; 
}
.yellow span {
  color: black !important;
}
</style>


Fix attributes for internal `preWrapperPlugin`

```css
<style>
.yellow {
  background-color: yellow !important; 
}
.yellow span {
  color: black !important;
}
</style>
```

````md
```md {data-attribute="some data" .yellow}
````

```md {data-attribute="some data" .yellow}
I made some custom styling for this code block through markdown-it-attrs

Also i added a custom attribute "data-attribute"

```

````md
```md {1}{data-attribute="some data" .yellow}
````
```md {1}{data-attribute="some data" .yellow}
I made some custom styling for this code block through markdown-it-attrs

Also i added a custom attribute "data-attribute"

```

````md
```md {1}
````
```md {1}
I made some custom styling for this code block through markdown-it-attrs

Also i added a custom attribute "data-attribute"

```

`````

I also tested if disabling `markdown-it-attrs` still gives the expected behaviour.
```ts [.vitepress/config/shared.ts]
export const shared = defineConfig({
  markdown: {
    attrs: {
      disable
    }
}
```
Let me know if changes are required or if more information is needed.

Resolves: #826