### PR TITLE
fix(theme): fixed sidebar expand caret showing when no children are present

### DIFF
--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -82,7 +82,7 @@ function onCaretClick() {
       <component v-else :is="textTag" class="text" v-html="item.text" />
 
       <div
-        v-if="item.collapsed != null"
+        v-if="item.collapsed != null && item.items && item.items.length"
         class="caret"
         role="button"
         aria-label="toggle section"


### PR DESCRIPTION
This PR removes the expand/collapse caret icon from the sidebar item when no children are present.

Currently, the icon shows only based on the condition `item.collapsed != null` which means the following sidebar configurations would result in the icon showing when it makes no sense to given that they have no children:

```
{
    text: 'Item',
    collapsed: true
},
{
    text: 'Item',
    collapsed: true,
    items: []
},
```

Here is a reproduction showing the issue: https://stackblitz.com/edit/vite-zljffu?file=docs%2F.vitepress%2Fconfig.ts