### PR TITLE
feat: add keybind(ctrl-p and ctrl-n) for mac platform

### DIFF
--- a/docs/zh/guide/ssr-compat.md
+++ b/docs/zh/guide/ssr-compat.md
@@ -48,7 +48,7 @@ if (!import.meta.env.SSR) {
 }
 ```
 
-因为 [`Theme.enhanceApp`](/guide/custom-theme#theme-interface) 可以是异步的，所以可以有条件地导入并注册访问浏览器 API 的 Vue 插件：
+因为 [`Theme.enhanceApp`](./custom-theme#theme-interface) 可以是异步的，所以可以有条件地导入并注册访问浏览器 API 的 Vue 插件：
 
 ```js
 // .vitepress/theme/index.js

--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -299,25 +299,39 @@ function scrollToSelectedResult() {
   })
 }
 
-onKeyStroke('ArrowUp', (event) => {
-  event.preventDefault()
-  selectedIndex.value--
-  if (selectedIndex.value < 0) {
-    selectedIndex.value = results.value.length - 1
-  }
+function goRelativeItem(offset: number) {
+  const resNum = results.value.length
+  selectedIndex.value = (selectedIndex.value + resNum + (offset % resNum)) % resNum
   disableMouseOver.value = true
   scrollToSelectedResult()
+}
+
+onKeyStroke('ArrowUp', (event) => {
+  event.preventDefault()
+  goRelativeItem(-1)
 })
 
 onKeyStroke('ArrowDown', (event) => {
   event.preventDefault()
-  selectedIndex.value++
-  if (selectedIndex.value >= results.value.length) {
-    selectedIndex.value = 0
-  }
-  disableMouseOver.value = true
-  scrollToSelectedResult()
+  goRelativeItem(1)
 })
+
+const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
+if (isMac) {
+  onKeyStroke('n', (event) => {
+    if (event.ctrlKey) {
+      event.preventDefault()
+      goRelativeItem(1)
+    }
+  })
+
+  onKeyStroke('p', (event) => {
+    if (event.ctrlKey) {
+      event.preventDefault()
+      goRelativeItem(-1)
+    }
+  })
+}
 
 const router = useRouter()
 
@@ -540,8 +554,17 @@ function formMarkRegex(terms: Set<string>) {
             <kbd :aria-label="translate('modal.footer.navigateUpKeyAriaLabel')">
               <span class="vpi-arrow-up navigate-icon" />
             </kbd>
+            <span>/</span>
+            <kbd :aria-label="translate('modal.footer.navigateDownKeyAriaLabel')">
+              <span class="navigate-icon">ctrl-p</span>
+            </kbd>
+            <span>and</span>
             <kbd :aria-label="translate('modal.footer.navigateDownKeyAriaLabel')">
               <span class="vpi-arrow-down navigate-icon" />
+            </kbd>
+            <span>/</span>
+            <kbd :aria-label="translate('modal.footer.navigateDownKeyAriaLabel')">
+              <span class="navigate-icon">ctrl-n</span>
             </kbd>
             {{ translate('modal.footer.navigateText') }}
           </span>

--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -316,8 +316,7 @@ onKeyStroke('ArrowDown', (event) => {
   goRelativeItem(1)
 })
 
-const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
-if (isMac) {
+if (document.documentElement.classList.contains('mac')) {
   onKeyStroke('n', (event) => {
     if (event.ctrlKey) {
       event.preventDefault()


### PR DESCRIPTION
<img width="921" alt="image" src="https://github.com/vuejs/vitepress/assets/111564053/7ffe2187-660a-4c46-a0c8-f69ef6c6b8fa">

The current appearance is like this, and we can using `ctrl-p/n` to navigate for mac platform (and just for local search)
this is related with #3853