### PR TITLE
styles(theme): fix long math equation overflow

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -244,6 +244,8 @@ vite-error-overlay {
 mjx-container {
   display: inline-block;
   margin: auto 2px -2px;
+  overflow-x: auto;
+  overflow-y: clip;
 }
 
 mjx-container > svg {


### PR DESCRIPTION
## Description

Small fix to #3914 Math equations overflow when accessing on Mobile devices.

## Reproduction
Write a markdown with the equation:
```
$$\text{input layer size 94 x 94 : }\ (64_nC2-FMP \sqrt[3]{2})_{12}-C2-C1-output$$
```