### PR TITLE
fix: bun scripts start w bunx

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -80,7 +80,7 @@ $ yarn vitepress init
 ```
 
 ```sh [bun]
-$ bun vitepress init
+$ bunx vitepress init
 ```
 
 :::


### PR DESCRIPTION
The getting started document uses `bun`, an npx-like functionality can be achieved by using bunx