### PR TITLE
fix(components): excerpt style in LocalSearchBox

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -781,12 +781,11 @@ function formMarkRegex(terms: Set<string>) {
 }
 
 .excerpt {
-  opacity: 75%;
+  opacity: 50%;
   pointer-events: none;
   max-height: 140px;
   overflow: hidden;
   position: relative;
-  opacity: 0.5;
   margin-top: 4px;
 }
 


### PR DESCRIPTION
The transparency style of the excerpt class in local search is written repeatedly