### PR TITLE
fix: make code blocks accessible with keyboard

### DIFF
--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -85,7 +85,6 @@ export async function highlight(
     {
       name: 'vitepress:clean-up',
       pre(node) {
-        delete node.properties.tabindex
         delete node.properties.style
       }
     }


### PR DESCRIPTION
Scrollable region must have keyboard access. Currently, I can't scroll the code horizontally with the keyboard because it's impossible to focus on it.

This is a WCAG requirement. Read more:
https://dequeuniversity.com/rules/axe/4.9/scrollable-region-focusable