### PR TITLE
fix(theme): correctly normalize paths ending with "index"

### DIFF
--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -17,7 +17,8 @@ export type {
 export const EXTERNAL_URL_RE = /^(?:[a-z]+:|\/\/)/i
 export const APPEARANCE_KEY = 'vitepress-theme-appearance'
 export const HASH_RE = /#.*$/
-export const EXT_RE = /(index)?\.(md|html)$/
+export const EXT_RE = /\.(md|html)$/
+export const INDEX_RE = /\/index$/
 
 export const inBrowser = typeof document !== 'undefined'
 
@@ -61,7 +62,7 @@ export function isActive(
 }
 
 export function normalize(path: string): string {
-  return decodeURI(path).replace(HASH_RE, '').replace(EXT_RE, '')
+  return decodeURI(path).replace(HASH_RE, '').replace(EXT_RE, '').replace(INDEX_RE, '/')
 }
 
 export function isExternal(path: string): boolean {

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -16,9 +16,10 @@ export type {
 
 export const EXTERNAL_URL_RE = /^(?:[a-z]+:|\/\/)/i
 export const APPEARANCE_KEY = 'vitepress-theme-appearance'
-export const HASH_RE = /#.*$/
-export const EXT_RE = /\.(md|html)$/
-export const INDEX_RE = /\/index$/
+
+const HASH_RE = /#.*$/
+const HASH_OR_QUERY_RE = /[?#].*$/
+const INDEX_OR_EXT_RE = /(?:(^|\/)index)?\.(?:md|html)$/
 
 export const inBrowser = typeof document !== 'undefined'
 
@@ -61,8 +62,10 @@ export function isActive(
   return true
 }
 
-export function normalize(path: string): string {
-  return decodeURI(path).replace(HASH_RE, '').replace(EXT_RE, '').replace(INDEX_RE, '/')
+function normalize(path: string): string {
+  return decodeURI(path)
+    .replace(HASH_OR_QUERY_RE, '')
+    .replace(INDEX_OR_EXT_RE, '$1')
 }
 
 export function isExternal(path: string): boolean {


### PR DESCRIPTION
When the path referenced by `link` in `themeConfig` ends with `index`, the sidebar fails to highlight the current page, and the prev/next navigation also becomes ineffective.

Here's an example:
```ts
sidebar: [
  {
    text: 'Examples',
    items: [
      { text: 'Markdown Examples', link: '/markdown-examples' },
      { text: 'ABC', link: '/xxx-index' }, //   ends with index
      { text: 'Runtime API Examples', link: '/api-examples' }
    ]
  }
]
```

![image](https://github.com/vuejs/vitepress/assets/16619108/f993127f-40c5-43c9-a438-16e19ed9b3cf)
