### PR TITLE
feat: scroll active sidebar link into view on page load

### DIFF
--- a/src/client/theme-default/components/VPSidebar.vue
+++ b/src/client/theme-default/components/VPSidebar.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useScrollLock } from '@vueuse/core'
 import { inBrowser } from 'vitepress'
-import { ref, watch } from 'vue'
+import { nextTick, onMounted, ref, watch } from 'vue'
 import { useSidebar } from '../composables/sidebar'
 import VPSidebarGroup from './VPSidebarGroup.vue'
 
@@ -35,6 +35,11 @@ watch(
   },
   { deep: true }
 )
+
+// scroll active link into view
+onMounted(() => {
+  nextTick(() => navEl.value?.querySelector('.is-active')?.scrollIntoView({ block: 'center'}))
+})
 </script>
 
 <template>

--- a/src/client/theme-default/composables/outline.ts
+++ b/src/client/theme-default/composables/outline.ts
@@ -168,6 +168,7 @@ export function useActiveAnchor(
 
     if (activeLink) {
       activeLink.classList.add('active')
+      activeLink.scrollIntoView({ behavior: 'smooth', block: 'center' })
       marker.value.style.top = activeLink.offsetTop + 39 + 'px'
       marker.value.style.opacity = '1'
     } else {


### PR DESCRIPTION
* Related #2881
* Resolves #3351 

I find myself searching in the sidebar in the VueUse docs for related composables, the current page link is often out of view in the sidebar. 

Not too happy with my solution in `VPSidebar.vue`, I guess this won't scroll the relevant link into view when navigating using in page links, also not sure if `querySelector` is the appropriate way to find the relevant link. Should a router hook be used instead?

I can add tests to confirm the changes work as expected, let me know if changes should be made!