### PR TITLE
fix(theme): make MathJax svg inline

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -247,5 +247,6 @@ mjx-container {
 }
 
 mjx-container > svg {
+  display: inline-block;
   margin: auto;
 }


### PR DESCRIPTION
MathJax uses `vertical-align` to adjust the vertical position of the svg, and `vertical-align` requires the element to be inline or a table-cell.

Before:
![图片](https://github.com/vuejs/vitepress/assets/47070449/83d3f719-20be-4fb3-924a-fb81980422f2)

After:
![图片](https://github.com/vuejs/vitepress/assets/47070449/ae1da390-f479-4009-8b42-4f9359287011)