### PR TITLE
footer prev / next navigation landmark has a unique name [#3516]

### DIFF
--- a/src/client/theme-default/components/VPDocFooter.vue
+++ b/src/client/theme-default/components/VPDocFooter.vue
@@ -39,7 +39,11 @@ const showFooter = computed(() => {
       </div>
     </div>
 
-    <nav v-if="control.prev?.link || control.next?.link" class="prev-next">
+    <nav v-if="control.prev?.link || control.next?.link" class="prev-next" aria-labelledby="doc-footer-aria-label">
+      <span class="visually-hidden" id="doc-footer-aria-label">
+        Pager
+      </span>
+
       <div class="pager">
         <VPLink v-if="control.prev?.link" class="pager-link prev" :href="control.prev.link">
           <span class="desc" v-html="theme.docFooter?.prev || 'Previous page'"></span>

--- a/src/client/theme-default/components/VPDocFooter.vue
+++ b/src/client/theme-default/components/VPDocFooter.vue
@@ -39,10 +39,12 @@ const showFooter = computed(() => {
       </div>
     </div>
 
-    <nav v-if="control.prev?.link || control.next?.link" class="prev-next" aria-labelledby="doc-footer-aria-label">
-      <span class="visually-hidden" id="doc-footer-aria-label">
-        Pager
-      </span>
+    <nav
+      v-if="control.prev?.link || control.next?.link"
+      class="prev-next"
+      aria-labelledby="doc-footer-aria-label"
+    >
+      <span class="visually-hidden" id="doc-footer-aria-label">Pager</span>
 
       <div class="pager">
         <VPLink v-if="control.prev?.link" class="pager-link prev" :href="control.prev.link">


### PR DESCRIPTION
Fixes #3516

- #3516

To test:

1. On a Vitepress site using the released version, run [axe DevTools](https://www.deque.com/axe/devtools/) on any page that has the footer pager nav. Confirm the error described in the linked issue
2. Repeat on this branch. Confirm that the error is gone.

Questions:

Maybe there's a better name than "Pager"?