### PR TITLE
docs: linked files not treated as assets

### DIFF
--- a/docs/guide/asset-handling.md
+++ b/docs/guide/asset-handling.md
@@ -12,6 +12,10 @@ You can reference static assets in your markdown files, your `*.vue` components 
 
 Common image, media, and font filetypes are detected and included as assets automatically.
 
+::: tip Linked files are not treated as assets
+PDFs or other documents referenced by links within markdown files are not automatically treated as assets. To make linked files accessible, you must manually place them within the [`public`](#the-public-directory) directory of your project.
+:::
+
 All referenced assets, including those using absolute paths, will be copied to the output directory with a hashed file name in the production build. Never-referenced assets will not be copied. Image assets smaller than 4kb will be base64 inlined - this can be configured via the [`vite`](../reference/site-config#vite) config option.
 
 All **static** path references, including absolute paths, should be based on your working directory structure.


### PR DESCRIPTION
Add a note to make clear that documents referenced by link in markdown files are not going to be automatically copied into the output directory in the production build (#3535).