### PR TITLE
From `pnpm vitepress init` to `pnpx vitepress init`

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -68,7 +68,7 @@ $ npx vitepress init
 ```
 
 ```sh [pnpm]
-$ pnpm vitepress init
+$ pnpx vitepress init
 ```
 
 ```sh [yarn]


### PR DESCRIPTION
The command `pnpm vitepress init` doesn't work as `vitepress` isn't a subcommand of pnpm.
But the command `pnpx vitepress init` works as `pnpx` is the equivalent of `npx` for pnpm.