### PR TITLE
sidebar uses native <details> for collapsible groups [#3804. also #3517]

### DIFF
--- a/__tests__/e2e/multi-sidebar/index.test.ts
+++ b/__tests__/e2e/multi-sidebar/index.test.ts
@@ -5,7 +5,8 @@ describe('test multi sidebar sort root', () => {
 
   test('using / sidebar', async () => {
     const sidebarLocator = page.locator(
-      '.VPSidebarItem.level-0 > .item > .text'
+      '.VPSidebarItem.level-0 > .item > summary > .text, \
+      .VPSidebarItem.level-0 > .item > .text'
     )
 
     const sidebarContent = await sidebarLocator.allTextContents()

--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -60,32 +60,14 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
   return [
     {
       text: 'Introduction',
-      collapsed: true,
+      collapsed: false,
       items: [
-        {
-          text: 'Group heading linked to "What is VitePress?"',
-          link: 'what-is-vitepress',
-          collapsed: true,
-          items: [
-            {
-              text: 'Another group heading linked to "What is VitePress?"',
-              link: 'what-is-vitepress',
-              collapsed: true,
-              items: [
-                {
-                  text: 'What is VitePress?',
-                  link: 'what-is-vitepress'
-                }
-              ]
-            }
-          ]
-        },
+        { text: 'What is VitePress?', link: 'what-is-vitepress' },
         { text: 'Getting Started', link: 'getting-started' },
         { text: 'Routing', link: 'routing' },
         { text: 'Deploy', link: 'deploy' }
       ]
     },
-    { text: 'What is VitePress?', link: 'what-is-vitepress' },
     {
       text: 'Writing',
       collapsed: false,

--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -60,14 +60,32 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
   return [
     {
       text: 'Introduction',
-      collapsed: false,
+      collapsed: true,
       items: [
-        { text: 'What is VitePress?', link: 'what-is-vitepress' },
+        {
+          text: 'Group heading linked to "What is VitePress?"',
+          link: 'what-is-vitepress',
+          collapsed: true,
+          items: [
+            {
+              text: 'Another group heading linked to "What is VitePress?"',
+              link: 'what-is-vitepress',
+              collapsed: true,
+              items: [
+                {
+                  text: 'What is VitePress?',
+                  link: 'what-is-vitepress'
+                }
+              ]
+            }
+          ]
+        },
         { text: 'Getting Started', link: 'getting-started' },
         { text: 'Routing', link: 'routing' },
         { text: 'Deploy', link: 'deploy' }
       ]
     },
+    { text: 'What is VitePress?', link: 'what-is-vitepress' },
     {
       text: 'Writing',
       collapsed: false,

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -151,10 +151,8 @@ const classes = computed(() => [
   transition: background-color 0.25s;
 }
 
-.VPSidebarItem.level-2.is-active > .item > .indicator,
-.VPSidebarItem.level-3.is-active > .item > .indicator,
-.VPSidebarItem.level-4.is-active > .item > .indicator,
-.VPSidebarItem.level-5.is-active > .item > .indicator {
+
+.VPSidebarItem:is(.level-2, .level-3, .level-4, .level-5).is-active > .item > .indicator {
   background-color: var(--vp-c-brand-1);
 }
 
@@ -177,39 +175,15 @@ const classes = computed(() => [
   color: var(--vp-c-text-1);
 }
 
-.VPSidebarItem.level-1 .text,
-.VPSidebarItem.level-2 .text,
-.VPSidebarItem.level-3 .text,
-.VPSidebarItem.level-4 .text,
-.VPSidebarItem.level-5 .text {
+.VPSidebarItem:is(.level-1, .level-2, .level-3, .level-4, .level-5) .text {
   font-weight: 500;
   color: var(--vp-c-text-2);
 }
 
-.VPSidebarItem.level-0.is-active > .item > summary .text,
-.VPSidebarItem.level-1.is-active > .item > summary .text,
-.VPSidebarItem.level-2.is-active > .item > summary .text,
-.VPSidebarItem.level-3.is-active > .item > summary .text,
-.VPSidebarItem.level-4.is-active > .item > summary .text,
-.VPSidebarItem.level-5.is-active > .item > summary .text,
-.VPSidebarItem.level-0.is-active > .item > .link > .text,
-.VPSidebarItem.level-1.is-active > .item > .link > .text,
-.VPSidebarItem.level-2.is-active > .item > .link > .text,
-.VPSidebarItem.level-3.is-active > .item > .link > .text,
-.VPSidebarItem.level-4.is-active > .item > .link > .text,
-.VPSidebarItem.level-5.is-active > .item > .link > .text,
-.VPSidebarItem.level-0 .link:hover >.text,
-.VPSidebarItem.level-1 .link:hover >.text,
-.VPSidebarItem.level-2 .link:hover >.text,
-.VPSidebarItem.level-3 .link:hover >.text,
-.VPSidebarItem.level-4 .link:hover >.text,
-.VPSidebarItem.level-5 .link:hover >.text,
-.VPSidebarItem.level-0 .link:focus >.text,
-.VPSidebarItem.level-1 .link:focus >.text,
-.VPSidebarItem.level-2 .link:focus >.text,
-.VPSidebarItem.level-3 .link:focus >.text,
-.VPSidebarItem.level-4 .link:focus >.text,
-.VPSidebarItem.level-5 .link:focus >.text {
+.VPSidebarItem.is-active:is(.level-0, .level-1, .level-2, .level-3, .level-4, .level-5)  > .item > summary .text,
+.VPSidebarItem.is-active:is(.level-0, .level-1, .level-2, .level-3, .level-4, .level-5)  > .item > .link > .text,
+.VPSidebarItem:is(.level-0, .level-1, .level-2, .level-3, .level-4, .level-5) .link:hover >.text,
+.VPSidebarItem:is(.level-0, .level-1, .level-2, .level-3, .level-4, .level-5) .link:focus >.text {
   color: var(--vp-c-brand-1);
 }
 
@@ -244,11 +218,7 @@ const classes = computed(() => [
   transform: rotate(0);
 }
 
-.VPSidebarItem.level-1 .items,
-.VPSidebarItem.level-2 .items,
-.VPSidebarItem.level-3 .items,
-.VPSidebarItem.level-4 .items,
-.VPSidebarItem.level-5 .items {
+.VPSidebarItem:is(.level-1, .level-2, .level-3, .level-4, .level-5) .items {
   border-left: 1px solid var(--vp-c-divider);
   padding-left: 16px;
 }

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -61,11 +61,11 @@ function onCaretClick() {
       class="item"
       :role="itemRole"
       v-on="
-        item.items
+        hasChildren
           ? { click: onItemInteraction, keydown: onItemInteraction }
           : {}
       "
-      :tabindex="item.items && 0"
+      :tabindex="hasChildren ? 0 : undefined"
     >
       <div class="indicator" />
 
@@ -82,7 +82,7 @@ function onCaretClick() {
       <component v-else :is="textTag" class="text" v-html="item.text" />
 
       <div
-        v-if="item.collapsed != null && item.items && item.items.length"
+        v-if="item.collapsed != null && hasChildren"
         class="caret"
         role="button"
         aria-label="toggle section"
@@ -94,7 +94,7 @@ function onCaretClick() {
       </div>
     </div>
 
-    <div v-if="item.items && item.items.length" class="items">
+    <div v-if="hasChildren" class="items">
       <template v-if="depth < 5">
         <VPSidebarItem
           v-for="i in item.items"

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -126,18 +126,19 @@ const classes = computed(() => [
   cursor: pointer;
   display: flex;
   justify-content: space-between;
+}
 
-  .link {
-    flex-grow: 0;
-  }
+.VPSidebarItem details summary .link {
+  flex-grow: 0;
+}
 
-  &::-webkit-details-marker {
-    display: none;
-  }
+  
+.VPSidebarItem details summary::-webkit-details-marker {
+  display: none;
+}
 
-  &::marker {
-    content: '';
-  }
+.VPSidebarItem details summary::marker {
+  content: '';
 }
 
 .indicator {

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -88,7 +88,7 @@ function onToggle(payload: ToggleEvent): void {
       class="item"
     >
       <div class="indicator" />
-      
+
       <VPLink
         v-if="item.link"
         :tag="linkTag"

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -10,10 +10,13 @@ const props = defineProps<{
 }>()
 
 const {
+  collapsed,
+  collapsible,
   isLink,
   isActiveLink,
   hasActiveLink,
-  hasChildren
+  hasChildren,
+  handleToggle,
 } = useSidebarControl(computed(() => props.item))
 
 const sectionTag = computed(() => (hasChildren.value ? 'section' : `div`))
@@ -34,14 +37,23 @@ const classes = computed(() => [
   { 'is-active': isActiveLink.value },
   { 'has-active': hasActiveLink.value }
 ])
+
+function onToggle(payload: ToggleEvent): void {
+  handleToggle(payload.newState)
+}
 </script>
 
 <template>
   <component :is="sectionTag" class="VPSidebarItem" :class="classes">
+    <!-- @TODO @toggle TS error blocked by
+      https://github.com/vuejs/core/pull/10938.
+      See also https://github.com/vuejs/core/issues/10928
+    -->
     <details
-      v-if="item.text && item.collapsed != null && hasChildren"
+      v-if="item.text && collapsible && hasChildren"
       class="item"
-      :open="!item.collapsed"
+      :open="!collapsed"
+      @toggle="onToggle"
     >
       <summary>
         <div class="indicator" />
@@ -94,7 +106,7 @@ const classes = computed(() => [
       <component v-else :is="textTag" class="text" v-html="item.text" />
     </div>
 
-    <div v-if="(item.collapsed == null || !item.text) && hasChildren" class="items">
+    <div v-if="(!collapsible || !item.text) && hasChildren" class="items">
       <template v-if="depth < 5">
         <VPSidebarItem
           v-for="i in item.items"

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -45,10 +45,6 @@ function onToggle(payload: ToggleEvent): void {
 
 <template>
   <component :is="sectionTag" class="VPSidebarItem" :class="classes">
-    <!-- @TODO @toggle TS error blocked by
-      https://github.com/vuejs/core/pull/10938.
-      See also https://github.com/vuejs/core/issues/10928
-    -->
     <details
       v-if="item.text && collapsible && hasChildren"
       class="item"

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -200,12 +200,8 @@ const classes = computed(() => [
   flex-shrink: 0;
 }
 
-.item:hover .caret {
-  color: var(--vp-c-text-2);
-}
-
-.item:hover .caret:hover {
-  color: var(--vp-c-text-1);
+.item summary:hover .caret {
+  color: var(--vp-c-text-1)
 }
 
 .caret-icon {

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -126,6 +126,7 @@ const classes = computed(() => [
   cursor: pointer;
   display: flex;
   justify-content: space-between;
+  position: relative;
 }
 
 .VPSidebarItem details summary .link {
@@ -151,8 +152,8 @@ const classes = computed(() => [
   transition: background-color 0.25s;
 }
 
-
-.VPSidebarItem:is(.level-2, .level-3, .level-4, .level-5).is-active > .item > .indicator {
+.VPSidebarItem:is(.level-2, .level-3, .level-4, .level-5).is-active > .item > .indicator,
+.VPSidebarItem:is(.level-2, .level-3, .level-4, .level-5).is-active > details > summary .indicator {
   background-color: var(--vp-c-brand-1);
 }
 

--- a/src/client/theme-default/composables/sidebar.ts
+++ b/src/client/theme-default/composables/sidebar.ts
@@ -20,13 +20,11 @@ import {
 import { useData } from './data'
 
 export interface SidebarControl {
-  collapsed: Ref<boolean>
   collapsible: ComputedRef<boolean>
   isLink: ComputedRef<boolean>
   isActiveLink: Ref<boolean>
   hasActiveLink: ComputedRef<boolean>
   hasChildren: ComputedRef<boolean>
-  toggle(): void
 }
 
 export function useSidebar() {
@@ -139,8 +137,6 @@ export function useSidebarControl(
 ): SidebarControl {
   const { page, hash } = useData()
 
-  const collapsed = ref(false)
-
   const collapsible = computed(() => {
     return item.value.collapsed != null
   })
@@ -171,27 +167,15 @@ export function useSidebarControl(
     return !!(item.value.items && item.value.items.length)
   })
 
-  watchEffect(() => {
-    collapsed.value = !!(collapsible.value && item.value.collapsed)
-  })
-
   watchPostEffect(() => {
-    ;(isActiveLink.value || hasActiveLink.value) && (collapsed.value = false)
+    isActiveLink.value || hasActiveLink.value
   })
-
-  function toggle() {
-    if (collapsible.value) {
-      collapsed.value = !collapsed.value
-    }
-  }
 
   return {
-    collapsed,
     collapsible,
     isLink,
     isActiveLink,
     hasActiveLink,
-    hasChildren,
-    toggle
+    hasChildren
   }
 }

--- a/src/client/theme-default/composables/sidebar.ts
+++ b/src/client/theme-default/composables/sidebar.ts
@@ -20,11 +20,13 @@ import {
 import { useData } from './data'
 
 export interface SidebarControl {
+  collapsed: Ref<boolean>
   collapsible: ComputedRef<boolean>
   isLink: ComputedRef<boolean>
   isActiveLink: Ref<boolean>
   hasActiveLink: ComputedRef<boolean>
   hasChildren: ComputedRef<boolean>
+  handleToggle(newState: string): void
 }
 
 export function useSidebar() {
@@ -137,6 +139,8 @@ export function useSidebarControl(
 ): SidebarControl {
   const { page, hash } = useData()
 
+  const collapsed = ref(false)
+
   const collapsible = computed(() => {
     return item.value.collapsed != null
   })
@@ -167,15 +171,26 @@ export function useSidebarControl(
     return !!(item.value.items && item.value.items.length)
   })
 
-  watchPostEffect(() => {
-    isActiveLink.value || hasActiveLink.value
+  watchEffect(() => {
+    collapsed.value = !!(collapsible.value && item.value.collapsed)
   })
 
+  watchPostEffect(() => {
+    console.log(item.value.text, isActiveLink.value, hasActiveLink.value)
+    ;(isActiveLink.value || hasActiveLink.value) && (collapsed.value = false)
+  })
+
+  function handleToggle(newState: string) {
+    collapsed.value = newState === 'closed'
+  }
+
   return {
+    collapsed,
     collapsible,
     isLink,
     isActiveLink,
     hasActiveLink,
-    hasChildren
+    hasChildren,
+    handleToggle
   }
 }

--- a/src/client/theme-default/composables/sidebar.ts
+++ b/src/client/theme-default/composables/sidebar.ts
@@ -176,7 +176,6 @@ export function useSidebarControl(
   })
 
   watchPostEffect(() => {
-    console.log(item.value.text, isActiveLink.value, hasActiveLink.value)
     ;(isActiveLink.value || hasActiveLink.value) && (collapsed.value = false)
   })
 


### PR DESCRIPTION
> Had time to hack on this now, so didn't wait to hear if it was desirable. Close if you need to 👍 

Closes #3804

- #3804

Fixes #3517, closes # 3802 as obviated

- #3517
- ~&nbsp;#3802&nbsp;~

~Fixes #3805~

- ~#3805~
- Reverted per https://github.com/vuejs/vitepress/pull/3806#issuecomment-2079941485

3804 is the primary target of this PR. Preserving the behaviors identified in 3517 and 3805 would have taken additional work, so I took the opportunity to address them for "free".

## Before

Sidebar collapsible groups used custom markup and JS. Carets are focusable, an accessibility problem.

## After

- 3804: Sidebar collapsible groups use native `<details>` elements. Custom markup and JS is reduced.
- 3517: dropped the separately-clickable carets. See PR #3802 for details on rationale.
- 3805: Clicking linked text in a collapsible group's heading doesn't toggle the group.

# To test

1. With the released version, replace `docs/.vitepress/config/en.ts`'s `sidebarGuide` with the following.

	```js
	function sidebarGuide(): DefaultTheme.SidebarItem[] {
	  return [
	    {
	      text: 'Introduction',
	      collapsed: true,
	      items: [
	        {
	          text: 'Group heading linked to "What is VitePress?"',
	          link: 'what-is-vitepress',
	          collapsed: true,
	          items: [
	            {
	              text: 'Another group heading linked to "What is VitePress?"',
	              link: 'what-is-vitepress',
	              collapsed: true,
	              items: [
	                {
	                  text: 'What is VitePress?',
	                  link: 'what-is-vitepress',
	                },
	              ],
	            },
	          ],
	        },
	        { text: 'Getting Started', link: 'getting-started' },
	        { text: 'Routing', link: 'routing' },
	        { text: 'Deploy' }
	      ]
	    },
	    { text: 'What is VitePress?', link: 'what-is-vitepress',},
	    {
	      text: 'Writing',
	      collapsed: false,
	      items: [
	        { text: 'Markdown Extensions', link: 'markdown' },
	        { text: 'Asset Handling', link: 'asset-handling' },
	        { text: 'Frontmatter', link: 'frontmatter' },
	        { text: 'Using Vue in Markdown', link: 'using-vue' },
	        { text: 'Internationalization', link: 'i18n' }
	      ]
	    },
	    {
	      text: 'Customization',
	      collapsed: false,
	      items: [
	        { text: 'Using a Custom Theme', link: 'custom-theme' },
	        {
	          text: 'Extending the Default Theme',
	          link: 'extending-default-theme'
	        },
	        { text: 'Build-Time Data Loading', link: 'data-loading' },
	        { text: 'SSR Compatibility', link: 'ssr-compat' },
	        { text: 'Connecting to a CMS', link: 'cms' }
	      ]
	    },
	    {
	      text: 'Experimental',
	      collapsed: false,
	      items: [
	        { text: 'MPA Mode', link: 'mpa-mode' },
	        { text: 'Sitemap Generation', link: 'sitemap-generation' }
	      ]
	    },
	    { text: 'Config & API Reference', base: '/reference/', link: 'site-config' }
	  ]
	}
	```
1. Run `pnpm run docs`
1. Open `http://localhost:<your port>/guide/what-is-vitepress` in a browser
3. Confirm that the "Introduction" group is closed. [3804 regression check]
4. Toggle "Introduction" and its children open by clicking on the carets [3517]. Confirm that all items linked to "What is VitePress?" have the active color. [3804 regression check]
5. Toggle unlinked group headings, eg. "Writing". Confirm that they toggle when either the text or caret is clicked. [3517]
6. Confirm that the non-group item linked to "What is VitePress?" has the indicator. [3804 regression check]
7. Toggle "Introduction" > "Group heading linked to “What is VitePress?”" closed.
7. Confirm that hovering over "Introduction" > "Deploy", which is not linked, does not give it the hover color. [3804 regression check]
8. Confirm that hovering of the _text_ "Group heading linked to “What is VitePress?”" gives it the hover color. [3804]
6. Confirm that hovering with the cursor over linked sidebar items gives them the hover color. [3804 regression check]
9. Click "Introduction" > "Routing"
10. ~Under "Introduction", click the _text_ of the first item, "Group heading linked to "“What is VitePress?”". Confirm that the site navigates _and_ the group stays closed. [3805]~ Reverted per https://github.com/vuejs/vitepress/pull/3806#issuecomment-2079941485