### PR TITLE
fix(router): hashchange not emitted in certain cases

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -180,7 +180,7 @@ export function createRouter(
               : link.href,
             link.baseURI
           )
-          const currentUrl = window.location
+          const currentUrl = new URL(window.location.href) // copy to keep old data
           // only intercept inbound html links
           if (
             !e.ctrlKey &&
@@ -211,7 +211,12 @@ export function createRouter(
                 window.scrollTo(0, 0)
               }
             } else {
-              go(href)
+              go(href).then(() => {
+                // do after the route is changed so location.hash in theme code is the new hash
+                if (hash !== currentUrl.hash) {
+                  window.dispatchEvent(new Event('hashchange'))
+                }
+              })
             }
           }
         }

--- a/src/client/theme-default/composables/langs.ts
+++ b/src/client/theme-default/composables/langs.ts
@@ -1,4 +1,4 @@
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 import { ensureStartingSlash } from '../support/utils'
 import { useData } from './data'
 import { hashRef } from './hash'
@@ -14,10 +14,6 @@ export function useLangs({
       site.value.locales[localeIndex.value]?.link ||
       (localeIndex.value === 'root' ? '/' : `/${localeIndex.value}/`)
   }))
-
-  watch(page, () => {
-    hashRef.value = location.hash ? location.hash : ''
-  })
 
   const localeLinks = computed(() =>
     Object.entries(site.value.locales).flatMap(([key, value]) =>

--- a/src/client/theme-default/composables/langs.ts
+++ b/src/client/theme-default/composables/langs.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { ensureStartingSlash } from '../support/utils'
 import { useData } from './data'
 import { hashRef } from './hash'
@@ -14,6 +14,10 @@ export function useLangs({
       site.value.locales[localeIndex.value]?.link ||
       (localeIndex.value === 'root' ? '/' : `/${localeIndex.value}/`)
   }))
+
+  watch(page, () => {
+    hashRef.value = location.hash ? location.hash : ''
+  })
 
   const localeLinks = computed(() =>
     Object.entries(site.value.locales).flatMap(([key, value]) =>


### PR DESCRIPTION
Two problems were discovered when the site was configured with i18n.

![langs-hash-bug](https://github.com/vuejs/vitepress/assets/44596995/2e81fc45-954f-42c7-9833-cad8d9172429)

1. The first problem was reproduced according to the procedure in the moving image above. The page hash value should end up as an empty string.

2. The second problem was similar, in the search box, when clicking on a search item with a hash value, I jumped to the corresponding location, and then switched languages, and found that the corresponding language jump address did not have a hash value.