### PR TITLE
feat: wrap app title in span to get targeted by CSS

### DIFF
--- a/src/client/theme-default/components/VPNavBarTitle.vue
+++ b/src/client/theme-default/components/VPNavBarTitle.vue
@@ -39,7 +39,7 @@ const target = computed(() =>
     >
       <slot name="nav-bar-title-before" />
       <VPImage v-if="theme.logo" class="logo" :image="theme.logo" />
-      <template v-if="theme.siteTitle">{{ theme.siteTitle }}</template>
+      <template v-if="theme.siteTitle"><span>{{ theme.siteTitle }}</span></template>
       <template v-else-if="theme.siteTitle === undefined"><span>{{ site.title }}</span></template>
       <slot name="nav-bar-title-after" />
     </a>

--- a/src/client/theme-default/components/VPNavBarTitle.vue
+++ b/src/client/theme-default/components/VPNavBarTitle.vue
@@ -40,7 +40,7 @@ const target = computed(() =>
       <slot name="nav-bar-title-before" />
       <VPImage v-if="theme.logo" class="logo" :image="theme.logo" />
       <template v-if="theme.siteTitle">{{ theme.siteTitle }}</template>
-      <template v-else-if="theme.siteTitle === undefined">{{ site.title }}</template>
+      <template v-else-if="theme.siteTitle === undefined"><span>{{ site.title }}</span></template>
       <slot name="nav-bar-title-after" />
     </a>
   </div>


### PR DESCRIPTION
Hi 👋🏻 

I want to remove site title only in home page and as there's no direct option I'm using CSS but unfortunetly current DOM structure doesn't allow targeting the text only so I wrapped title in span tag which I good as well.