### PR TITLE
fix(localSearch): remove empty titles that may appear in search results

### DIFF
--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -235,8 +235,9 @@ function* splitPageIntoSections(html: string) {
     const anchor = headingResult?.[2] ?? ''
     const content = result[i + 2]
     if (!title || !content) continue
-    const titles = parentTitles.slice(0, level)
+    let titles = parentTitles.slice(0, level)
     titles[level] = title
+    titles = titles.filter(Boolean)
     yield { anchor, titles, text: getSearchableText(content) }
     if (level === 0) {
       parentTitles = [title]


### PR DESCRIPTION
When the main title of the page is not set, results with empty text in the title field in the search results.

Reproduction: https://unplugin.unjs.io/

<img width="1428" alt="image" src="https://github.com/vuejs/vitepress/assets/44596995/250c173d-c695-4fab-834c-fbe321fd783b">
