### PR TITLE
fix: createContentLoader issue by pattern mapping from config.root to config.srcDir

### DIFF
--- a/src/node/contentLoader.ts
+++ b/src/node/contentLoader.ts
@@ -75,7 +75,7 @@ export interface ContentData {
  */
 export function createContentLoader<T = ContentData[]>(
   /**
-   * files to glob / watch - relative to <project root>
+   * files to glob / watch - relative to srcDir
    */
   pattern: string | string[],
   {

--- a/src/node/contentLoader.ts
+++ b/src/node/contentLoader.ts
@@ -98,7 +98,7 @@ export function createContentLoader<T = ContentData[]>(
   }
 
   if (typeof pattern === 'string') pattern = [pattern]
-  pattern = pattern.map((p) => normalizePath(path.join(config.root, p)))
+  pattern = pattern.map((p) => normalizePath(path.join(config.srcDir, p)))
 
   let md: MarkdownRenderer
 


### PR DESCRIPTION
close #3622

It looks like a bug in #3622.

According to the docs about [createContentLoader](https://vitepress.dev/guide/data-loading#createcontentloader), the glob pattern should be relatived to the [source directory](https://vitepress.dev/guide/routing#source-directory) instead of [project root](https://vitepress.dev/guide/routing#project-root).