### PR TITLE
fix: improve code group explicit/implicit logic

### DIFF
--- a/src/client/app/composables/codeGroups.ts
+++ b/src/client/app/composables/codeGroups.ts
@@ -7,7 +7,7 @@ export function useCodeGroups() {
         Array.from(el.children).forEach((child) => {
           child.classList.remove('active')
         })
-        el.children[0].classList.add('active')
+        el.querySelector('div[class^="language"]')?.classList.add('active')
       })
     })
   }
@@ -24,19 +24,21 @@ export function useCodeGroups() {
         const i = Array.from(group.querySelectorAll('input')).indexOf(el)
         if (i < 0) return
 
-        const blocks = group.querySelector('.blocks')
-        if (!blocks) return
-
-        const current = Array.from(blocks.children).find((child) =>
-          child.classList.contains('active')
+        const codeBlocks = group.querySelectorAll(
+          '.blocks > div[class^="language"]'
         )
-        if (!current) return
+        if (!codeBlocks) return
 
-        const next = blocks.children[i]
-        if (!next || current === next) return
+        const activeBlock = Array.from(codeBlocks).find((block) =>
+          block.classList.contains('active')
+        )
+        if (!activeBlock) return
 
-        current.classList.remove('active')
-        next.classList.add('active')
+        const nextBlock = codeBlocks[i]
+        if (!nextBlock || activeBlock === nextBlock) return
+
+        activeBlock.classList.remove('active')
+        nextBlock.classList.add('active')
 
         const label = group?.querySelector(`label[for="${el.id}"]`)
         label?.scrollIntoView({ block: 'nearest' })


### PR DESCRIPTION
## example code:

I noticed that https://github.com/vuejs/vitepress/pull/2719 PR supports code-group supports nested html tags, but once I add strange tags (no one should do this) It has some flaws in its logic. I have made some improvements to this.

<pre>
::: code-group

## 123

```
null
```

## 456

```js
console.log(123);
```

```sh [npm]
$ npm add -D vitepress
```

```sh [pnpm]
$ pnpm add -D vitepress
```

```sh [yarn]
$ yarn add -D vitepress
```

```sh [bun]
$ bun add -D vitepress
```

:::
</pre>


### before

https://github.com/vuejs/vitepress/assets/32004925/df83e0f4-4189-40fb-8227-fb01ee198f6a



### after


https://github.com/vuejs/vitepress/assets/32004925/857cce26-4143-4113-9dcd-bf80214689d0


