### PR TITLE
feat: added new slots for both before and after contents

### DIFF
--- a/docs/guide/extending-default-theme.md
+++ b/docs/guide/extending-default-theme.md
@@ -185,6 +185,8 @@ Full list of slots available in the default theme layout:
   - `doc-footer-before`
   - `doc-before`
   - `doc-after`
+  - `doc-content-before`
+  - `doc-content-after`
   - `sidebar-nav-before`
   - `sidebar-nav-after`
   - `aside-top`

--- a/docs/zh/guide/extending-default-theme.md
+++ b/docs/zh/guide/extending-default-theme.md
@@ -184,6 +184,8 @@ export default {
   - `doc-footer-before`
   - `doc-before`
   - `doc-after`
+  - `doc-content-before`
+  - `doc-content-after`
   - `sidebar-nav-before`
   - `sidebar-nav-after`
   - `aside-top`

--- a/src/client/theme-default/Layout.vue
+++ b/src/client/theme-default/Layout.vue
@@ -68,6 +68,8 @@ provide('hero-image-slot-exists', heroImageSlotExists)
       <template #doc-footer-before><slot name="doc-footer-before" /></template>
       <template #doc-before><slot name="doc-before" /></template>
       <template #doc-after><slot name="doc-after" /></template>
+      <template #doc-content-before><slot name="doc-content-before" /></template>
+      <template #doc-content-after><slot name="doc-content-after" /></template>
       <template #doc-top><slot name="doc-top" /></template>
       <template #doc-bottom><slot name="doc-bottom" /></template>
 

--- a/src/client/theme-default/components/VPContent.vue
+++ b/src/client/theme-default/components/VPContent.vue
@@ -50,6 +50,8 @@ const { hasSidebar } = useSidebar()
       <template #doc-footer-before><slot name="doc-footer-before" /></template>
       <template #doc-before><slot name="doc-before" /></template>
       <template #doc-after><slot name="doc-after" /></template>
+      <template #doc-content-before><slot name="doc-content-before" /></template>
+      <template #doc-content-after><slot name="doc-content-after" /></template>
 
       <template #aside-top><slot name="aside-top" /></template>
       <template #aside-outline-before><slot name="aside-outline-before" /></template>

--- a/src/client/theme-default/components/VPDoc.vue
+++ b/src/client/theme-default/components/VPDoc.vue
@@ -43,6 +43,7 @@ const pageName = computed(() =>
         <div class="content-container">
           <slot name="doc-before" />
           <main class="main">
+            <slot name="doc-content-before" />
             <Content
               class="vp-doc"
               :class="[
@@ -50,6 +51,7 @@ const pageName = computed(() =>
                 theme.externalLinkIcon && 'external-link-icon-enabled'
               ]"
             />
+            <slot name="doc-content-after" />
           </main>
           <VPDocFooter>
             <template #doc-footer-before><slot name="doc-footer-before" /></template>


### PR DESCRIPTION
## Summary

There will be many helpers, informational components for documentations right before and after the content itself (e.g. feedback, support links, versions, releases, reactions, comments, copyright notices).

Currently, developers must either write their own transform hooks or markdown-it middleware to transform and inject the before and after components as sections.

This Pull Request added two new slots to simplify the procedure in such use cases:

 - `doc-content-before`
 - `doc-content-after`

with these two newly added slots, it will be easier for users to add and integrate their own helper, informational components.