### PR TITLE
outline nav does not has duplicative assistive tech-exclusive text [#3800]

### DIFF
--- a/src/client/theme-default/components/VPDocAsideOutline.vue
+++ b/src/client/theme-default/components/VPDocAsideOutline.vue
@@ -25,7 +25,8 @@ useActiveAnchor(container, marker)
 </script>
 
 <template>
-  <div
+  <nav
+    aria-labelledby="doc-outline-aria-label"
     class="VPDocAsideOutline"
     :class="{ 'has-outline': headers.length > 0 }"
     ref="container"
@@ -34,16 +35,18 @@ useActiveAnchor(container, marker)
     <div class="content">
       <div class="outline-marker" ref="marker" />
 
-      <div class="outline-title" role="heading" aria-level="2">{{ resolveTitle(theme) }}</div>
+      <div
+        aria-level="2"
+        class="outline-title"
+        id="doc-outline-aria-label"
+        role="heading"
+      >
+        {{ resolveTitle(theme) }}
+      </div>
 
-      <nav aria-labelledby="doc-outline-aria-label">
-        <span class="visually-hidden" id="doc-outline-aria-label">
-          Table of Contents for current page
-        </span>
-        <VPDocOutlineItem :headers="headers" :root="true" />
-      </nav>
+      <VPDocOutlineItem :headers="headers" :root="true" />
     </div>
-  </div>
+  </nav>
 </template>
 
 <style scoped>


### PR DESCRIPTION
Fixes #3800

- #3800 

## Before

- The outline had two navigation elements, one labelled but one not
- The labelled navigation's label was exclusive to assistive tech. It was at best duplicative of and at worst in conflict with the configurable heading displayed visually, which is also available to assistive tech.

## After

The outline has one navigation element. Its label is the configurable heading displayed visually.

## Testing

1. On a Vitepress site using the released version, on any page with an outline, use a screen reader or other assistive tech to read the outline. Confirm that the nested navigation adds no value, that the labelled nav's label is distinct from what is displayed visually, and that the divergent assistive tech experience adds no value.

On this branch, 

2. Run [axe DevTools](https://www.deque.com/axe/devtools/) on a page with an outline. Confirm that there is no regression error in the outline
3. Use a screen reader or other assistive tech to read the outline. Confirm that the single nav is labelled by the visually displayed heading, and that the assistive tech experience of the outline is closer to the visual experience than it was.