### PR TITLE
docs(getting-started.md):Add a space

### DIFF
--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -72,7 +72,7 @@ $ pnpm vitepress init
 ```
 
 ```sh [bun]
-$ bunx vitepress init
+$ bun x vitepress init
 ```
 
 :::


### PR DESCRIPTION
This is a space prompted by the instructions when the bun is runtime, and after the system installs the bun, there is no instruction called bunx but needs 'bun x' to execute normally, so a space is added.