### PR TITLE
fix(theme): ignore inner-page items in next/prev link

### DIFF
--- a/src/client/theme-default/composables/prev-next.ts
+++ b/src/client/theme-default/composables/prev-next.ts
@@ -13,7 +13,7 @@ export function usePrevNext() {
     // ignore inner-page links with hashes
     const candidates = uniqBy(
       links,
-      (link) => link.link.substring(0, link.link.lastIndexOf('#')) || link.link
+      (link) => link.link.replace(/[?#].*$/, '')
     )
 
     const index = candidates.findIndex((link) => {

--- a/src/client/theme-default/composables/prev-next.ts
+++ b/src/client/theme-default/composables/prev-next.ts
@@ -8,7 +8,13 @@ export function usePrevNext() {
 
   return computed(() => {
     const sidebar = getSidebar(theme.value.sidebar, page.value.relativePath)
-    const candidates = getFlatSideBarLinks(sidebar)
+    const links = getFlatSideBarLinks(sidebar)
+
+    // ignore inner-page links with hashes
+    const candidates = uniqBy(
+      links,
+      (link) => link.link.substring(0, link.link.lastIndexOf('#')) || link.link
+    )
 
     const index = candidates.findIndex((link) => {
       return isActive(page.value.relativePath, link.link)
@@ -59,5 +65,13 @@ export function usePrevNext() {
       prev?: { text?: string; link?: string }
       next?: { text?: string; link?: string }
     }
+  })
+}
+
+function uniqBy<T>(array: T[], keyFn: (item: T) => any): T[] {
+  const seen = new Set()
+  return array.filter((item) => {
+    const k = keyFn(item)
+    return seen.has(k) ? false : seen.add(k)
   })
 }

--- a/src/client/theme-default/composables/prev-next.ts
+++ b/src/client/theme-default/composables/prev-next.ts
@@ -11,10 +11,7 @@ export function usePrevNext() {
     const links = getFlatSideBarLinks(sidebar)
 
     // ignore inner-page links with hashes
-    const candidates = uniqBy(
-      links,
-      (link) => link.link.replace(/[?#].*$/, '')
-    )
+    const candidates = uniqBy(links, (link) => link.link.replace(/[?#].*$/, ''))
 
     const index = candidates.findIndex((link) => {
       return isActive(page.value.relativePath, link.link)


### PR DESCRIPTION
Next/prev links should jump to a separate page.  This would be spoiled by inner-page links with hashes, so jump over them.

Closes https://github.com/vuejs/vitepress/issues/3662