### PR TITLE
interactive controls are not nested [#3517]

### DIFF
--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -48,10 +48,6 @@ function onItemInteraction(e: MouseEvent | Event) {
   }
   !props.item.link && toggle()
 }
-
-function onCaretClick() {
-  props.item.link && toggle()
-}
 </script>
 
 <template>
@@ -84,11 +80,6 @@ function onCaretClick() {
       <div
         v-if="item.collapsed != null && item.items && item.items.length"
         class="caret"
-        role="button"
-        aria-label="toggle section"
-        @click="onCaretClick"
-        @keydown.enter="onCaretClick"
-        tabindex="0"
       >
         <span class="vpi-chevron-right caret-icon" />
       </div>


### PR DESCRIPTION
Fixes #3517 

- #3517

## Before

Sidebar items group's headings are focusable, and so are their child carets. The focusable child carets are an accessibility problem (as described in the linked issue) and add no value (focusing and clicking on the caret has the same effect as focusing and clicking on the heading).

## After

Collapsible sidebar items' caret not focusable. Clicking on caret still toggles the group, because a click on caret is a click on the group heading.

## Testing

1. On a Vitepress site using the released version, on any page with a collapsible sidebar item group
	  - use the keyboard <kbd>Tab</kbd> key to navigate to the collapsible group's header. Note that the focus ring contains the caret. Type <kbd>Enter</kbd> and Confirm that the group toggles.
	  - Advance one more <kbd>Tab</kbd> stop to select the caret. Type <kbd>Enter</kbd> and Confirm that the group toggles.
	  - Use the mouse to click on the caret. Confirm that it toggles the group.
3. On that page, run [axe DevTools](https://www.deque.com/axe/devtools/). Confirm the error described in the linked issue
4. Repeat on this branch.
	  - Confirm that the error is gone
	  - Confirm that the group header can be focused with the keyboard
	  - Confirm that <kbd>Enter</kbd> when the group header is focused toggles the group
	  - Confirm that clicking the caret with the mouse toggles the group