### PR TITLE
fix: change the setup wizard command for `pnpm`

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -72,7 +72,7 @@ $ npx vitepress init
 ```
 
 ```sh [pnpm]
-$ pnpm vitepress init
+$ pnpm dlx vitepress init
 ```
 
 ```sh [yarn]

--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -72,7 +72,7 @@ $ npx vitepress init
 ```
 
 ```sh [pnpm]
-$ pnpm dlx vitepress init
+$ pnpx vitepress init
 ```
 
 ```sh [yarn]


### PR DESCRIPTION
The `pnpm vitepress init` command will throw this error

```
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitepress" not found
```

The alternative of `npx` in pnpm is `pnpm dlx` (`pnpx`)