### PR TITLE
✨ feat: add hero slots that are inside container

### DIFF
--- a/docs/guide/extending-default-theme.md
+++ b/docs/guide/extending-default-theme.md
@@ -195,7 +195,9 @@ Full list of slots available in the default theme layout:
   - `aside-ads-after`
 - When `layout: 'home'` is enabled via frontmatter:
   - `home-hero-before`
+  - `home-hero-info-before`
   - `home-hero-info`
+  - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`
   - `home-features-before`

--- a/docs/zh/guide/extending-default-theme.md
+++ b/docs/zh/guide/extending-default-theme.md
@@ -194,7 +194,9 @@ export default {
   - `aside-ads-after`
 - 当 `layout: 'home'` 在 frontmatter 中被启用时:
   - `home-hero-before`
+  - `home-hero-info-before`
   - `home-hero-info`
+  - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`
   - `home-features-before`

--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -25,7 +25,7 @@ const heroImageSlotExists = inject('hero-image-slot-exists') as Ref<boolean>
   <div class="VPHero" :class="{ 'has-image': image || heroImageSlotExists }">
     <div class="container">
       <div class="main">
-        <slot name="home-hero-info-before"></slot>
+        <slot name="home-hero-info-before" />
         <slot name="home-hero-info">
           <h1 v-if="name" class="name">
             <span v-html="name" class="clip"></span>
@@ -45,7 +45,7 @@ const heroImageSlotExists = inject('hero-image-slot-exists') as Ref<boolean>
             />
           </div>
         </div>
-        <slot name="home-hero-actions-after"></slot>
+        <slot name="home-hero-actions-after" />
       </div>
 
       <div v-if="image || heroImageSlotExists" class="image">

--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -25,6 +25,7 @@ const heroImageSlotExists = inject('hero-image-slot-exists') as Ref<boolean>
   <div class="VPHero" :class="{ 'has-image': image || heroImageSlotExists }">
     <div class="container">
       <div class="main">
+        <slot name="home-hero-info-before"></slot>
         <slot name="home-hero-info">
           <h1 v-if="name" class="name">
             <span v-html="name" class="clip"></span>
@@ -44,6 +45,7 @@ const heroImageSlotExists = inject('hero-image-slot-exists') as Ref<boolean>
             />
           </div>
         </div>
+        <slot name="home-hero-actions-after"></slot>
       </div>
 
       <div v-if="image || heroImageSlotExists" class="image">

--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -33,6 +33,7 @@ const heroImageSlotExists = inject('hero-image-slot-exists') as Ref<boolean>
           <p v-if="text" v-html="text" class="text"></p>
           <p v-if="tagline" v-html="tagline" class="tagline"></p>
         </slot>
+        <slot name="home-hero-info-after" />
 
         <div v-if="actions" class="actions">
           <div v-for="action in actions" :key="action.link" class="action">


### PR DESCRIPTION
Hi 👋🏻 

When trying to add some content before app title & after actions **but inside container** there's no easy way, we have to create custom container class and VitePress' container classes are also scoped which we can't leverage.

Basically, What I'm trying to create is something like this:
![image](https://github.com/vuejs/vitepress/assets/47495003/0d9ff78c-b3d0-4565-beee-1bd37fe34461)

> _P.S. There's no need for `home-hero-actions-before` because `home-hero-info-after` can do the job_