### PR TITLE
feat(theme): allow selectively disabling external link icon on navbar items

### DIFF
--- a/docs/pt/reference/default-theme-config.md
+++ b/docs/pt/reference/default-theme-config.md
@@ -93,6 +93,7 @@ interface NavItemWithLink {
   activeMatch?: string
   target?: string
   rel?: string
+  noIcon?: boolean
 }
 
 interface NavItemChildren {

--- a/docs/reference/default-theme-config.md
+++ b/docs/reference/default-theme-config.md
@@ -93,6 +93,7 @@ interface NavItemWithLink {
   activeMatch?: string
   target?: string
   rel?: string
+  noIcon?: boolean
 }
 
 interface NavItemChildren {

--- a/docs/zh/reference/default-theme-config.md
+++ b/docs/zh/reference/default-theme-config.md
@@ -93,6 +93,7 @@ interface NavItemWithLink {
   activeMatch?: string
   target?: string
   rel?: string
+  noIcon?: boolean
 }
 
 interface NavItemChildren {

--- a/src/client/theme-default/components/VPNavBarMenuLink.vue
+++ b/src/client/theme-default/components/VPNavBarMenuLink.vue
@@ -22,6 +22,7 @@ const { page } = useData()
       )
     }"
     :href="item.link"
+    :noIcon="item.noIcon"
     :target="item.target"
     :rel="item.rel"
     tabindex="0"

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -176,6 +176,7 @@ export namespace DefaultTheme {
     activeMatch?: string
     rel?: string
     target?: string
+    noIcon?: boolean
   }
 
   export interface NavItemChildren {


### PR DESCRIPTION
It seems that by default, VitePress automatically adds an icon based on whether the link is an external link or not. I see that there's an option to [disable external link icons](https://vitepress.dev/reference/default-theme-config#externallinkicon) entirely but that wasn't quite what I was looking for (plus couldn't get it to work). I also noticed that this option used to exist but was removed [here](https://github.com/vuejs/vitepress/pull/1881/files) which made sense for that use case, but this PR makes it optionally able to be removed on a "per link" level.

**User Case:**

```js
export default {
  themeConfig: {
    nav: [
      // don't want the external link icon here.
      { text: 'Support', link: 'mailto:support@website.com?subject=Support Request', noIcon: true },
      // want the external link icon here.
      { text: 'Sign in', link: 'https://website.com/login' }
    ]
  }
}
```

This seems to work very nicely and gave the results I was looking for. I'm hoping this can be added. 

**Results:**

<img width="175" alt="image" src="https://github.com/vuejs/vitepress/assets/18044230/ba0216f0-ce3c-4ced-955a-0a5418ad7a0f">


