### PR TITLE
chore: Fix dead link in MiniSearch type definitions

### DIFF
--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -417,14 +417,14 @@ export namespace DefaultTheme {
 
     miniSearch?: {
       /**
-       * @see https://lucaong.github.io/minisearch/modules/_minisearch_.html#options
+       * @see https://lucaong.github.io/minisearch/types/MiniSearch.Options.html
        */
       options?: Pick<
         MiniSearchOptions,
         'extractField' | 'tokenize' | 'processTerm'
       >
       /**
-       * @see https://lucaong.github.io/minisearch/modules/_minisearch_.html#searchoptions-1
+       * @see https://lucaong.github.io/minisearch/types/MiniSearch.SearchOptions.html
        */
       searchOptions?: MiniSearchOptions['searchOptions']
 


### PR DESCRIPTION
The documentation for MiniSearch seems to have been revised, and the link to the type definitions in vitepress is no longer valid.
![image](https://github.com/vuejs/vitepress/assets/63507251/bf619fc3-d7ce-4d76-a161-cadfa6f2bd7b)
