### PR TITLE
docs: fix translations of the vp-raw block description

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -233,7 +233,7 @@ This is a special container that can be used to prevent style and router conflic
 
 ```md
 ::: raw
-Wraps in a <div class="vp-raw">
+Wraps in a <div class="vp-raw" />
 :::
 ```
 

--- a/docs/pt/guide/markdown.md
+++ b/docs/pt/guide/markdown.md
@@ -233,7 +233,7 @@ Este é um recipiente especial que pode ser usado para evitar conflitos de estil
 
 ```md
 ::: raw
-Envolve em um <div class="vp-raw">
+Envolve em um <div class="vp-raw" />
 :::
 ```
 

--- a/docs/ru/guide/markdown.md
+++ b/docs/ru/guide/markdown.md
@@ -237,7 +237,7 @@ export default defineConfig({
 
 ```md
 ::: raw
-Заворачивается в <div class="vp-raw">
+Заворачивается в <div class="vp-raw" />
 :::
 ```
 

--- a/docs/zh/guide/markdown.md
+++ b/docs/zh/guide/markdown.md
@@ -233,7 +233,7 @@ export default defineConfig({
 
 ```md
 ::: raw
-Wraps in a <div class="vp-raw">
+Wraps in a <div class="vp-raw" />
 :::
 ```
 


### PR DESCRIPTION
Hello Vitepress team.

This is my first PR. I usually try the official documentation examples when deploying documentation. 

When I copied this examples:
![Snipaste_2024-05-28_12-39-04](https://github.com/vuejs/vitepress/assets/46964330/d0720db4-3d2b-4545-87c3-cda5eb7767fe)

 I found a compilation error:
![Snipaste_2024-05-28_12-28-27](https://github.com/vuejs/vitepress/assets/46964330/8c7158f1-9bc2-4595-9a27-406501d51563)

The reason is that this error is easy to fix for more experienced developers, but it might confuse some beginners. 

Therefore, I suggest adding a end tag to make the documentation more complete:
![Snipaste_2024-05-28_12-39-17](https://github.com/vuejs/vitepress/assets/46964330/68fa487f-6870-44fd-a03f-4c31c146325f)

 I hope this merge can help everyone.

Cheers.