### PR TITLE
docs: remove unnecessary nojekyll for GitHub Actions deployment

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -168,9 +168,7 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
          - name: Install dependencies
            run: npm ci # or pnpm install / yarn install / bun install
          - name: Build with VitePress
-           run: |
-             npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
-             touch docs/.vitepress/dist/.nojekyll
+           run: npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
          - name: Upload artifact
            uses: actions/upload-pages-artifact@v3
            with:

--- a/docs/zh/guide/deploy.md
+++ b/docs/zh/guide/deploy.md
@@ -168,9 +168,7 @@ Cache-Control: max-age=31536000,immutable
          - name: Install dependencies
            run: npm ci # 或 pnpm install / yarn install / bun install
          - name: Build with VitePress
-           run: |
-             npm run docs:build # 或 pnpm docs:build / yarn docs:build / bun run docs:build
-             touch docs/.vitepress/dist/.nojekyll
+           run: npm run docs:build # 或 pnpm docs:build / yarn docs:build / bun run docs:build
          - name: Upload artifact
            uses: actions/upload-pages-artifact@v3
            with:


### PR DESCRIPTION
There is no need for `.nojekyll` when deploying via GitHub Actions (see https://github.com/vuejs/vitepress/discussions/3629 / https://github.com/actions/jekyll-build-pages).