### PR TITLE
fix(theme): judgment conditions error with `markdownStyles`

### DIFF
--- a/src/client/theme-default/components/VPHome.vue
+++ b/src/client/theme-default/components/VPHome.vue
@@ -23,7 +23,7 @@ const { frontmatter } = useData()
     <VPHomeFeatures />
     <slot name="home-features-after" />
 
-    <VPHomeContent v-if="frontmatter.markdownStyles !== false">
+    <VPHomeContent v-if="frontmatter.markdownStyles">
       <Content />
     </VPHomeContent>
     <Content v-else />


### PR DESCRIPTION
When I do not declare markdownStyles in frontmatter but the `<Content />` still be wrapped by `<VPHomeContent />`. So there is a problem with the judgment conditions here.