### PR TITLE
fix: normalize path with suffix slash

### DIFF
--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -20,6 +20,7 @@ export const APPEARANCE_KEY = 'vitepress-theme-appearance'
 const HASH_RE = /#.*$/
 const HASH_OR_QUERY_RE = /[?#].*$/
 const INDEX_OR_EXT_RE = /(?:(^|\/)index)?\.(?:md|html)$/
+const SUFFIX_SLASH_RE = /\/$/
 
 export const inBrowser = typeof document !== 'undefined'
 
@@ -66,6 +67,7 @@ function normalize(path: string): string {
   return decodeURI(path)
     .replace(HASH_OR_QUERY_RE, '')
     .replace(INDEX_OR_EXT_RE, '$1')
+    .replace(SUFFIX_SLASH_RE, '')
 }
 
 export function isExternal(path: string): boolean {


### PR DESCRIPTION
normalize `guide/routing/` -> `guide/routing`, with the following directory structure:

```
.
├─ routing
│  └─ index.md
└─ index.md
```