### PR TITLE
Put all styles in `@layer` for lowered specificity

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -1,251 +1,253 @@
-@media (prefers-reduced-motion: reduce) {
+@layer vitepress.base {
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    ::before,
+    ::after {
+      animation-delay: -1ms !important;
+      animation-duration: 1ms !important;
+      animation-iteration-count: 1 !important;
+      background-attachment: initial !important;
+      scroll-behavior: auto !important;
+      transition-duration: 0s !important;
+      transition-delay: 0s !important;
+    }
+  }
+
   *,
   ::before,
   ::after {
-    animation-delay: -1ms !important;
-    animation-duration: 1ms !important;
-    animation-iteration-count: 1 !important;
-    background-attachment: initial !important;
-    scroll-behavior: auto !important;
-    transition-duration: 0s !important;
-    transition-delay: 0s !important;
+    box-sizing: border-box;
   }
-}
 
-*,
-::before,
-::after {
-  box-sizing: border-box;
-}
+  html {
+    line-height: 1.4;
+    font-size: 16px;
+    -webkit-text-size-adjust: 100%;
+  }
 
-html {
-  line-height: 1.4;
-  font-size: 16px;
-  -webkit-text-size-adjust: 100%;
-}
+  html.dark {
+    color-scheme: dark;
+  }
 
-html.dark {
-  color-scheme: dark;
-}
+  body {
+    margin: 0;
+    width: 100%;
+    min-width: 320px;
+    min-height: 100vh;
+    line-height: 24px;
+    font-family: var(--vp-font-family-base);
+    font-size: 16px;
+    font-weight: 400;
+    color: var(--vp-c-text-1);
+    background-color: var(--vp-c-bg);
+    font-synthesis: style;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 
-body {
-  margin: 0;
-  width: 100%;
-  min-width: 320px;
-  min-height: 100vh;
-  line-height: 24px;
-  font-family: var(--vp-font-family-base);
-  font-size: 16px;
-  font-weight: 400;
-  color: var(--vp-c-text-1);
-  background-color: var(--vp-c-bg);
-  font-synthesis: style;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+  main {
+    display: block;
+  }
 
-main {
-  display: block;
-}
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0;
+    line-height: 24px;
+    font-size: 16px;
+    font-weight: 400;
+  }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  margin: 0;
-  line-height: 24px;
-  font-size: 16px;
-  font-weight: 400;
-}
+  p {
+    margin: 0;
+  }
 
-p {
-  margin: 0;
-}
+  strong,
+  b {
+    font-weight: 600;
+  }
 
-strong,
-b {
-  font-weight: 600;
-}
+  /**
+   * Avoid 300ms click delay on touch devices that support the `touch-action`
+   * CSS property.
+   *
+   * In particular, unlike most other browsers, IE11+Edge on Windows 10 on
+   * touch devices and IE Mobile 10-11 DON'T remove the click delay when
+   * `<meta name="viewport" content="width=device-width">` is present.
+   * However, they DO support removing the click delay via
+   * `touch-action: manipulation`.
+   *
+   * See:
+   * - http://v4-alpha.getbootstrap.com/content/reboot/#click-delay-optimization-for-touch
+   * - http://caniuse.com/#feat=css-touch-action
+   * - http://patrickhlauke.github.io/touch/tests/results/#suppressing-300ms-delay
+   */
+  a,
+  area,
+  button,
+  [role='button'],
+  input,
+  label,
+  select,
+  summary,
+  textarea {
+    touch-action: manipulation;
+  }
 
-/**
- * Avoid 300ms click delay on touch devices that support the `touch-action`
- * CSS property.
- *
- * In particular, unlike most other browsers, IE11+Edge on Windows 10 on
- * touch devices and IE Mobile 10-11 DON'T remove the click delay when
- * `<meta name="viewport" content="width=device-width">` is present.
- * However, they DO support removing the click delay via
- * `touch-action: manipulation`.
- *
- * See:
- * - http://v4-alpha.getbootstrap.com/content/reboot/#click-delay-optimization-for-touch
- * - http://caniuse.com/#feat=css-touch-action
- * - http://patrickhlauke.github.io/touch/tests/results/#suppressing-300ms-delay
- */
-a,
-area,
-button,
-[role='button'],
-input,
-label,
-select,
-summary,
-textarea {
-  touch-action: manipulation;
-}
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
 
-a {
-  color: inherit;
-  text-decoration: inherit;
-}
+  ol,
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 
-ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+  blockquote {
+    margin: 0;
+  }
 
-blockquote {
-  margin: 0;
-}
+  pre,
+  code,
+  kbd,
+  samp {
+    font-family: var(--vp-font-family-mono);
+  }
 
-pre,
-code,
-kbd,
-samp {
-  font-family: var(--vp-font-family-mono);
-}
+  img,
+  svg,
+  video,
+  canvas,
+  audio,
+  iframe,
+  embed,
+  object {
+    display: block;
+  }
 
-img,
-svg,
-video,
-canvas,
-audio,
-iframe,
-embed,
-object {
-  display: block;
-}
+  figure {
+    margin: 0;
+  }
 
-figure {
-  margin: 0;
-}
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
 
-img,
-video {
-  max-width: 100%;
-  height: auto;
-}
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    border: 0;
+    padding: 0;
+    line-height: inherit;
+    color: inherit;
+  }
 
-button,
-input,
-optgroup,
-select,
-textarea {
-  border: 0;
-  padding: 0;
-  line-height: inherit;
-  color: inherit;
-}
+  button {
+    padding: 0;
+    font-family: inherit;
+    background-color: transparent;
+    background-image: none;
+  }
 
-button {
-  padding: 0;
-  font-family: inherit;
-  background-color: transparent;
-  background-image: none;
-}
+  button:enabled,
+  [role='button']:enabled {
+    cursor: pointer;
+  }
 
-button:enabled,
-[role='button']:enabled {
-  cursor: pointer;
-}
+  button:focus,
+  button:focus-visible {
+    outline: 1px dotted;
+    outline: 4px auto -webkit-focus-ring-color;
+  }
 
-button:focus,
-button:focus-visible {
-  outline: 1px dotted;
-  outline: 4px auto -webkit-focus-ring-color;
-}
+  button:focus:not(:focus-visible) {
+    outline: none !important;
+  }
 
-button:focus:not(:focus-visible) {
-  outline: none !important;
-}
+  input:focus,
+  textarea:focus,
+  select:focus {
+    outline: none;
+  }
 
-input:focus,
-textarea:focus,
-select:focus {
-  outline: none;
-}
+  table {
+    border-collapse: collapse;
+  }
 
-table {
-  border-collapse: collapse;
-}
+  input {
+    background-color: transparent;
+  }
 
-input {
-  background-color: transparent;
-}
+  input:-ms-input-placeholder,
+  textarea:-ms-input-placeholder {
+    color: var(--vp-c-text-3);
+  }
 
-input:-ms-input-placeholder,
-textarea:-ms-input-placeholder {
-  color: var(--vp-c-text-3);
-}
+  input::-ms-input-placeholder,
+  textarea::-ms-input-placeholder {
+    color: var(--vp-c-text-3);
+  }
 
-input::-ms-input-placeholder,
-textarea::-ms-input-placeholder {
-  color: var(--vp-c-text-3);
-}
+  input::placeholder,
+  textarea::placeholder {
+    color: var(--vp-c-text-3);
+  }
 
-input::placeholder,
-textarea::placeholder {
-  color: var(--vp-c-text-3);
-}
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
+  input[type='number'] {
+    -moz-appearance: textfield;
+  }
 
-input[type='number'] {
-  -moz-appearance: textfield;
-}
+  textarea {
+    resize: vertical;
+  }
 
-textarea {
-  resize: vertical;
-}
+  select {
+    -webkit-appearance: none;
+  }
 
-select {
-  -webkit-appearance: none;
-}
+  fieldset {
+    margin: 0;
+    padding: 0;
+  }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  li,
+  p {
+    overflow-wrap: break-word;
+  }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-li,
-p {
-  overflow-wrap: break-word;
-}
+  vite-error-overlay {
+    z-index: 9999;
+  }
 
-vite-error-overlay {
-  z-index: 9999;
-}
+  mjx-container {
+    overflow-x: auto;
+  }
 
-mjx-container {
-  overflow-x: auto;
-}
-
-mjx-container > svg {
-  display: inline-block;
-  margin: auto;
+  mjx-container > svg {
+    display: inline-block;
+    margin: auto;
+  }
 }

--- a/src/client/theme-default/styles/components/custom-block.css
+++ b/src/client/theme-default/styles/components/custom-block.css
@@ -1,208 +1,210 @@
-.custom-block {
-  border: 1px solid transparent;
-  border-radius: 8px;
-  padding: 16px 16px 8px;
-  line-height: 24px;
-  font-size: var(--vp-custom-block-font-size);
-  color: var(--vp-c-text-2);
-}
+@layer vitepress.components.customblock {
+  .custom-block {
+    border: 1px solid transparent;
+    border-radius: 8px;
+    padding: 16px 16px 8px;
+    line-height: 24px;
+    font-size: var(--vp-custom-block-font-size);
+    color: var(--vp-c-text-2);
+  }
 
-.custom-block.info {
-  border-color: var(--vp-custom-block-info-border);
-  color: var(--vp-custom-block-info-text);
-  background-color: var(--vp-custom-block-info-bg);
-}
+  .custom-block.info {
+    border-color: var(--vp-custom-block-info-border);
+    color: var(--vp-custom-block-info-text);
+    background-color: var(--vp-custom-block-info-bg);
+  }
 
-.custom-block.info a,
-.custom-block.info code {
-  color: var(--vp-c-brand-1);
-}
+  .custom-block.info a,
+  .custom-block.info code {
+    color: var(--vp-c-brand-1);
+  }
 
-.custom-block.info a:hover,
-.custom-block.info a:hover > code {
-  color: var(--vp-c-brand-2);
-}
+  .custom-block.info a:hover,
+  .custom-block.info a:hover > code {
+    color: var(--vp-c-brand-2);
+  }
 
-.custom-block.info code {
-  background-color: var(--vp-custom-block-info-code-bg);
-}
+  .custom-block.info code {
+    background-color: var(--vp-custom-block-info-code-bg);
+  }
 
-.custom-block.note {
-  border-color: var(--vp-custom-block-note-border);
-  color: var(--vp-custom-block-note-text);
-  background-color: var(--vp-custom-block-note-bg);
-}
+  .custom-block.note {
+    border-color: var(--vp-custom-block-note-border);
+    color: var(--vp-custom-block-note-text);
+    background-color: var(--vp-custom-block-note-bg);
+  }
 
-.custom-block.note a,
-.custom-block.note code {
-  color: var(--vp-c-brand-1);
-}
+  .custom-block.note a,
+  .custom-block.note code {
+    color: var(--vp-c-brand-1);
+  }
 
-.custom-block.note a:hover,
-.custom-block.note a:hover > code {
-  color: var(--vp-c-brand-2);
-}
+  .custom-block.note a:hover,
+  .custom-block.note a:hover > code {
+    color: var(--vp-c-brand-2);
+  }
 
-.custom-block.note code {
-  background-color: var(--vp-custom-block-note-code-bg);
-}
+  .custom-block.note code {
+    background-color: var(--vp-custom-block-note-code-bg);
+  }
 
-.custom-block.tip {
-  border-color: var(--vp-custom-block-tip-border);
-  color: var(--vp-custom-block-tip-text);
-  background-color: var(--vp-custom-block-tip-bg);
-}
+  .custom-block.tip {
+    border-color: var(--vp-custom-block-tip-border);
+    color: var(--vp-custom-block-tip-text);
+    background-color: var(--vp-custom-block-tip-bg);
+  }
 
-.custom-block.tip a,
-.custom-block.tip code {
-  color: var(--vp-c-tip-1);
-}
+  .custom-block.tip a,
+  .custom-block.tip code {
+    color: var(--vp-c-tip-1);
+  }
 
-.custom-block.tip a:hover,
-.custom-block.tip a:hover > code {
-  color: var(--vp-c-tip-2);
-}
+  .custom-block.tip a:hover,
+  .custom-block.tip a:hover > code {
+    color: var(--vp-c-tip-2);
+  }
 
-.custom-block.tip code {
-  background-color: var(--vp-custom-block-tip-code-bg);
-}
+  .custom-block.tip code {
+    background-color: var(--vp-custom-block-tip-code-bg);
+  }
 
-.custom-block.important {
-  border-color: var(--vp-custom-block-important-border);
-  color: var(--vp-custom-block-important-text);
-  background-color: var(--vp-custom-block-important-bg);
-}
+  .custom-block.important {
+    border-color: var(--vp-custom-block-important-border);
+    color: var(--vp-custom-block-important-text);
+    background-color: var(--vp-custom-block-important-bg);
+  }
 
-.custom-block.important a,
-.custom-block.important code {
-  color: var(--vp-c-important-1);
-}
+  .custom-block.important a,
+  .custom-block.important code {
+    color: var(--vp-c-important-1);
+  }
 
-.custom-block.important a:hover,
-.custom-block.important a:hover > code {
-  color: var(--vp-c-important-2);
-}
+  .custom-block.important a:hover,
+  .custom-block.important a:hover > code {
+    color: var(--vp-c-important-2);
+  }
 
-.custom-block.important code {
-  background-color: var(--vp-custom-block-important-code-bg);
-}
+  .custom-block.important code {
+    background-color: var(--vp-custom-block-important-code-bg);
+  }
 
-.custom-block.warning {
-  border-color: var(--vp-custom-block-warning-border);
-  color: var(--vp-custom-block-warning-text);
-  background-color: var(--vp-custom-block-warning-bg);
-}
+  .custom-block.warning {
+    border-color: var(--vp-custom-block-warning-border);
+    color: var(--vp-custom-block-warning-text);
+    background-color: var(--vp-custom-block-warning-bg);
+  }
 
-.custom-block.warning a,
-.custom-block.warning code {
-  color: var(--vp-c-warning-1);
-}
+  .custom-block.warning a,
+  .custom-block.warning code {
+    color: var(--vp-c-warning-1);
+  }
 
-.custom-block.warning a:hover,
-.custom-block.warning a:hover > code {
-  color: var(--vp-c-warning-2);
-}
+  .custom-block.warning a:hover,
+  .custom-block.warning a:hover > code {
+    color: var(--vp-c-warning-2);
+  }
 
-.custom-block.warning code {
-  background-color: var(--vp-custom-block-warning-code-bg);
-}
+  .custom-block.warning code {
+    background-color: var(--vp-custom-block-warning-code-bg);
+  }
 
-.custom-block.danger {
-  border-color: var(--vp-custom-block-danger-border);
-  color: var(--vp-custom-block-danger-text);
-  background-color: var(--vp-custom-block-danger-bg);
-}
+  .custom-block.danger {
+    border-color: var(--vp-custom-block-danger-border);
+    color: var(--vp-custom-block-danger-text);
+    background-color: var(--vp-custom-block-danger-bg);
+  }
 
-.custom-block.danger a,
-.custom-block.danger code {
-  color: var(--vp-c-danger-1);
-}
+  .custom-block.danger a,
+  .custom-block.danger code {
+    color: var(--vp-c-danger-1);
+  }
 
-.custom-block.danger a:hover,
-.custom-block.danger a:hover > code {
-  color: var(--vp-c-danger-2);
-}
+  .custom-block.danger a:hover,
+  .custom-block.danger a:hover > code {
+    color: var(--vp-c-danger-2);
+  }
 
-.custom-block.danger code {
-  background-color: var(--vp-custom-block-danger-code-bg);
-}
+  .custom-block.danger code {
+    background-color: var(--vp-custom-block-danger-code-bg);
+  }
 
-.custom-block.caution {
-  border-color: var(--vp-custom-block-caution-border);
-  color: var(--vp-custom-block-caution-text);
-  background-color: var(--vp-custom-block-caution-bg);
-}
+  .custom-block.caution {
+    border-color: var(--vp-custom-block-caution-border);
+    color: var(--vp-custom-block-caution-text);
+    background-color: var(--vp-custom-block-caution-bg);
+  }
 
-.custom-block.caution a,
-.custom-block.caution code {
-  color: var(--vp-c-caution-1);
-}
+  .custom-block.caution a,
+  .custom-block.caution code {
+    color: var(--vp-c-caution-1);
+  }
 
-.custom-block.caution a:hover,
-.custom-block.caution a:hover > code {
-  color: var(--vp-c-caution-2);
-}
+  .custom-block.caution a:hover,
+  .custom-block.caution a:hover > code {
+    color: var(--vp-c-caution-2);
+  }
 
-.custom-block.caution code {
-  background-color: var(--vp-custom-block-caution-code-bg);
-}
+  .custom-block.caution code {
+    background-color: var(--vp-custom-block-caution-code-bg);
+  }
 
-.custom-block.details {
-  border-color: var(--vp-custom-block-details-border);
-  color: var(--vp-custom-block-details-text);
-  background-color: var(--vp-custom-block-details-bg);
-}
+  .custom-block.details {
+    border-color: var(--vp-custom-block-details-border);
+    color: var(--vp-custom-block-details-text);
+    background-color: var(--vp-custom-block-details-bg);
+  }
 
-.custom-block.details a {
-  color: var(--vp-c-brand-1);
-}
+  .custom-block.details a {
+    color: var(--vp-c-brand-1);
+  }
 
-.custom-block.details a:hover,
-.custom-block.details a:hover > code {
-  color: var(--vp-c-brand-2);
-}
+  .custom-block.details a:hover,
+  .custom-block.details a:hover > code {
+    color: var(--vp-c-brand-2);
+  }
 
-.custom-block.details code {
-  background-color: var(--vp-custom-block-details-code-bg);
-}
+  .custom-block.details code {
+    background-color: var(--vp-custom-block-details-code-bg);
+  }
 
-.custom-block-title {
-  font-weight: 600;
-}
+  .custom-block-title {
+    font-weight: 600;
+  }
 
-.custom-block p + p {
-  margin: 8px 0;
-}
+  .custom-block p + p {
+    margin: 8px 0;
+  }
 
-.custom-block.details summary {
-  margin: 0 0 8px;
-  font-weight: 700;
-  cursor: pointer;
-  user-select: none;
-}
+  .custom-block.details summary {
+    margin: 0 0 8px;
+    font-weight: 700;
+    cursor: pointer;
+    user-select: none;
+  }
 
-.custom-block.details summary + p {
-  margin: 8px 0;
-}
+  .custom-block.details summary + p {
+    margin: 8px 0;
+  }
 
-.custom-block a {
-  color: inherit;
-  font-weight: 600;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  transition: opacity 0.25s;
-}
+  .custom-block a {
+    color: inherit;
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    transition: opacity 0.25s;
+  }
 
-.custom-block a:hover {
-  opacity: 0.75;
-}
+  .custom-block a:hover {
+    opacity: 0.75;
+  }
 
-.custom-block code {
-  font-size: var(--vp-custom-block-code-font-size);
-}
+  .custom-block code {
+    font-size: var(--vp-custom-block-code-font-size);
+  }
 
-.custom-block.custom-block th,
-.custom-block.custom-block blockquote > p {
-  font-size: var(--vp-custom-block-font-size);
-  color: inherit;
+  .custom-block.custom-block th,
+  .custom-block.custom-block blockquote > p {
+    font-size: var(--vp-custom-block-font-size);
+    color: inherit;
+  }
 }

--- a/src/client/theme-default/styles/components/vp-code-group.css
+++ b/src/client/theme-default/styles/components/vp-code-group.css
@@ -1,85 +1,87 @@
-.vp-code-group {
-  margin-top: 16px;
-}
-
-.vp-code-group .tabs {
-  position: relative;
-  display: flex;
-  margin-right: -24px;
-  margin-left: -24px;
-  padding: 0 12px;
-  background-color: var(--vp-code-tab-bg);
-  overflow-x: auto;
-  overflow-y: hidden;
-  box-shadow: inset 0 -1px var(--vp-code-tab-divider);
-}
-
-@media (min-width: 640px) {
-  .vp-code-group .tabs {
-    margin-right: 0;
-    margin-left: 0;
-    border-radius: 8px 8px 0 0;
+@layer vitepress.components.codegroup {
+  .vp-code-group {
+    margin-top: 16px;
   }
-}
 
-.vp-code-group .tabs input {
-  position: fixed;
-  opacity: 0;
-  pointer-events: none;
-}
+  .vp-code-group .tabs {
+    position: relative;
+    display: flex;
+    margin-right: -24px;
+    margin-left: -24px;
+    padding: 0 12px;
+    background-color: var(--vp-code-tab-bg);
+    overflow-x: auto;
+    overflow-y: hidden;
+    box-shadow: inset 0 -1px var(--vp-code-tab-divider);
+  }
 
-.vp-code-group .tabs label {
-  position: relative;
-  display: inline-block;
-  border-bottom: 1px solid transparent;
-  padding: 0 12px;
-  line-height: 48px;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--vp-code-tab-text-color);
-  white-space: nowrap;
-  cursor: pointer;
-  transition: color 0.25s;
-}
+  @media (min-width: 640px) {
+    .vp-code-group .tabs {
+      margin-right: 0;
+      margin-left: 0;
+      border-radius: 8px 8px 0 0;
+    }
+  }
 
-.vp-code-group .tabs label::after {
-  position: absolute;
-  right: 8px;
-  bottom: -1px;
-  left: 8px;
-  z-index: 1;
-  height: 2px;
-  border-radius: 2px;
-  content: '';
-  background-color: transparent;
-  transition: background-color 0.25s;
-}
+  .vp-code-group .tabs input {
+    position: fixed;
+    opacity: 0;
+    pointer-events: none;
+  }
 
-.vp-code-group label:hover {
-  color: var(--vp-code-tab-hover-text-color);
-}
+  .vp-code-group .tabs label {
+    position: relative;
+    display: inline-block;
+    border-bottom: 1px solid transparent;
+    padding: 0 12px;
+    line-height: 48px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--vp-code-tab-text-color);
+    white-space: nowrap;
+    cursor: pointer;
+    transition: color 0.25s;
+  }
 
-.vp-code-group input:checked + label {
-  color: var(--vp-code-tab-active-text-color);
-}
+  .vp-code-group .tabs label::after {
+    position: absolute;
+    right: 8px;
+    bottom: -1px;
+    left: 8px;
+    z-index: 1;
+    height: 2px;
+    border-radius: 2px;
+    content: '';
+    background-color: transparent;
+    transition: background-color 0.25s;
+  }
 
-.vp-code-group input:checked + label::after {
-  background-color: var(--vp-code-tab-active-bar-color);
-}
+  .vp-code-group label:hover {
+    color: var(--vp-code-tab-hover-text-color);
+  }
 
-.vp-code-group div[class*='language-'],
-.vp-block {
-  display: none;
-  margin-top: 0 !important;
-  border-top-left-radius: 0 !important;
-  border-top-right-radius: 0 !important;
-}
+  .vp-code-group input:checked + label {
+    color: var(--vp-code-tab-active-text-color);
+  }
 
-.vp-code-group div[class*='language-'].active,
-.vp-block.active {
-  display: block;
-}
+  .vp-code-group input:checked + label::after {
+    background-color: var(--vp-code-tab-active-bar-color);
+  }
 
-.vp-block {
-  padding: 20px 24px;
+  .vp-code-group div[class*='language-'],
+  .vp-block {
+    display: none;
+    margin-top: 0 !important;
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+  }
+
+  .vp-code-group div[class*='language-'].active,
+  .vp-block.active {
+    display: block;
+  }
+
+  .vp-block {
+    padding: 20px 24px;
+  }
 }

--- a/src/client/theme-default/styles/components/vp-code.css
+++ b/src/client/theme-default/styles/components/vp-code.css
@@ -1,7 +1,9 @@
-.dark .vp-code span {
-  color: var(--shiki-dark, inherit);
-}
+@layer vitepress.components.code {
+  .dark .vp-code span {
+    color: var(--shiki-dark, inherit);
+  }
 
-html:not(.dark) .vp-code span {
-  color: var(--shiki-light, inherit);
+  html:not(.dark) .vp-code span {
+    color: var(--shiki-light, inherit);
+  }
 }

--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -1,559 +1,563 @@
-/**
+@layer vitepress.components.doc {
+  /**
  * Headings
  * -------------------------------------------------------------------------- */
 
-.vp-doc h1,
-.vp-doc h2,
-.vp-doc h3,
-.vp-doc h4,
-.vp-doc h5,
-.vp-doc h6 {
-  position: relative;
-  font-weight: 600;
-  outline: none;
-}
+  .vp-doc h1,
+  .vp-doc h2,
+  .vp-doc h3,
+  .vp-doc h4,
+  .vp-doc h5,
+  .vp-doc h6 {
+    position: relative;
+    font-weight: 600;
+    outline: none;
+  }
 
-.vp-doc h1 {
-  letter-spacing: -0.02em;
-  line-height: 40px;
-  font-size: 28px;
-}
-
-.vp-doc h2 {
-  margin: 48px 0 16px;
-  border-top: 1px solid var(--vp-c-divider);
-  padding-top: 24px;
-  letter-spacing: -0.02em;
-  line-height: 32px;
-  font-size: 24px;
-}
-
-.vp-doc h3 {
-  margin: 32px 0 0;
-  letter-spacing: -0.01em;
-  line-height: 28px;
-  font-size: 20px;
-}
-
-.vp-doc h4 {
-  margin: 24px 0 0;
-  letter-spacing: -0.01em;
-  line-height: 24px;
-  font-size: 18px;
-}
-
-.vp-doc .header-anchor {
-  position: absolute;
-  top: 0;
-  left: 0;
-  margin-left: -0.87em;
-  font-weight: 500;
-  user-select: none;
-  opacity: 0;
-  text-decoration: none;
-  transition:
-    color 0.25s,
-    opacity 0.25s;
-}
-
-.vp-doc .header-anchor:before {
-  content: var(--vp-header-anchor-symbol);
-}
-
-.vp-doc h1:hover .header-anchor,
-.vp-doc h1 .header-anchor:focus,
-.vp-doc h2:hover .header-anchor,
-.vp-doc h2 .header-anchor:focus,
-.vp-doc h3:hover .header-anchor,
-.vp-doc h3 .header-anchor:focus,
-.vp-doc h4:hover .header-anchor,
-.vp-doc h4 .header-anchor:focus,
-.vp-doc h5:hover .header-anchor,
-.vp-doc h5 .header-anchor:focus,
-.vp-doc h6:hover .header-anchor,
-.vp-doc h6 .header-anchor:focus {
-  opacity: 1;
-}
-
-@media (min-width: 768px) {
   .vp-doc h1 {
     letter-spacing: -0.02em;
     line-height: 40px;
-    font-size: 32px;
+    font-size: 28px;
   }
-}
 
-.vp-doc h2 .header-anchor {
-  top: 24px;
-}
+  .vp-doc h2 {
+    margin: 48px 0 16px;
+    border-top: 1px solid var(--vp-c-divider);
+    padding-top: 24px;
+    letter-spacing: -0.02em;
+    line-height: 32px;
+    font-size: 24px;
+  }
 
-/**
+  .vp-doc h3 {
+    margin: 32px 0 0;
+    letter-spacing: -0.01em;
+    line-height: 28px;
+    font-size: 20px;
+  }
+
+  .vp-doc h4 {
+    margin: 24px 0 0;
+    letter-spacing: -0.01em;
+    line-height: 24px;
+    font-size: 18px;
+  }
+
+  .vp-doc .header-anchor {
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin-left: -0.87em;
+    font-weight: 500;
+    user-select: none;
+    opacity: 0;
+    text-decoration: none;
+    transition:
+      color 0.25s,
+      opacity 0.25s;
+  }
+
+  .vp-doc .header-anchor:before {
+    content: var(--vp-header-anchor-symbol);
+  }
+
+  .vp-doc h1:hover .header-anchor,
+  .vp-doc h1 .header-anchor:focus,
+  .vp-doc h2:hover .header-anchor,
+  .vp-doc h2 .header-anchor:focus,
+  .vp-doc h3:hover .header-anchor,
+  .vp-doc h3 .header-anchor:focus,
+  .vp-doc h4:hover .header-anchor,
+  .vp-doc h4 .header-anchor:focus,
+  .vp-doc h5:hover .header-anchor,
+  .vp-doc h5 .header-anchor:focus,
+  .vp-doc h6:hover .header-anchor,
+  .vp-doc h6 .header-anchor:focus {
+    opacity: 1;
+  }
+
+  @media (min-width: 768px) {
+    .vp-doc h1 {
+      letter-spacing: -0.02em;
+      line-height: 40px;
+      font-size: 32px;
+    }
+  }
+
+  .vp-doc h2 .header-anchor {
+    top: 24px;
+  }
+
+  /**
  * Paragraph and inline elements
  * -------------------------------------------------------------------------- */
 
-.vp-doc p,
-.vp-doc summary {
-  margin: 16px 0;
-}
+  .vp-doc p,
+  .vp-doc summary {
+    margin: 16px 0;
+  }
 
-.vp-doc p {
-  line-height: 28px;
-}
+  .vp-doc p {
+    line-height: 28px;
+  }
 
-.vp-doc blockquote {
-  margin: 16px 0;
-  border-left: 2px solid var(--vp-c-divider);
-  padding-left: 16px;
-  transition: border-color 0.5s;
-  color: var(--vp-c-text-2);
-}
+  .vp-doc blockquote {
+    margin: 16px 0;
+    border-left: 2px solid var(--vp-c-divider);
+    padding-left: 16px;
+    transition: border-color 0.5s;
+    color: var(--vp-c-text-2);
+  }
 
-.vp-doc blockquote > p {
-  margin: 0;
-  font-size: 16px;
-  transition: color 0.5s;
-}
+  .vp-doc blockquote > p {
+    margin: 0;
+    font-size: 16px;
+    transition: color 0.5s;
+  }
 
-.vp-doc a {
-  font-weight: 500;
-  color: var(--vp-c-brand-1);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  transition:
-    color 0.25s,
-    opacity 0.25s;
-}
+  .vp-doc a {
+    font-weight: 500;
+    color: var(--vp-c-brand-1);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    transition:
+      color 0.25s,
+      opacity 0.25s;
+  }
 
-.vp-doc a:hover {
-  color: var(--vp-c-brand-2);
-}
+  .vp-doc a:hover {
+    color: var(--vp-c-brand-2);
+  }
 
-.vp-doc strong {
-  font-weight: 600;
-}
+  .vp-doc strong {
+    font-weight: 600;
+  }
 
-/**
+  /**
  * Lists
  * -------------------------------------------------------------------------- */
 
-.vp-doc ul,
-.vp-doc ol {
-  padding-left: 1.25rem;
-  margin: 16px 0;
-}
+  .vp-doc ul,
+  .vp-doc ol {
+    padding-left: 1.25rem;
+    margin: 16px 0;
+  }
 
-.vp-doc ul {
-  list-style: disc;
-}
+  .vp-doc ul {
+    list-style: disc;
+  }
 
-.vp-doc ol {
-  list-style: decimal;
-}
+  .vp-doc ol {
+    list-style: decimal;
+  }
 
-.vp-doc li + li {
-  margin-top: 8px;
-}
+  .vp-doc li + li {
+    margin-top: 8px;
+  }
 
-.vp-doc li > ol,
-.vp-doc li > ul {
-  margin: 8px 0 0;
-}
+  .vp-doc li > ol,
+  .vp-doc li > ul {
+    margin: 8px 0 0;
+  }
 
-/**
+  /**
  * Table
  * -------------------------------------------------------------------------- */
 
-.vp-doc table {
-  display: block;
-  border-collapse: collapse;
-  margin: 20px 0;
-  overflow-x: auto;
-}
+  .vp-doc table {
+    display: block;
+    border-collapse: collapse;
+    margin: 20px 0;
+    overflow-x: auto;
+  }
 
-.vp-doc tr {
-  background-color: var(--vp-c-bg);
-  border-top: 1px solid var(--vp-c-divider);
-  transition: background-color 0.5s;
-}
+  .vp-doc tr {
+    background-color: var(--vp-c-bg);
+    border-top: 1px solid var(--vp-c-divider);
+    transition: background-color 0.5s;
+  }
 
-.vp-doc tr:nth-child(2n) {
-  background-color: var(--vp-c-bg-soft);
-}
+  .vp-doc tr:nth-child(2n) {
+    background-color: var(--vp-c-bg-soft);
+  }
 
-.vp-doc th,
-.vp-doc td {
-  border: 1px solid var(--vp-c-divider);
-  padding: 8px 16px;
-}
+  .vp-doc th,
+  .vp-doc td {
+    border: 1px solid var(--vp-c-divider);
+    padding: 8px 16px;
+  }
 
-.vp-doc th {
-  text-align: left;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--vp-c-text-2);
-  background-color: var(--vp-c-bg-soft);
-}
+  .vp-doc th {
+    text-align: left;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--vp-c-text-2);
+    background-color: var(--vp-c-bg-soft);
+  }
 
-.vp-doc td {
-  font-size: 14px;
-}
+  .vp-doc td {
+    font-size: 14px;
+  }
 
-/**
+  /**
  * Decorational elements
  * -------------------------------------------------------------------------- */
 
-.vp-doc hr {
-  margin: 16px 0;
-  border: none;
-  border-top: 1px solid var(--vp-c-divider);
-}
+  .vp-doc hr {
+    margin: 16px 0;
+    border: none;
+    border-top: 1px solid var(--vp-c-divider);
+  }
 
-/**
+  /**
  * Custom Block
  * -------------------------------------------------------------------------- */
 
-.vp-doc .custom-block {
-  margin: 16px 0;
-}
+  .vp-doc .custom-block {
+    margin: 16px 0;
+  }
 
-.vp-doc .custom-block p {
-  margin: 8px 0;
-  line-height: 24px;
-}
+  .vp-doc .custom-block p {
+    margin: 8px 0;
+    line-height: 24px;
+  }
 
-.vp-doc .custom-block p:first-child {
-  margin: 0;
-}
+  .vp-doc .custom-block p:first-child {
+    margin: 0;
+  }
 
-.vp-doc .custom-block div[class*='language-'] {
-  margin: 8px 0;
-  border-radius: 8px;
-}
+  .vp-doc .custom-block div[class*='language-'] {
+    margin: 8px 0;
+    border-radius: 8px;
+  }
 
-.vp-doc .custom-block div[class*='language-'] code {
-  font-weight: 400;
-  background-color: transparent;
-}
+  .vp-doc .custom-block div[class*='language-'] code {
+    font-weight: 400;
+    background-color: transparent;
+  }
 
-.vp-doc .custom-block .vp-code-group .tabs {
-  margin: 0;
-  border-radius: 8px 8px 0 0;
-}
+  .vp-doc .custom-block .vp-code-group .tabs {
+    margin: 0;
+    border-radius: 8px 8px 0 0;
+  }
 
-/**
+  /**
  * Code
  * -------------------------------------------------------------------------- */
 
-/* inline code */
-.vp-doc :not(pre, h1, h2, h3, h4, h5, h6) > code {
-  font-size: var(--vp-code-font-size);
-  color: var(--vp-code-color);
-}
+  /* inline code */
+  .vp-doc :not(pre, h1, h2, h3, h4, h5, h6) > code {
+    font-size: var(--vp-code-font-size);
+    color: var(--vp-code-color);
+  }
 
-.vp-doc :not(pre) > code {
-  border-radius: 4px;
-  padding: 3px 6px;
-  background-color: var(--vp-code-bg);
-  transition:
-    color 0.25s,
-    background-color 0.5s;
-}
+  .vp-doc :not(pre) > code {
+    border-radius: 4px;
+    padding: 3px 6px;
+    background-color: var(--vp-code-bg);
+    transition:
+      color 0.25s,
+      background-color 0.5s;
+  }
 
-.vp-doc a > code {
-  color: var(--vp-code-link-color);
-}
+  .vp-doc a > code {
+    color: var(--vp-code-link-color);
+  }
 
-.vp-doc a:hover > code {
-  color: var(--vp-code-link-hover-color);
-}
+  .vp-doc a:hover > code {
+    color: var(--vp-code-link-hover-color);
+  }
 
-.vp-doc h1 > code,
-.vp-doc h2 > code,
-.vp-doc h3 > code,
-.vp-doc h4 > code {
-  font-size: 0.9em;
-}
+  .vp-doc h1 > code,
+  .vp-doc h2 > code,
+  .vp-doc h3 > code,
+  .vp-doc h4 > code {
+    font-size: 0.9em;
+  }
 
-.vp-doc div[class*='language-'],
-.vp-block {
-  position: relative;
-  margin: 16px -24px;
-  background-color: var(--vp-code-block-bg);
-  overflow-x: auto;
-  transition: background-color 0.5s;
-}
-
-@media (min-width: 640px) {
   .vp-doc div[class*='language-'],
   .vp-block {
-    border-radius: 8px;
-    margin: 16px 0;
+    position: relative;
+    margin: 16px -24px;
+    background-color: var(--vp-code-block-bg);
+    overflow-x: auto;
+    transition: background-color 0.5s;
   }
-}
 
-@media (max-width: 639px) {
-  .vp-doc li div[class*='language-'] {
-    border-radius: 8px 0 0 8px;
+  @media (min-width: 640px) {
+    .vp-doc div[class*='language-'],
+    .vp-block {
+      border-radius: 8px;
+      margin: 16px 0;
+    }
   }
-}
 
-.vp-doc div[class*='language-'] + div[class*='language-'],
-.vp-doc div[class$='-api'] + div[class*='language-'],
-.vp-doc div[class*='language-'] + div[class$='-api'] > div[class*='language-'] {
-  margin-top: -8px;
-}
+  @media (max-width: 639px) {
+    .vp-doc li div[class*='language-'] {
+      border-radius: 8px 0 0 8px;
+    }
+  }
 
-.vp-doc [class*='language-'] pre,
-.vp-doc [class*='language-'] code {
-  /*rtl:ignore*/
-  direction: ltr;
-  /*rtl:ignore*/
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: normal;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-}
+  .vp-doc div[class*='language-'] + div[class*='language-'],
+  .vp-doc div[class$='-api'] + div[class*='language-'],
+  .vp-doc
+    div[class*='language-']
+    + div[class$='-api']
+    > div[class*='language-'] {
+    margin-top: -8px;
+  }
 
-.vp-doc [class*='language-'] pre {
-  position: relative;
-  z-index: 1;
-  margin: 0;
-  padding: 20px 0;
-  background: transparent;
-  overflow-x: auto;
-}
+  .vp-doc [class*='language-'] pre,
+  .vp-doc [class*='language-'] code {
+    /*rtl:ignore*/
+    direction: ltr;
+    /*rtl:ignore*/
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+  }
 
-.vp-doc [class*='language-'] code {
-  display: block;
-  padding: 0 24px;
-  width: fit-content;
-  min-width: 100%;
-  line-height: var(--vp-code-line-height);
-  font-size: var(--vp-code-font-size);
-  color: var(--vp-code-block-color);
-  transition: color 0.5s;
-}
+  .vp-doc [class*='language-'] pre {
+    position: relative;
+    z-index: 1;
+    margin: 0;
+    padding: 20px 0;
+    background: transparent;
+    overflow-x: auto;
+  }
 
-.vp-doc [class*='language-'] code .highlighted {
-  background-color: var(--vp-code-line-highlight-color);
-  transition: background-color 0.5s;
-  margin: 0 -24px;
-  padding: 0 24px;
-  width: calc(100% + 2 * 24px);
-  display: inline-block;
-}
+  .vp-doc [class*='language-'] code {
+    display: block;
+    padding: 0 24px;
+    width: fit-content;
+    min-width: 100%;
+    line-height: var(--vp-code-line-height);
+    font-size: var(--vp-code-font-size);
+    color: var(--vp-code-block-color);
+    transition: color 0.5s;
+  }
 
-.vp-doc [class*='language-'] code .highlighted.error {
-  background-color: var(--vp-code-line-error-color);
-}
+  .vp-doc [class*='language-'] code .highlighted {
+    background-color: var(--vp-code-line-highlight-color);
+    transition: background-color 0.5s;
+    margin: 0 -24px;
+    padding: 0 24px;
+    width: calc(100% + 2 * 24px);
+    display: inline-block;
+  }
 
-.vp-doc [class*='language-'] code .highlighted.warning {
-  background-color: var(--vp-code-line-warning-color);
-}
+  .vp-doc [class*='language-'] code .highlighted.error {
+    background-color: var(--vp-code-line-error-color);
+  }
 
-.vp-doc [class*='language-'] code .diff {
-  transition: background-color 0.5s;
-  margin: 0 -24px;
-  padding: 0 24px;
-  width: calc(100% + 2 * 24px);
-  display: inline-block;
-}
+  .vp-doc [class*='language-'] code .highlighted.warning {
+    background-color: var(--vp-code-line-warning-color);
+  }
 
-.vp-doc [class*='language-'] code .diff::before {
-  position: absolute;
-  left: 10px;
-}
+  .vp-doc [class*='language-'] code .diff {
+    transition: background-color 0.5s;
+    margin: 0 -24px;
+    padding: 0 24px;
+    width: calc(100% + 2 * 24px);
+    display: inline-block;
+  }
 
-.vp-doc [class*='language-'] .has-focused-lines .line:not(.has-focus) {
-  filter: blur(0.095rem);
-  opacity: 0.4;
-  transition:
-    filter 0.35s,
-    opacity 0.35s;
-}
+  .vp-doc [class*='language-'] code .diff::before {
+    position: absolute;
+    left: 10px;
+  }
 
-.vp-doc [class*='language-'] .has-focused-lines .line:not(.has-focus) {
-  opacity: 0.7;
-  transition:
-    filter 0.35s,
-    opacity 0.35s;
-}
+  .vp-doc [class*='language-'] .has-focused-lines .line:not(.has-focus) {
+    filter: blur(0.095rem);
+    opacity: 0.4;
+    transition:
+      filter 0.35s,
+      opacity 0.35s;
+  }
 
-.vp-doc [class*='language-']:hover .has-focused-lines .line:not(.has-focus) {
-  filter: blur(0);
-  opacity: 1;
-}
+  .vp-doc [class*='language-'] .has-focused-lines .line:not(.has-focus) {
+    opacity: 0.7;
+    transition:
+      filter 0.35s,
+      opacity 0.35s;
+  }
 
-.vp-doc [class*='language-'] code .diff.remove {
-  background-color: var(--vp-code-line-diff-remove-color);
-  opacity: 0.7;
-}
+  .vp-doc [class*='language-']:hover .has-focused-lines .line:not(.has-focus) {
+    filter: blur(0);
+    opacity: 1;
+  }
 
-.vp-doc [class*='language-'] code .diff.remove::before {
-  content: '-';
-  color: var(--vp-code-line-diff-remove-symbol-color);
-}
+  .vp-doc [class*='language-'] code .diff.remove {
+    background-color: var(--vp-code-line-diff-remove-color);
+    opacity: 0.7;
+  }
 
-.vp-doc [class*='language-'] code .diff.add {
-  background-color: var(--vp-code-line-diff-add-color);
-}
+  .vp-doc [class*='language-'] code .diff.remove::before {
+    content: '-';
+    color: var(--vp-code-line-diff-remove-symbol-color);
+  }
 
-.vp-doc [class*='language-'] code .diff.add::before {
-  content: '+';
-  color: var(--vp-code-line-diff-add-symbol-color);
-}
+  .vp-doc [class*='language-'] code .diff.add {
+    background-color: var(--vp-code-line-diff-add-color);
+  }
 
-.vp-doc div[class*='language-'].line-numbers-mode {
-  /*rtl:ignore*/
-  padding-left: 32px;
-}
+  .vp-doc [class*='language-'] code .diff.add::before {
+    content: '+';
+    color: var(--vp-code-line-diff-add-symbol-color);
+  }
 
-.vp-doc .line-numbers-wrapper {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  /*rtl:ignore*/
-  left: 0;
-  z-index: 3;
-  /*rtl:ignore*/
-  border-right: 1px solid var(--vp-code-block-divider-color);
-  padding-top: 20px;
-  width: 32px;
-  text-align: center;
-  font-family: var(--vp-font-family-mono);
-  line-height: var(--vp-code-line-height);
-  font-size: var(--vp-code-font-size);
-  color: var(--vp-code-line-number-color);
-  transition:
-    border-color 0.5s,
-    color 0.5s;
-}
+  .vp-doc div[class*='language-'].line-numbers-mode {
+    /*rtl:ignore*/
+    padding-left: 32px;
+  }
 
-.vp-doc [class*='language-'] > button.copy {
-  /*rtl:ignore*/
-  direction: ltr;
-  position: absolute;
-  top: 12px;
-  /*rtl:ignore*/
-  right: 12px;
-  z-index: 3;
-  border: 1px solid var(--vp-code-copy-code-border-color);
-  border-radius: 4px;
-  width: 40px;
-  height: 40px;
-  background-color: var(--vp-code-copy-code-bg);
-  opacity: 0;
-  cursor: pointer;
-  background-image: var(--vp-icon-copy);
-  background-position: 50%;
-  background-size: 20px;
-  background-repeat: no-repeat;
-  transition:
-    border-color 0.25s,
-    background-color 0.25s,
-    opacity 0.25s;
-}
+  .vp-doc .line-numbers-wrapper {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    /*rtl:ignore*/
+    left: 0;
+    z-index: 3;
+    /*rtl:ignore*/
+    border-right: 1px solid var(--vp-code-block-divider-color);
+    padding-top: 20px;
+    width: 32px;
+    text-align: center;
+    font-family: var(--vp-font-family-mono);
+    line-height: var(--vp-code-line-height);
+    font-size: var(--vp-code-font-size);
+    color: var(--vp-code-line-number-color);
+    transition:
+      border-color 0.5s,
+      color 0.5s;
+  }
 
-.vp-doc [class*='language-']:hover > button.copy,
-.vp-doc [class*='language-'] > button.copy:focus {
-  opacity: 1;
-}
+  .vp-doc [class*='language-'] > button.copy {
+    /*rtl:ignore*/
+    direction: ltr;
+    position: absolute;
+    top: 12px;
+    /*rtl:ignore*/
+    right: 12px;
+    z-index: 3;
+    border: 1px solid var(--vp-code-copy-code-border-color);
+    border-radius: 4px;
+    width: 40px;
+    height: 40px;
+    background-color: var(--vp-code-copy-code-bg);
+    opacity: 0;
+    cursor: pointer;
+    background-image: var(--vp-icon-copy);
+    background-position: 50%;
+    background-size: 20px;
+    background-repeat: no-repeat;
+    transition:
+      border-color 0.25s,
+      background-color 0.25s,
+      opacity 0.25s;
+  }
 
-.vp-doc [class*='language-'] > button.copy:hover,
-.vp-doc [class*='language-'] > button.copy.copied {
-  border-color: var(--vp-code-copy-code-hover-border-color);
-  background-color: var(--vp-code-copy-code-hover-bg);
-}
+  .vp-doc [class*='language-']:hover > button.copy,
+  .vp-doc [class*='language-'] > button.copy:focus {
+    opacity: 1;
+  }
 
-.vp-doc [class*='language-'] > button.copy.copied,
-.vp-doc [class*='language-'] > button.copy:hover.copied {
-  /*rtl:ignore*/
-  border-radius: 0 4px 4px 0;
-  background-color: var(--vp-code-copy-code-hover-bg);
-  background-image: var(--vp-icon-copied);
-}
+  .vp-doc [class*='language-'] > button.copy:hover,
+  .vp-doc [class*='language-'] > button.copy.copied {
+    border-color: var(--vp-code-copy-code-hover-border-color);
+    background-color: var(--vp-code-copy-code-hover-bg);
+  }
 
-.vp-doc [class*='language-'] > button.copy.copied::before,
-.vp-doc [class*='language-'] > button.copy:hover.copied::before {
-  position: relative;
-  top: -1px;
-  /*rtl:ignore*/
-  transform: translateX(calc(-100% - 1px));
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border: 1px solid var(--vp-code-copy-code-hover-border-color);
-  /*rtl:ignore*/
-  border-right: 0;
-  border-radius: 4px 0 0 4px;
-  padding: 0 10px;
-  width: fit-content;
-  height: 40px;
-  text-align: center;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--vp-code-copy-code-active-text);
-  background-color: var(--vp-code-copy-code-hover-bg);
-  white-space: nowrap;
-  content: var(--vp-code-copy-copied-text-content);
-}
+  .vp-doc [class*='language-'] > button.copy.copied,
+  .vp-doc [class*='language-'] > button.copy:hover.copied {
+    /*rtl:ignore*/
+    border-radius: 0 4px 4px 0;
+    background-color: var(--vp-code-copy-code-hover-bg);
+    background-image: var(--vp-icon-copied);
+  }
 
-.vp-doc [class*='language-'] > span.lang {
-  position: absolute;
-  top: 2px;
-  /*rtl:ignore*/
-  right: 8px;
-  z-index: 2;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--vp-code-lang-color);
-  transition:
-    color 0.4s,
-    opacity 0.4s;
-}
+  .vp-doc [class*='language-'] > button.copy.copied::before,
+  .vp-doc [class*='language-'] > button.copy:hover.copied::before {
+    position: relative;
+    top: -1px;
+    /*rtl:ignore*/
+    transform: translateX(calc(-100% - 1px));
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid var(--vp-code-copy-code-hover-border-color);
+    /*rtl:ignore*/
+    border-right: 0;
+    border-radius: 4px 0 0 4px;
+    padding: 0 10px;
+    width: fit-content;
+    height: 40px;
+    text-align: center;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--vp-code-copy-code-active-text);
+    background-color: var(--vp-code-copy-code-hover-bg);
+    white-space: nowrap;
+    content: var(--vp-code-copy-copied-text-content);
+  }
 
-.vp-doc [class*='language-']:hover > button.copy + span.lang,
-.vp-doc [class*='language-'] > button.copy:focus + span.lang {
-  opacity: 0;
-}
+  .vp-doc [class*='language-'] > span.lang {
+    position: absolute;
+    top: 2px;
+    /*rtl:ignore*/
+    right: 8px;
+    z-index: 2;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--vp-code-lang-color);
+    transition:
+      color 0.4s,
+      opacity 0.4s;
+  }
 
-/**
+  .vp-doc [class*='language-']:hover > button.copy + span.lang,
+  .vp-doc [class*='language-'] > button.copy:focus + span.lang {
+    opacity: 0;
+  }
+
+  /**
  * Component: Team
  * -------------------------------------------------------------------------- */
 
-.vp-doc .VPTeamMembers {
-  margin-top: 24px;
-}
+  .vp-doc .VPTeamMembers {
+    margin-top: 24px;
+  }
 
-.vp-doc .VPTeamMembers.small.count-1 .container {
-  margin: 0 !important;
-  max-width: calc((100% - 24px) / 2) !important;
-}
+  .vp-doc .VPTeamMembers.small.count-1 .container {
+    margin: 0 !important;
+    max-width: calc((100% - 24px) / 2) !important;
+  }
 
-.vp-doc .VPTeamMembers.small.count-2 .container,
-.vp-doc .VPTeamMembers.small.count-3 .container {
-  max-width: 100% !important;
-}
+  .vp-doc .VPTeamMembers.small.count-2 .container,
+  .vp-doc .VPTeamMembers.small.count-3 .container {
+    max-width: 100% !important;
+  }
 
-.vp-doc .VPTeamMembers.medium.count-1 .container {
-  margin: 0 !important;
-  max-width: calc((100% - 24px) / 2) !important;
-}
+  .vp-doc .VPTeamMembers.medium.count-1 .container {
+    margin: 0 !important;
+    max-width: calc((100% - 24px) / 2) !important;
+  }
 
-/**
+  /**
  * External links
  * -------------------------------------------------------------------------- */
 
-/* prettier-ignore */
-:is(.vp-external-link-icon, .vp-doc a[href*='://'], .vp-doc a[target='_blank']):not(.no-icon)::after {
+  /* prettier-ignore */
+  :is(.vp-external-link-icon, .vp-doc a[href*='://'], .vp-doc a[target='_blank']):not(.no-icon)::after {
   display: inline-block;
   margin-top: -1px;
   margin-left: 4px;
@@ -567,12 +571,13 @@
   mask-image: var(--icon);
 }
 
-.vp-external-link-icon::after {
-  content: '';
-}
+  .vp-external-link-icon::after {
+    content: '';
+  }
 
-/* prettier-ignore */
-.external-link-icon-enabled :is(.vp-doc a[href*='://'], .vp-doc a[target='_blank'])::after {
+  /* prettier-ignore */
+  .external-link-icon-enabled :is(.vp-doc a[href*='://'], .vp-doc a[target='_blank'])::after {
   content: '';
   color: currentColor;
+}
 }

--- a/src/client/theme-default/styles/components/vp-sponsor.css
+++ b/src/client/theme-default/styles/components/vp-sponsor.css
@@ -1,155 +1,157 @@
-/**
+@layer vitepress.components.sponsor {
+  /**
  * VPSponsors styles are defined as global because a new class gets
  * allied in onMounted` hook and we can't use scoped style.
  */
-.vp-sponsor {
-  border-radius: 16px;
-  overflow: hidden;
-}
+  .vp-sponsor {
+    border-radius: 16px;
+    overflow: hidden;
+  }
 
-.vp-sponsor.aside {
-  border-radius: 12px;
-}
+  .vp-sponsor.aside {
+    border-radius: 12px;
+  }
 
-.vp-sponsor-section + .vp-sponsor-section {
-  margin-top: 4px;
-}
+  .vp-sponsor-section + .vp-sponsor-section {
+    margin-top: 4px;
+  }
 
-.vp-sponsor-tier {
-  margin: 0 0 4px !important;
-  text-align: center;
-  letter-spacing: 1px !important;
-  line-height: 24px;
-  width: 100%;
-  font-weight: 600;
-  color: var(--vp-c-text-2);
-  background-color: var(--vp-c-bg-soft);
-}
+  .vp-sponsor-tier {
+    margin: 0 0 4px !important;
+    text-align: center;
+    letter-spacing: 1px !important;
+    line-height: 24px;
+    width: 100%;
+    font-weight: 600;
+    color: var(--vp-c-text-2);
+    background-color: var(--vp-c-bg-soft);
+  }
 
-.vp-sponsor.normal .vp-sponsor-tier {
-  padding: 13px 0 11px;
-  font-size: 14px;
-}
+  .vp-sponsor.normal .vp-sponsor-tier {
+    padding: 13px 0 11px;
+    font-size: 14px;
+  }
 
-.vp-sponsor.aside .vp-sponsor-tier {
-  padding: 9px 0 7px;
-  font-size: 12px;
-}
+  .vp-sponsor.aside .vp-sponsor-tier {
+    padding: 9px 0 7px;
+    font-size: 12px;
+  }
 
-.vp-sponsor-grid + .vp-sponsor-tier {
-  margin-top: 4px;
-}
+  .vp-sponsor-grid + .vp-sponsor-tier {
+    margin-top: 4px;
+  }
 
-.vp-sponsor-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
+  .vp-sponsor-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
 
-.vp-sponsor-grid.xmini .vp-sponsor-grid-link {
-  height: 64px;
-}
-.vp-sponsor-grid.xmini .vp-sponsor-grid-image {
-  max-width: 64px;
-  max-height: 22px;
-}
+  .vp-sponsor-grid.xmini .vp-sponsor-grid-link {
+    height: 64px;
+  }
+  .vp-sponsor-grid.xmini .vp-sponsor-grid-image {
+    max-width: 64px;
+    max-height: 22px;
+  }
 
-.vp-sponsor-grid.mini .vp-sponsor-grid-link {
-  height: 72px;
-}
-.vp-sponsor-grid.mini .vp-sponsor-grid-image {
-  max-width: 96px;
-  max-height: 24px;
-}
+  .vp-sponsor-grid.mini .vp-sponsor-grid-link {
+    height: 72px;
+  }
+  .vp-sponsor-grid.mini .vp-sponsor-grid-image {
+    max-width: 96px;
+    max-height: 24px;
+  }
 
-.vp-sponsor-grid.small .vp-sponsor-grid-link {
-  height: 96px;
-}
-.vp-sponsor-grid.small .vp-sponsor-grid-image {
-  max-width: 96px;
-  max-height: 24px;
-}
+  .vp-sponsor-grid.small .vp-sponsor-grid-link {
+    height: 96px;
+  }
+  .vp-sponsor-grid.small .vp-sponsor-grid-image {
+    max-width: 96px;
+    max-height: 24px;
+  }
 
-.vp-sponsor-grid.medium .vp-sponsor-grid-link {
-  height: 112px;
-}
-.vp-sponsor-grid.medium .vp-sponsor-grid-image {
-  max-width: 120px;
-  max-height: 36px;
-}
+  .vp-sponsor-grid.medium .vp-sponsor-grid-link {
+    height: 112px;
+  }
+  .vp-sponsor-grid.medium .vp-sponsor-grid-image {
+    max-width: 120px;
+    max-height: 36px;
+  }
 
-.vp-sponsor-grid.big .vp-sponsor-grid-link {
-  height: 184px;
-}
-.vp-sponsor-grid.big .vp-sponsor-grid-image {
-  max-width: 192px;
-  max-height: 56px;
-}
+  .vp-sponsor-grid.big .vp-sponsor-grid-link {
+    height: 184px;
+  }
+  .vp-sponsor-grid.big .vp-sponsor-grid-image {
+    max-width: 192px;
+    max-height: 56px;
+  }
 
-.vp-sponsor-grid[data-vp-grid='2'] .vp-sponsor-grid-item {
-  width: calc((100% - 4px) / 2);
-}
+  .vp-sponsor-grid[data-vp-grid='2'] .vp-sponsor-grid-item {
+    width: calc((100% - 4px) / 2);
+  }
 
-.vp-sponsor-grid[data-vp-grid='3'] .vp-sponsor-grid-item {
-  width: calc((100% - 4px * 2) / 3);
-}
+  .vp-sponsor-grid[data-vp-grid='3'] .vp-sponsor-grid-item {
+    width: calc((100% - 4px * 2) / 3);
+  }
 
-.vp-sponsor-grid[data-vp-grid='4'] .vp-sponsor-grid-item {
-  width: calc((100% - 4px * 3) / 4);
-}
+  .vp-sponsor-grid[data-vp-grid='4'] .vp-sponsor-grid-item {
+    width: calc((100% - 4px * 3) / 4);
+  }
 
-.vp-sponsor-grid[data-vp-grid='5'] .vp-sponsor-grid-item {
-  width: calc((100% - 4px * 4) / 5);
-}
+  .vp-sponsor-grid[data-vp-grid='5'] .vp-sponsor-grid-item {
+    width: calc((100% - 4px * 4) / 5);
+  }
 
-.vp-sponsor-grid[data-vp-grid='6'] .vp-sponsor-grid-item {
-  width: calc((100% - 4px * 5) / 6);
-}
+  .vp-sponsor-grid[data-vp-grid='6'] .vp-sponsor-grid-item {
+    width: calc((100% - 4px * 5) / 6);
+  }
 
-.vp-sponsor-grid-item {
-  flex-shrink: 0;
-  width: 100%;
-  background-color: var(--vp-c-bg-soft);
-  transition: background-color 0.25s;
-}
+  .vp-sponsor-grid-item {
+    flex-shrink: 0;
+    width: 100%;
+    background-color: var(--vp-c-bg-soft);
+    transition: background-color 0.25s;
+  }
 
-.vp-sponsor-grid-item:hover {
-  background-color: var(--vp-c-default-soft);
-}
+  .vp-sponsor-grid-item:hover {
+    background-color: var(--vp-c-default-soft);
+  }
 
-.vp-sponsor-grid-item:hover .vp-sponsor-grid-image {
-  filter: grayscale(0) invert(0);
-}
+  .vp-sponsor-grid-item:hover .vp-sponsor-grid-image {
+    filter: grayscale(0) invert(0);
+  }
 
-.vp-sponsor-grid-item.empty:hover {
-  background-color: var(--vp-c-bg-soft);
-}
+  .vp-sponsor-grid-item.empty:hover {
+    background-color: var(--vp-c-bg-soft);
+  }
 
-.dark .vp-sponsor-grid-item:hover {
-  background-color: var(--vp-c-white);
-}
+  .dark .vp-sponsor-grid-item:hover {
+    background-color: var(--vp-c-white);
+  }
 
-.dark .vp-sponsor-grid-item.empty:hover {
-  background-color: var(--vp-c-bg-soft);
-}
+  .dark .vp-sponsor-grid-item.empty:hover {
+    background-color: var(--vp-c-bg-soft);
+  }
 
-.vp-sponsor-grid-link {
-  display: flex;
-}
+  .vp-sponsor-grid-link {
+    display: flex;
+  }
 
-.vp-sponsor-grid-box {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-}
+  .vp-sponsor-grid-box {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+  }
 
-.vp-sponsor-grid-image {
-  max-width: 100%;
-  filter: grayscale(1);
-  transition: filter 0.25s;
-}
+  .vp-sponsor-grid-image {
+    max-width: 100%;
+    filter: grayscale(1);
+    transition: filter 0.25s;
+  }
 
-.dark .vp-sponsor-grid-image {
-  filter: grayscale(1) invert(1);
+  .dark .vp-sponsor-grid-image {
+    filter: grayscale(1) invert(1);
+  }
 }

--- a/src/client/theme-default/styles/icons.css
+++ b/src/client/theme-default/styles/icons.css
@@ -1,123 +1,125 @@
-[class^='vpi-'],
-[class*=' vpi-'],
-.vp-icon {
-  width: 1em;
-  height: 1em;
-}
-[class^='vpi-'].bg,
-[class*=' vpi-'].bg,
-.vp-icon.bg {
-  background-size: 100% 100%;
-  background-color: transparent;
-}
-[class^='vpi-']:not(.bg),
-[class*=' vpi-']:not(.bg),
-.vp-icon:not(.bg) {
-  -webkit-mask: var(--icon) no-repeat;
-  mask: var(--icon) no-repeat;
-  -webkit-mask-size: 100% 100%;
-  mask-size: 100% 100%;
-  background-color: currentColor;
-  color: inherit;
-}
+@layer vitepress.icons {
+  [class^='vpi-'],
+  [class*=' vpi-'],
+  .vp-icon {
+    width: 1em;
+    height: 1em;
+  }
+  [class^='vpi-'].bg,
+  [class*=' vpi-'].bg,
+  .vp-icon.bg {
+    background-size: 100% 100%;
+    background-color: transparent;
+  }
+  [class^='vpi-']:not(.bg),
+  [class*=' vpi-']:not(.bg),
+  .vp-icon:not(.bg) {
+    -webkit-mask: var(--icon) no-repeat;
+    mask: var(--icon) no-repeat;
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+    background-color: currentColor;
+    color: inherit;
+  }
 
-/* internal icons - used under ISC from https://lucide.dev/ */
-.vpi-align-left {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M21 6H3M15 12H3M17 18H3'/%3E%3C/svg%3E");
-}
-.vpi-arrow-right,
-.vpi-arrow-down,
-.vpi-arrow-left,
-.vpi-arrow-up {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M5 12h14M12 5l7 7-7 7'/%3E%3C/svg%3E");
-}
-.vpi-chevron-right,
-.vpi-chevron-down,
-.vpi-chevron-left,
-.vpi-chevron-up {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m9 18 6-6-6-6'/%3E%3C/svg%3E");
-}
-.vpi-chevron-down,
-.vpi-arrow-down {
-  transform: rotate(90deg);
-}
-.vpi-chevron-left,
-.vpi-arrow-left {
-  transform: rotate(180deg);
-}
-.vpi-chevron-up,
-.vpi-arrow-up {
-  transform: rotate(-90deg);
-}
-.vpi-square-pen {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7'/%3E%3Cpath d='M18.375 2.625a2.121 2.121 0 1 1 3 3L12 15l-4 1 1-4Z'/%3E%3C/svg%3E");
-}
-.vpi-plus {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M5 12h14M12 5v14'/%3E%3C/svg%3E");
-}
-.vpi-sun {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3Cpath d='M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41'/%3E%3C/svg%3E");
-}
-.vpi-moon {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z'/%3E%3C/svg%3E");
-}
-.vpi-more-horizontal {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='1'/%3E%3Ccircle cx='19' cy='12' r='1'/%3E%3Ccircle cx='5' cy='12' r='1'/%3E%3C/svg%3E");
-}
-.vpi-languages {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m5 8 6 6M4 14l6-6 2-3M2 5h12M7 2h1M22 22l-5-10-5 10M14 18h6'/%3E%3C/svg%3E");
-}
-.vpi-heart {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z'/%3E%3C/svg%3E");
-}
-.vpi-search {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E");
-}
-.vpi-layout-list {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect width='7' height='7' x='3' y='3' rx='1'/%3E%3Crect width='7' height='7' x='3' y='14' rx='1'/%3E%3Cpath d='M14 4h7M14 9h7M14 15h7M14 20h7'/%3E%3C/svg%3E");
-}
-.vpi-delete {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M20 5H9l-7 7 7 7h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2ZM18 9l-6 6M12 9l6 6'/%3E%3C/svg%3E");
-}
-.vpi-corner-down-left {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m9 10-5 5 5 5'/%3E%3Cpath d='M20 4v7a4 4 0 0 1-4 4H4'/%3E%3C/svg%3E");
-}
-:root {
-  /* clipboard */
-  --vp-icon-copy: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='rgba(128,128,128,1)' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect width='8' height='4' x='8' y='2' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'/%3E%3C/svg%3E");
-  /* clipboard-copy */
-  --vp-icon-copied: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='rgba(128,128,128,1)' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect width='8' height='4' x='8' y='2' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'/%3E%3Cpath d='m9 14 2 2 4-4'/%3E%3C/svg%3E");
-}
+  /* internal icons - used under ISC from https://lucide.dev/ */
+  .vpi-align-left {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M21 6H3M15 12H3M17 18H3'/%3E%3C/svg%3E");
+  }
+  .vpi-arrow-right,
+  .vpi-arrow-down,
+  .vpi-arrow-left,
+  .vpi-arrow-up {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M5 12h14M12 5l7 7-7 7'/%3E%3C/svg%3E");
+  }
+  .vpi-chevron-right,
+  .vpi-chevron-down,
+  .vpi-chevron-left,
+  .vpi-chevron-up {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m9 18 6-6-6-6'/%3E%3C/svg%3E");
+  }
+  .vpi-chevron-down,
+  .vpi-arrow-down {
+    transform: rotate(90deg);
+  }
+  .vpi-chevron-left,
+  .vpi-arrow-left {
+    transform: rotate(180deg);
+  }
+  .vpi-chevron-up,
+  .vpi-arrow-up {
+    transform: rotate(-90deg);
+  }
+  .vpi-square-pen {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7'/%3E%3Cpath d='M18.375 2.625a2.121 2.121 0 1 1 3 3L12 15l-4 1 1-4Z'/%3E%3C/svg%3E");
+  }
+  .vpi-plus {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M5 12h14M12 5v14'/%3E%3C/svg%3E");
+  }
+  .vpi-sun {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3Cpath d='M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41'/%3E%3C/svg%3E");
+  }
+  .vpi-moon {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z'/%3E%3C/svg%3E");
+  }
+  .vpi-more-horizontal {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='1'/%3E%3Ccircle cx='19' cy='12' r='1'/%3E%3Ccircle cx='5' cy='12' r='1'/%3E%3C/svg%3E");
+  }
+  .vpi-languages {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m5 8 6 6M4 14l6-6 2-3M2 5h12M7 2h1M22 22l-5-10-5 10M14 18h6'/%3E%3C/svg%3E");
+  }
+  .vpi-heart {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z'/%3E%3C/svg%3E");
+  }
+  .vpi-search {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E");
+  }
+  .vpi-layout-list {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect width='7' height='7' x='3' y='3' rx='1'/%3E%3Crect width='7' height='7' x='3' y='14' rx='1'/%3E%3Cpath d='M14 4h7M14 9h7M14 15h7M14 20h7'/%3E%3C/svg%3E");
+  }
+  .vpi-delete {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M20 5H9l-7 7 7 7h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2ZM18 9l-6 6M12 9l6 6'/%3E%3C/svg%3E");
+  }
+  .vpi-corner-down-left {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m9 10-5 5 5 5'/%3E%3Cpath d='M20 4v7a4 4 0 0 1-4 4H4'/%3E%3C/svg%3E");
+  }
+  :root {
+    /* clipboard */
+    --vp-icon-copy: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='rgba(128,128,128,1)' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect width='8' height='4' x='8' y='2' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'/%3E%3C/svg%3E");
+    /* clipboard-copy */
+    --vp-icon-copied: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='rgba(128,128,128,1)' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect width='8' height='4' x='8' y='2' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'/%3E%3Cpath d='m9 14 2 2 4-4'/%3E%3C/svg%3E");
+  }
 
-/* social icons - used under CC0 1.0 from https://simpleicons.org/ */
-.vpi-social-discord {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418Z'/%3E%3C/svg%3E");
-}
-.vpi-social-facebook {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z'/%3E%3C/svg%3E");
-}
-.vpi-social-github {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E");
-}
-.vpi-social-instagram {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M7.03.084c-1.277.06-2.149.264-2.91.563a5.874 5.874 0 0 0-2.124 1.388 5.878 5.878 0 0 0-1.38 2.127C.321 4.926.12 5.8.064 7.076.008 8.354-.005 8.764.001 12.023c.007 3.259.021 3.667.083 4.947.061 1.277.264 2.149.563 2.911.308.789.72 1.457 1.388 2.123a5.872 5.872 0 0 0 2.129 1.38c.763.295 1.636.496 2.913.552 1.278.056 1.689.069 4.947.063 3.257-.007 3.668-.021 4.947-.082 1.28-.06 2.147-.265 2.91-.563a5.881 5.881 0 0 0 2.123-1.388 5.881 5.881 0 0 0 1.38-2.129c.295-.763.496-1.636.551-2.912.056-1.28.07-1.69.063-4.948-.006-3.258-.02-3.667-.081-4.947-.06-1.28-.264-2.148-.564-2.911a5.892 5.892 0 0 0-1.387-2.123 5.857 5.857 0 0 0-2.128-1.38C19.074.322 18.202.12 16.924.066 15.647.009 15.236-.006 11.977 0 8.718.008 8.31.021 7.03.084m.14 21.693c-1.17-.05-1.805-.245-2.228-.408a3.736 3.736 0 0 1-1.382-.895 3.695 3.695 0 0 1-.9-1.378c-.165-.423-.363-1.058-.417-2.228-.06-1.264-.072-1.644-.08-4.848-.006-3.204.006-3.583.061-4.848.05-1.169.246-1.805.408-2.228.216-.561.477-.96.895-1.382a3.705 3.705 0 0 1 1.379-.9c.423-.165 1.057-.361 2.227-.417 1.265-.06 1.644-.072 4.848-.08 3.203-.006 3.583.006 4.85.062 1.168.05 1.804.244 2.227.408.56.216.96.475 1.382.895.421.42.681.817.9 1.378.165.422.362 1.056.417 2.227.06 1.265.074 1.645.08 4.848.005 3.203-.006 3.583-.061 4.848-.051 1.17-.245 1.805-.408 2.23-.216.56-.477.96-.896 1.38a3.705 3.705 0 0 1-1.378.9c-.422.165-1.058.362-2.226.418-1.266.06-1.645.072-4.85.079-3.204.007-3.582-.006-4.848-.06m9.783-16.192a1.44 1.44 0 1 0 1.437-1.442 1.44 1.44 0 0 0-1.437 1.442M5.839 12.012a6.161 6.161 0 1 0 12.323-.024 6.162 6.162 0 0 0-12.323.024M8 12.008A4 4 0 1 1 12.008 16 4 4 0 0 1 8 12.008'/%3E%3C/svg%3E");
-}
-.vpi-social-linkedin {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z'/%3E%3C/svg%3E");
-}
-.vpi-social-mastodon {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M23.268 5.313c-.35-2.578-2.617-4.61-5.304-5.004C17.51.242 15.792 0 11.813 0h-.03c-3.98 0-4.835.242-5.288.309C3.882.692 1.496 2.518.917 5.127.64 6.412.61 7.837.661 9.143c.074 1.874.088 3.745.26 5.611.118 1.24.325 2.47.62 3.68.55 2.237 2.777 4.098 4.96 4.857 2.336.792 4.849.923 7.256.38.265-.061.527-.132.786-.213.585-.184 1.27-.39 1.774-.753a.057.057 0 0 0 .023-.043v-1.809a.052.052 0 0 0-.02-.041.053.053 0 0 0-.046-.01 20.282 20.282 0 0 1-4.709.545c-2.73 0-3.463-1.284-3.674-1.818a5.593 5.593 0 0 1-.319-1.433.053.053 0 0 1 .066-.054c1.517.363 3.072.546 4.632.546.376 0 .75 0 1.125-.01 1.57-.044 3.224-.124 4.768-.422.038-.008.077-.015.11-.024 2.435-.464 4.753-1.92 4.989-5.604.008-.145.03-1.52.03-1.67.002-.512.167-3.63-.024-5.545zm-3.748 9.195h-2.561V8.29c0-1.309-.55-1.976-1.67-1.976-1.23 0-1.846.79-1.846 2.35v3.403h-2.546V8.663c0-1.56-.617-2.35-1.848-2.35-1.112 0-1.668.668-1.67 1.977v6.218H4.822V8.102c0-1.31.337-2.35 1.011-3.12.696-.77 1.608-1.164 2.74-1.164 1.311 0 2.302.5 2.962 1.498l.638 1.06.638-1.06c.66-.999 1.65-1.498 2.96-1.498 1.13 0 2.043.395 2.74 1.164.675.77 1.012 1.81 1.012 3.12z'/%3E%3C/svg%3E");
-}
-.vpi-social-npm {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z'/%3E%3C/svg%3E");
-}
-.vpi-social-slack {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z'/%3E%3C/svg%3E");
-}
-.vpi-social-twitter,
-.vpi-social-x {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z'/%3E%3C/svg%3E");
-}
-.vpi-social-youtube {
-  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z'/%3E%3C/svg%3E");
+  /* social icons - used under CC0 1.0 from https://simpleicons.org/ */
+  .vpi-social-discord {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418Z'/%3E%3C/svg%3E");
+  }
+  .vpi-social-facebook {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z'/%3E%3C/svg%3E");
+  }
+  .vpi-social-github {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E");
+  }
+  .vpi-social-instagram {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M7.03.084c-1.277.06-2.149.264-2.91.563a5.874 5.874 0 0 0-2.124 1.388 5.878 5.878 0 0 0-1.38 2.127C.321 4.926.12 5.8.064 7.076.008 8.354-.005 8.764.001 12.023c.007 3.259.021 3.667.083 4.947.061 1.277.264 2.149.563 2.911.308.789.72 1.457 1.388 2.123a5.872 5.872 0 0 0 2.129 1.38c.763.295 1.636.496 2.913.552 1.278.056 1.689.069 4.947.063 3.257-.007 3.668-.021 4.947-.082 1.28-.06 2.147-.265 2.91-.563a5.881 5.881 0 0 0 2.123-1.388 5.881 5.881 0 0 0 1.38-2.129c.295-.763.496-1.636.551-2.912.056-1.28.07-1.69.063-4.948-.006-3.258-.02-3.667-.081-4.947-.06-1.28-.264-2.148-.564-2.911a5.892 5.892 0 0 0-1.387-2.123 5.857 5.857 0 0 0-2.128-1.38C19.074.322 18.202.12 16.924.066 15.647.009 15.236-.006 11.977 0 8.718.008 8.31.021 7.03.084m.14 21.693c-1.17-.05-1.805-.245-2.228-.408a3.736 3.736 0 0 1-1.382-.895 3.695 3.695 0 0 1-.9-1.378c-.165-.423-.363-1.058-.417-2.228-.06-1.264-.072-1.644-.08-4.848-.006-3.204.006-3.583.061-4.848.05-1.169.246-1.805.408-2.228.216-.561.477-.96.895-1.382a3.705 3.705 0 0 1 1.379-.9c.423-.165 1.057-.361 2.227-.417 1.265-.06 1.644-.072 4.848-.08 3.203-.006 3.583.006 4.85.062 1.168.05 1.804.244 2.227.408.56.216.96.475 1.382.895.421.42.681.817.9 1.378.165.422.362 1.056.417 2.227.06 1.265.074 1.645.08 4.848.005 3.203-.006 3.583-.061 4.848-.051 1.17-.245 1.805-.408 2.23-.216.56-.477.96-.896 1.38a3.705 3.705 0 0 1-1.378.9c-.422.165-1.058.362-2.226.418-1.266.06-1.645.072-4.85.079-3.204.007-3.582-.006-4.848-.06m9.783-16.192a1.44 1.44 0 1 0 1.437-1.442 1.44 1.44 0 0 0-1.437 1.442M5.839 12.012a6.161 6.161 0 1 0 12.323-.024 6.162 6.162 0 0 0-12.323.024M8 12.008A4 4 0 1 1 12.008 16 4 4 0 0 1 8 12.008'/%3E%3C/svg%3E");
+  }
+  .vpi-social-linkedin {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z'/%3E%3C/svg%3E");
+  }
+  .vpi-social-mastodon {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M23.268 5.313c-.35-2.578-2.617-4.61-5.304-5.004C17.51.242 15.792 0 11.813 0h-.03c-3.98 0-4.835.242-5.288.309C3.882.692 1.496 2.518.917 5.127.64 6.412.61 7.837.661 9.143c.074 1.874.088 3.745.26 5.611.118 1.24.325 2.47.62 3.68.55 2.237 2.777 4.098 4.96 4.857 2.336.792 4.849.923 7.256.38.265-.061.527-.132.786-.213.585-.184 1.27-.39 1.774-.753a.057.057 0 0 0 .023-.043v-1.809a.052.052 0 0 0-.02-.041.053.053 0 0 0-.046-.01 20.282 20.282 0 0 1-4.709.545c-2.73 0-3.463-1.284-3.674-1.818a5.593 5.593 0 0 1-.319-1.433.053.053 0 0 1 .066-.054c1.517.363 3.072.546 4.632.546.376 0 .75 0 1.125-.01 1.57-.044 3.224-.124 4.768-.422.038-.008.077-.015.11-.024 2.435-.464 4.753-1.92 4.989-5.604.008-.145.03-1.52.03-1.67.002-.512.167-3.63-.024-5.545zm-3.748 9.195h-2.561V8.29c0-1.309-.55-1.976-1.67-1.976-1.23 0-1.846.79-1.846 2.35v3.403h-2.546V8.663c0-1.56-.617-2.35-1.848-2.35-1.112 0-1.668.668-1.67 1.977v6.218H4.822V8.102c0-1.31.337-2.35 1.011-3.12.696-.77 1.608-1.164 2.74-1.164 1.311 0 2.302.5 2.962 1.498l.638 1.06.638-1.06c.66-.999 1.65-1.498 2.96-1.498 1.13 0 2.043.395 2.74 1.164.675.77 1.012 1.81 1.012 3.12z'/%3E%3C/svg%3E");
+  }
+  .vpi-social-npm {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z'/%3E%3C/svg%3E");
+  }
+  .vpi-social-slack {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z'/%3E%3C/svg%3E");
+  }
+  .vpi-social-twitter,
+  .vpi-social-x {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z'/%3E%3C/svg%3E");
+  }
+  .vpi-social-youtube {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z'/%3E%3C/svg%3E");
+  }
 }

--- a/src/client/theme-default/styles/utils.css
+++ b/src/client/theme-default/styles/utils.css
@@ -1,9 +1,11 @@
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  white-space: nowrap;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  overflow: hidden;
+@layer vitepress.utils {
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    white-space: nowrap;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+  }
 }

--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -1,21 +1,22 @@
-/**
+@layer vitepress.vars {
+  /**
  * Colors: Solid
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-c-white: #ffffff;
-  --vp-c-black: #000000;
+  :root {
+    --vp-c-white: #ffffff;
+    --vp-c-black: #000000;
 
-  --vp-c-neutral: var(--vp-c-black);
-  --vp-c-neutral-inverse: var(--vp-c-white);
-}
+    --vp-c-neutral: var(--vp-c-black);
+    --vp-c-neutral-inverse: var(--vp-c-white);
+  }
 
-.dark {
-  --vp-c-neutral: var(--vp-c-white);
-  --vp-c-neutral-inverse: var(--vp-c-black);
-}
+  .dark {
+    --vp-c-neutral: var(--vp-c-white);
+    --vp-c-neutral-inverse: var(--vp-c-black);
+  }
 
-/**
+  /**
  * Colors: Palette
  *
  * The primitive colors used for accent colors. These colors are referenced
@@ -43,73 +44,73 @@
  *    custom containers.
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-c-gray-1: #dddde3;
-  --vp-c-gray-2: #e4e4e9;
-  --vp-c-gray-3: #ebebef;
-  --vp-c-gray-soft: rgba(142, 150, 170, 0.14);
+  :root {
+    --vp-c-gray-1: #dddde3;
+    --vp-c-gray-2: #e4e4e9;
+    --vp-c-gray-3: #ebebef;
+    --vp-c-gray-soft: rgba(142, 150, 170, 0.14);
 
-  --vp-c-indigo-1: #3451b2;
-  --vp-c-indigo-2: #3a5ccc;
-  --vp-c-indigo-3: #5672cd;
-  --vp-c-indigo-soft: rgba(100, 108, 255, 0.14);
+    --vp-c-indigo-1: #3451b2;
+    --vp-c-indigo-2: #3a5ccc;
+    --vp-c-indigo-3: #5672cd;
+    --vp-c-indigo-soft: rgba(100, 108, 255, 0.14);
 
-  --vp-c-purple-1: #6f42c1;
-  --vp-c-purple-2: #7e4cc9;
-  --vp-c-purple-3: #8e5cd9;
-  --vp-c-purple-soft: rgba(159, 122, 234, 0.14);
+    --vp-c-purple-1: #6f42c1;
+    --vp-c-purple-2: #7e4cc9;
+    --vp-c-purple-3: #8e5cd9;
+    --vp-c-purple-soft: rgba(159, 122, 234, 0.14);
 
-  --vp-c-green-1: #18794e;
-  --vp-c-green-2: #299764;
-  --vp-c-green-3: #30a46c;
-  --vp-c-green-soft: rgba(16, 185, 129, 0.14);
+    --vp-c-green-1: #18794e;
+    --vp-c-green-2: #299764;
+    --vp-c-green-3: #30a46c;
+    --vp-c-green-soft: rgba(16, 185, 129, 0.14);
 
-  --vp-c-yellow-1: #915930;
-  --vp-c-yellow-2: #946300;
-  --vp-c-yellow-3: #9f6a00;
-  --vp-c-yellow-soft: rgba(234, 179, 8, 0.14);
+    --vp-c-yellow-1: #915930;
+    --vp-c-yellow-2: #946300;
+    --vp-c-yellow-3: #9f6a00;
+    --vp-c-yellow-soft: rgba(234, 179, 8, 0.14);
 
-  --vp-c-red-1: #b8272c;
-  --vp-c-red-2: #d5393e;
-  --vp-c-red-3: #e0575b;
-  --vp-c-red-soft: rgba(244, 63, 94, 0.14);
+    --vp-c-red-1: #b8272c;
+    --vp-c-red-2: #d5393e;
+    --vp-c-red-3: #e0575b;
+    --vp-c-red-soft: rgba(244, 63, 94, 0.14);
 
-  --vp-c-sponsor: #db2777;
-}
+    --vp-c-sponsor: #db2777;
+  }
 
-.dark {
-  --vp-c-gray-1: #515c67;
-  --vp-c-gray-2: #414853;
-  --vp-c-gray-3: #32363f;
-  --vp-c-gray-soft: rgba(101, 117, 133, 0.16);
+  .dark {
+    --vp-c-gray-1: #515c67;
+    --vp-c-gray-2: #414853;
+    --vp-c-gray-3: #32363f;
+    --vp-c-gray-soft: rgba(101, 117, 133, 0.16);
 
-  --vp-c-indigo-1: #a8b1ff;
-  --vp-c-indigo-2: #5c73e7;
-  --vp-c-indigo-3: #3e63dd;
-  --vp-c-indigo-soft: rgba(100, 108, 255, 0.16);
+    --vp-c-indigo-1: #a8b1ff;
+    --vp-c-indigo-2: #5c73e7;
+    --vp-c-indigo-3: #3e63dd;
+    --vp-c-indigo-soft: rgba(100, 108, 255, 0.16);
 
-  --vp-c-purple-1: #c8abfa;
-  --vp-c-purple-2: #a879e6;
-  --vp-c-purple-3: #8e5cd9;
-  --vp-c-purple-soft: rgba(159, 122, 234, 0.16);
+    --vp-c-purple-1: #c8abfa;
+    --vp-c-purple-2: #a879e6;
+    --vp-c-purple-3: #8e5cd9;
+    --vp-c-purple-soft: rgba(159, 122, 234, 0.16);
 
-  --vp-c-green-1: #3dd68c;
-  --vp-c-green-2: #30a46c;
-  --vp-c-green-3: #298459;
-  --vp-c-green-soft: rgba(16, 185, 129, 0.16);
+    --vp-c-green-1: #3dd68c;
+    --vp-c-green-2: #30a46c;
+    --vp-c-green-3: #298459;
+    --vp-c-green-soft: rgba(16, 185, 129, 0.16);
 
-  --vp-c-yellow-1: #f9b44e;
-  --vp-c-yellow-2: #da8b17;
-  --vp-c-yellow-3: #a46a0a;
-  --vp-c-yellow-soft: rgba(234, 179, 8, 0.16);
+    --vp-c-yellow-1: #f9b44e;
+    --vp-c-yellow-2: #da8b17;
+    --vp-c-yellow-3: #a46a0a;
+    --vp-c-yellow-soft: rgba(234, 179, 8, 0.16);
 
-  --vp-c-red-1: #f66f81;
-  --vp-c-red-2: #f14158;
-  --vp-c-red-3: #b62a3c;
-  --vp-c-red-soft: rgba(244, 63, 94, 0.16);
-}
+    --vp-c-red-1: #f66f81;
+    --vp-c-red-2: #f14158;
+    --vp-c-red-3: #b62a3c;
+    --vp-c-red-soft: rgba(244, 63, 94, 0.16);
+  }
 
-/**
+  /**
  * Colors: Background
  *
  * - `bg`: The bg color used for main screen.
@@ -124,21 +125,21 @@
  *   the page. Used for things like "carbon ads" or "table".
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-c-bg: #ffffff;
-  --vp-c-bg-alt: #f6f6f7;
-  --vp-c-bg-elv: #ffffff;
-  --vp-c-bg-soft: #f6f6f7;
-}
+  :root {
+    --vp-c-bg: #ffffff;
+    --vp-c-bg-alt: #f6f6f7;
+    --vp-c-bg-elv: #ffffff;
+    --vp-c-bg-soft: #f6f6f7;
+  }
 
-.dark {
-  --vp-c-bg: #1b1b1f;
-  --vp-c-bg-alt: #161618;
-  --vp-c-bg-elv: #202127;
-  --vp-c-bg-soft: #202127;
-}
+  .dark {
+    --vp-c-bg: #1b1b1f;
+    --vp-c-bg-alt: #161618;
+    --vp-c-bg-elv: #202127;
+    --vp-c-bg-soft: #202127;
+  }
 
-/**
+  /**
  * Colors: Borders
  *
  * - `divider`: This is used for separators. This is used to divide sections
@@ -151,19 +152,19 @@
  *   the header and the lest of the page.
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-c-border: #c2c2c4;
-  --vp-c-divider: #e2e2e3;
-  --vp-c-gutter: #e2e2e3;
-}
+  :root {
+    --vp-c-border: #c2c2c4;
+    --vp-c-divider: #e2e2e3;
+    --vp-c-gutter: #e2e2e3;
+  }
 
-.dark {
-  --vp-c-border: #3c3f44;
-  --vp-c-divider: #2e2e32;
-  --vp-c-gutter: #000000;
-}
+  .dark {
+    --vp-c-border: #3c3f44;
+    --vp-c-divider: #2e2e32;
+    --vp-c-gutter: #000000;
+  }
 
-/**
+  /**
  * Colors: Text
  *
  * - `text-1`: Used for primary text.
@@ -173,19 +174,19 @@
  * - `text-3`: Used for subtle texts, such as "placeholders" or "caret icon".
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-c-text-1: rgba(60, 60, 67);
-  --vp-c-text-2: rgba(60, 60, 67, 0.78);
-  --vp-c-text-3: rgba(60, 60, 67, 0.56);
-}
+  :root {
+    --vp-c-text-1: rgba(60, 60, 67);
+    --vp-c-text-2: rgba(60, 60, 67, 0.78);
+    --vp-c-text-3: rgba(60, 60, 67, 0.56);
+  }
 
-.dark {
-  --vp-c-text-1: rgba(255, 255, 245, 0.86);
-  --vp-c-text-2: rgba(235, 235, 245, 0.6);
-  --vp-c-text-3: rgba(235, 235, 245, 0.38);
-}
+  .dark {
+    --vp-c-text-1: rgba(255, 255, 245, 0.86);
+    --vp-c-text-2: rgba(235, 235, 245, 0.6);
+    --vp-c-text-3: rgba(235, 235, 245, 0.38);
+  }
 
-/**
+  /**
  * Colors: Function
  *
  * - `default`: The color used purely for subtle indication without any
@@ -206,363 +207,367 @@
  * To understand the scaling system, refer to "Colors: Palette" section.
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-c-default-1: var(--vp-c-gray-1);
-  --vp-c-default-2: var(--vp-c-gray-2);
-  --vp-c-default-3: var(--vp-c-gray-3);
-  --vp-c-default-soft: var(--vp-c-gray-soft);
+  :root {
+    --vp-c-default-1: var(--vp-c-gray-1);
+    --vp-c-default-2: var(--vp-c-gray-2);
+    --vp-c-default-3: var(--vp-c-gray-3);
+    --vp-c-default-soft: var(--vp-c-gray-soft);
 
-  --vp-c-brand-1: var(--vp-c-indigo-1);
-  --vp-c-brand-2: var(--vp-c-indigo-2);
-  --vp-c-brand-3: var(--vp-c-indigo-3);
-  --vp-c-brand-soft: var(--vp-c-indigo-soft);
+    --vp-c-brand-1: var(--vp-c-indigo-1);
+    --vp-c-brand-2: var(--vp-c-indigo-2);
+    --vp-c-brand-3: var(--vp-c-indigo-3);
+    --vp-c-brand-soft: var(--vp-c-indigo-soft);
 
-  /* DEPRECATED: Use `--vp-c-brand-1` instead. */
-  --vp-c-brand: var(--vp-c-brand-1);
+    /* DEPRECATED: Use `--vp-c-brand-1` instead. */
+    --vp-c-brand: var(--vp-c-brand-1);
 
-  --vp-c-tip-1: var(--vp-c-brand-1);
-  --vp-c-tip-2: var(--vp-c-brand-2);
-  --vp-c-tip-3: var(--vp-c-brand-3);
-  --vp-c-tip-soft: var(--vp-c-brand-soft);
+    --vp-c-tip-1: var(--vp-c-brand-1);
+    --vp-c-tip-2: var(--vp-c-brand-2);
+    --vp-c-tip-3: var(--vp-c-brand-3);
+    --vp-c-tip-soft: var(--vp-c-brand-soft);
 
-  --vp-c-note-1: var(--vp-c-brand-1);
-  --vp-c-note-2: var(--vp-c-brand-2);
-  --vp-c-note-3: var(--vp-c-brand-3);
-  --vp-c-note-soft: var(--vp-c-brand-soft);
+    --vp-c-note-1: var(--vp-c-brand-1);
+    --vp-c-note-2: var(--vp-c-brand-2);
+    --vp-c-note-3: var(--vp-c-brand-3);
+    --vp-c-note-soft: var(--vp-c-brand-soft);
 
-  --vp-c-success-1: var(--vp-c-green-1);
-  --vp-c-success-2: var(--vp-c-green-2);
-  --vp-c-success-3: var(--vp-c-green-3);
-  --vp-c-success-soft: var(--vp-c-green-soft);
+    --vp-c-success-1: var(--vp-c-green-1);
+    --vp-c-success-2: var(--vp-c-green-2);
+    --vp-c-success-3: var(--vp-c-green-3);
+    --vp-c-success-soft: var(--vp-c-green-soft);
 
-  --vp-c-important-1: var(--vp-c-purple-1);
-  --vp-c-important-2: var(--vp-c-purple-2);
-  --vp-c-important-3: var(--vp-c-purple-3);
-  --vp-c-important-soft: var(--vp-c-purple-soft);
+    --vp-c-important-1: var(--vp-c-purple-1);
+    --vp-c-important-2: var(--vp-c-purple-2);
+    --vp-c-important-3: var(--vp-c-purple-3);
+    --vp-c-important-soft: var(--vp-c-purple-soft);
 
-  --vp-c-warning-1: var(--vp-c-yellow-1);
-  --vp-c-warning-2: var(--vp-c-yellow-2);
-  --vp-c-warning-3: var(--vp-c-yellow-3);
-  --vp-c-warning-soft: var(--vp-c-yellow-soft);
+    --vp-c-warning-1: var(--vp-c-yellow-1);
+    --vp-c-warning-2: var(--vp-c-yellow-2);
+    --vp-c-warning-3: var(--vp-c-yellow-3);
+    --vp-c-warning-soft: var(--vp-c-yellow-soft);
 
-  --vp-c-danger-1: var(--vp-c-red-1);
-  --vp-c-danger-2: var(--vp-c-red-2);
-  --vp-c-danger-3: var(--vp-c-red-3);
-  --vp-c-danger-soft: var(--vp-c-red-soft);
+    --vp-c-danger-1: var(--vp-c-red-1);
+    --vp-c-danger-2: var(--vp-c-red-2);
+    --vp-c-danger-3: var(--vp-c-red-3);
+    --vp-c-danger-soft: var(--vp-c-red-soft);
 
-  --vp-c-caution-1: var(--vp-c-red-1);
-  --vp-c-caution-2: var(--vp-c-red-2);
-  --vp-c-caution-3: var(--vp-c-red-3);
-  --vp-c-caution-soft: var(--vp-c-red-soft);
-}
+    --vp-c-caution-1: var(--vp-c-red-1);
+    --vp-c-caution-2: var(--vp-c-red-2);
+    --vp-c-caution-3: var(--vp-c-red-3);
+    --vp-c-caution-soft: var(--vp-c-red-soft);
+  }
 
-/**
+  /**
  * Typography
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-font-family-base: 'Inter', ui-sans-serif, system-ui, sans-serif,
-    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --vp-font-family-mono: ui-monospace, 'Menlo', 'Monaco', 'Consolas',
-    'Liberation Mono', 'Courier New', monospace;
-  font-optical-sizing: auto;
-}
+  :root {
+    --vp-font-family-base: 'Inter', ui-sans-serif, system-ui, sans-serif,
+      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+      'Noto Color Emoji';
+    --vp-font-family-mono: ui-monospace, 'Menlo', 'Monaco', 'Consolas',
+      'Liberation Mono', 'Courier New', monospace;
+    font-optical-sizing: auto;
+  }
 
-:root:where(:lang(zh)) {
-  --vp-font-family-base: 'Punctuation SC', 'Inter', ui-sans-serif, system-ui,
-    'PingFang SC', 'Noto Sans CJK SC', 'Noto Sans SC', 'Heiti SC',
-    'Microsoft YaHei', 'DengXian', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-}
+  :root:where(:lang(zh)) {
+    --vp-font-family-base: 'Punctuation SC', 'Inter', ui-sans-serif, system-ui,
+      'PingFang SC', 'Noto Sans CJK SC', 'Noto Sans SC', 'Heiti SC',
+      'Microsoft YaHei', 'DengXian', sans-serif, 'Apple Color Emoji',
+      'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  }
 
-/**
+  /**
  * Shadows
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);
-  --vp-shadow-2: 0 3px 12px rgba(0, 0, 0, 0.07), 0 1px 4px rgba(0, 0, 0, 0.07);
-  --vp-shadow-3: 0 12px 32px rgba(0, 0, 0, 0.1), 0 2px 6px rgba(0, 0, 0, 0.08);
-  --vp-shadow-4: 0 14px 44px rgba(0, 0, 0, 0.12), 0 3px 9px rgba(0, 0, 0, 0.12);
-  --vp-shadow-5: 0 18px 56px rgba(0, 0, 0, 0.16), 0 4px 12px rgba(0, 0, 0, 0.16);
-}
+  :root {
+    --vp-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);
+    --vp-shadow-2: 0 3px 12px rgba(0, 0, 0, 0.07), 0 1px 4px rgba(0, 0, 0, 0.07);
+    --vp-shadow-3: 0 12px 32px rgba(0, 0, 0, 0.1), 0 2px 6px rgba(0, 0, 0, 0.08);
+    --vp-shadow-4: 0 14px 44px rgba(0, 0, 0, 0.12),
+      0 3px 9px rgba(0, 0, 0, 0.12);
+    --vp-shadow-5: 0 18px 56px rgba(0, 0, 0, 0.16),
+      0 4px 12px rgba(0, 0, 0, 0.16);
+  }
 
-/**
+  /**
  * Z-indexes
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-z-index-footer: 10;
-  --vp-z-index-local-nav: 20;
-  --vp-z-index-nav: 30;
-  --vp-z-index-layout-top: 40;
-  --vp-z-index-backdrop: 50;
-  --vp-z-index-sidebar: 60;
-}
-
-@media (min-width: 960px) {
   :root {
-    --vp-z-index-sidebar: 25;
+    --vp-z-index-footer: 10;
+    --vp-z-index-local-nav: 20;
+    --vp-z-index-nav: 30;
+    --vp-z-index-layout-top: 40;
+    --vp-z-index-backdrop: 50;
+    --vp-z-index-sidebar: 60;
   }
-}
 
-/**
+  @media (min-width: 960px) {
+    :root {
+      --vp-z-index-sidebar: 25;
+    }
+  }
+
+  /**
  * Layouts
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-layout-max-width: 1440px;
-}
+  :root {
+    --vp-layout-max-width: 1440px;
+  }
 
-/**
+  /**
  * Component: Header Anchor
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-header-anchor-symbol: '#';
-}
+  :root {
+    --vp-header-anchor-symbol: '#';
+  }
 
-/**
+  /**
  * Component: Code
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-code-line-height: 1.7;
-  --vp-code-font-size: 0.875em;
-  --vp-code-color: var(--vp-c-brand-1);
-  --vp-code-link-color: var(--vp-c-brand-1);
-  --vp-code-link-hover-color: var(--vp-c-brand-2);
-  --vp-code-bg: var(--vp-c-default-soft);
+  :root {
+    --vp-code-line-height: 1.7;
+    --vp-code-font-size: 0.875em;
+    --vp-code-color: var(--vp-c-brand-1);
+    --vp-code-link-color: var(--vp-c-brand-1);
+    --vp-code-link-hover-color: var(--vp-c-brand-2);
+    --vp-code-bg: var(--vp-c-default-soft);
 
-  --vp-code-block-color: var(--vp-c-text-2);
-  --vp-code-block-bg: var(--vp-c-bg-alt);
-  --vp-code-block-divider-color: var(--vp-c-gutter);
+    --vp-code-block-color: var(--vp-c-text-2);
+    --vp-code-block-bg: var(--vp-c-bg-alt);
+    --vp-code-block-divider-color: var(--vp-c-gutter);
 
-  --vp-code-lang-color: var(--vp-c-text-3);
+    --vp-code-lang-color: var(--vp-c-text-3);
 
-  --vp-code-line-highlight-color: var(--vp-c-default-soft);
-  --vp-code-line-number-color: var(--vp-c-text-3);
+    --vp-code-line-highlight-color: var(--vp-c-default-soft);
+    --vp-code-line-number-color: var(--vp-c-text-3);
 
-  --vp-code-line-diff-add-color: var(--vp-c-success-soft);
-  --vp-code-line-diff-add-symbol-color: var(--vp-c-success-1);
+    --vp-code-line-diff-add-color: var(--vp-c-success-soft);
+    --vp-code-line-diff-add-symbol-color: var(--vp-c-success-1);
 
-  --vp-code-line-diff-remove-color: var(--vp-c-danger-soft);
-  --vp-code-line-diff-remove-symbol-color: var(--vp-c-danger-1);
+    --vp-code-line-diff-remove-color: var(--vp-c-danger-soft);
+    --vp-code-line-diff-remove-symbol-color: var(--vp-c-danger-1);
 
-  --vp-code-line-warning-color: var(--vp-c-warning-soft);
-  --vp-code-line-error-color: var(--vp-c-danger-soft);
+    --vp-code-line-warning-color: var(--vp-c-warning-soft);
+    --vp-code-line-error-color: var(--vp-c-danger-soft);
 
-  --vp-code-copy-code-border-color: var(--vp-c-divider);
-  --vp-code-copy-code-bg: var(--vp-c-bg-soft);
-  --vp-code-copy-code-hover-border-color: var(--vp-c-divider);
-  --vp-code-copy-code-hover-bg: var(--vp-c-bg);
-  --vp-code-copy-code-active-text: var(--vp-c-text-2);
-  --vp-code-copy-copied-text-content: 'Copied';
+    --vp-code-copy-code-border-color: var(--vp-c-divider);
+    --vp-code-copy-code-bg: var(--vp-c-bg-soft);
+    --vp-code-copy-code-hover-border-color: var(--vp-c-divider);
+    --vp-code-copy-code-hover-bg: var(--vp-c-bg);
+    --vp-code-copy-code-active-text: var(--vp-c-text-2);
+    --vp-code-copy-copied-text-content: 'Copied';
 
-  --vp-code-tab-divider: var(--vp-code-block-divider-color);
-  --vp-code-tab-text-color: var(--vp-c-text-2);
-  --vp-code-tab-bg: var(--vp-code-block-bg);
-  --vp-code-tab-hover-text-color: var(--vp-c-text-1);
-  --vp-code-tab-active-text-color: var(--vp-c-text-1);
-  --vp-code-tab-active-bar-color: var(--vp-c-brand-1);
-}
+    --vp-code-tab-divider: var(--vp-code-block-divider-color);
+    --vp-code-tab-text-color: var(--vp-c-text-2);
+    --vp-code-tab-bg: var(--vp-code-block-bg);
+    --vp-code-tab-hover-text-color: var(--vp-c-text-1);
+    --vp-code-tab-active-text-color: var(--vp-c-text-1);
+    --vp-code-tab-active-bar-color: var(--vp-c-brand-1);
+  }
 
-/**
+  /**
  * Component: Button
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-button-brand-border: transparent;
-  --vp-button-brand-text: var(--vp-c-white);
-  --vp-button-brand-bg: var(--vp-c-brand-3);
-  --vp-button-brand-hover-border: transparent;
-  --vp-button-brand-hover-text: var(--vp-c-white);
-  --vp-button-brand-hover-bg: var(--vp-c-brand-2);
-  --vp-button-brand-active-border: transparent;
-  --vp-button-brand-active-text: var(--vp-c-white);
-  --vp-button-brand-active-bg: var(--vp-c-brand-1);
+  :root {
+    --vp-button-brand-border: transparent;
+    --vp-button-brand-text: var(--vp-c-white);
+    --vp-button-brand-bg: var(--vp-c-brand-3);
+    --vp-button-brand-hover-border: transparent;
+    --vp-button-brand-hover-text: var(--vp-c-white);
+    --vp-button-brand-hover-bg: var(--vp-c-brand-2);
+    --vp-button-brand-active-border: transparent;
+    --vp-button-brand-active-text: var(--vp-c-white);
+    --vp-button-brand-active-bg: var(--vp-c-brand-1);
 
-  --vp-button-alt-border: transparent;
-  --vp-button-alt-text: var(--vp-c-text-1);
-  --vp-button-alt-bg: var(--vp-c-default-3);
-  --vp-button-alt-hover-border: transparent;
-  --vp-button-alt-hover-text: var(--vp-c-text-1);
-  --vp-button-alt-hover-bg: var(--vp-c-default-2);
-  --vp-button-alt-active-border: transparent;
-  --vp-button-alt-active-text: var(--vp-c-text-1);
-  --vp-button-alt-active-bg: var(--vp-c-default-1);
+    --vp-button-alt-border: transparent;
+    --vp-button-alt-text: var(--vp-c-text-1);
+    --vp-button-alt-bg: var(--vp-c-default-3);
+    --vp-button-alt-hover-border: transparent;
+    --vp-button-alt-hover-text: var(--vp-c-text-1);
+    --vp-button-alt-hover-bg: var(--vp-c-default-2);
+    --vp-button-alt-active-border: transparent;
+    --vp-button-alt-active-text: var(--vp-c-text-1);
+    --vp-button-alt-active-bg: var(--vp-c-default-1);
 
-  --vp-button-sponsor-border: var(--vp-c-text-2);
-  --vp-button-sponsor-text: var(--vp-c-text-2);
-  --vp-button-sponsor-bg: transparent;
-  --vp-button-sponsor-hover-border: var(--vp-c-sponsor);
-  --vp-button-sponsor-hover-text: var(--vp-c-sponsor);
-  --vp-button-sponsor-hover-bg: transparent;
-  --vp-button-sponsor-active-border: var(--vp-c-sponsor);
-  --vp-button-sponsor-active-text: var(--vp-c-sponsor);
-  --vp-button-sponsor-active-bg: transparent;
-}
+    --vp-button-sponsor-border: var(--vp-c-text-2);
+    --vp-button-sponsor-text: var(--vp-c-text-2);
+    --vp-button-sponsor-bg: transparent;
+    --vp-button-sponsor-hover-border: var(--vp-c-sponsor);
+    --vp-button-sponsor-hover-text: var(--vp-c-sponsor);
+    --vp-button-sponsor-hover-bg: transparent;
+    --vp-button-sponsor-active-border: var(--vp-c-sponsor);
+    --vp-button-sponsor-active-text: var(--vp-c-sponsor);
+    --vp-button-sponsor-active-bg: transparent;
+  }
 
-/**
+  /**
  * Component: Custom Block
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-custom-block-font-size: 14px;
-  --vp-custom-block-code-font-size: 13px;
+  :root {
+    --vp-custom-block-font-size: 14px;
+    --vp-custom-block-code-font-size: 13px;
 
-  --vp-custom-block-info-border: transparent;
-  --vp-custom-block-info-text: var(--vp-c-text-1);
-  --vp-custom-block-info-bg: var(--vp-c-default-soft);
-  --vp-custom-block-info-code-bg: var(--vp-c-default-soft);
+    --vp-custom-block-info-border: transparent;
+    --vp-custom-block-info-text: var(--vp-c-text-1);
+    --vp-custom-block-info-bg: var(--vp-c-default-soft);
+    --vp-custom-block-info-code-bg: var(--vp-c-default-soft);
 
-  --vp-custom-block-note-border: transparent;
-  --vp-custom-block-note-text: var(--vp-c-text-1);
-  --vp-custom-block-note-bg: var(--vp-c-default-soft);
-  --vp-custom-block-note-code-bg: var(--vp-c-default-soft);
+    --vp-custom-block-note-border: transparent;
+    --vp-custom-block-note-text: var(--vp-c-text-1);
+    --vp-custom-block-note-bg: var(--vp-c-default-soft);
+    --vp-custom-block-note-code-bg: var(--vp-c-default-soft);
 
-  --vp-custom-block-tip-border: transparent;
-  --vp-custom-block-tip-text: var(--vp-c-text-1);
-  --vp-custom-block-tip-bg: var(--vp-c-tip-soft);
-  --vp-custom-block-tip-code-bg: var(--vp-c-tip-soft);
+    --vp-custom-block-tip-border: transparent;
+    --vp-custom-block-tip-text: var(--vp-c-text-1);
+    --vp-custom-block-tip-bg: var(--vp-c-tip-soft);
+    --vp-custom-block-tip-code-bg: var(--vp-c-tip-soft);
 
-  --vp-custom-block-important-border: transparent;
-  --vp-custom-block-important-text: var(--vp-c-text-1);
-  --vp-custom-block-important-bg: var(--vp-c-important-soft);
-  --vp-custom-block-important-code-bg: var(--vp-c-important-soft);
+    --vp-custom-block-important-border: transparent;
+    --vp-custom-block-important-text: var(--vp-c-text-1);
+    --vp-custom-block-important-bg: var(--vp-c-important-soft);
+    --vp-custom-block-important-code-bg: var(--vp-c-important-soft);
 
-  --vp-custom-block-warning-border: transparent;
-  --vp-custom-block-warning-text: var(--vp-c-text-1);
-  --vp-custom-block-warning-bg: var(--vp-c-warning-soft);
-  --vp-custom-block-warning-code-bg: var(--vp-c-warning-soft);
+    --vp-custom-block-warning-border: transparent;
+    --vp-custom-block-warning-text: var(--vp-c-text-1);
+    --vp-custom-block-warning-bg: var(--vp-c-warning-soft);
+    --vp-custom-block-warning-code-bg: var(--vp-c-warning-soft);
 
-  --vp-custom-block-danger-border: transparent;
-  --vp-custom-block-danger-text: var(--vp-c-text-1);
-  --vp-custom-block-danger-bg: var(--vp-c-danger-soft);
-  --vp-custom-block-danger-code-bg: var(--vp-c-danger-soft);
+    --vp-custom-block-danger-border: transparent;
+    --vp-custom-block-danger-text: var(--vp-c-text-1);
+    --vp-custom-block-danger-bg: var(--vp-c-danger-soft);
+    --vp-custom-block-danger-code-bg: var(--vp-c-danger-soft);
 
-  --vp-custom-block-caution-border: transparent;
-  --vp-custom-block-caution-text: var(--vp-c-text-1);
-  --vp-custom-block-caution-bg: var(--vp-c-caution-soft);
-  --vp-custom-block-caution-code-bg: var(--vp-c-caution-soft);
+    --vp-custom-block-caution-border: transparent;
+    --vp-custom-block-caution-text: var(--vp-c-text-1);
+    --vp-custom-block-caution-bg: var(--vp-c-caution-soft);
+    --vp-custom-block-caution-code-bg: var(--vp-c-caution-soft);
 
-  --vp-custom-block-details-border: var(--vp-custom-block-info-border);
-  --vp-custom-block-details-text: var(--vp-custom-block-info-text);
-  --vp-custom-block-details-bg: var(--vp-custom-block-info-bg);
-  --vp-custom-block-details-code-bg: var(--vp-custom-block-info-code-bg);
-}
+    --vp-custom-block-details-border: var(--vp-custom-block-info-border);
+    --vp-custom-block-details-text: var(--vp-custom-block-info-text);
+    --vp-custom-block-details-bg: var(--vp-custom-block-info-bg);
+    --vp-custom-block-details-code-bg: var(--vp-custom-block-info-code-bg);
+  }
 
-/**
+  /**
  * Component: Input
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-input-border-color: var(--vp-c-border);
-  --vp-input-bg-color: var(--vp-c-bg-alt);
+  :root {
+    --vp-input-border-color: var(--vp-c-border);
+    --vp-input-bg-color: var(--vp-c-bg-alt);
 
-  --vp-input-switch-bg-color: var(--vp-c-default-soft);
-}
+    --vp-input-switch-bg-color: var(--vp-c-default-soft);
+  }
 
-/**
+  /**
  * Component: Nav
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-nav-height: 64px;
-  --vp-nav-bg-color: var(--vp-c-bg);
-  --vp-nav-screen-bg-color: var(--vp-c-bg);
-  --vp-nav-logo-height: 24px;
-}
+  :root {
+    --vp-nav-height: 64px;
+    --vp-nav-bg-color: var(--vp-c-bg);
+    --vp-nav-screen-bg-color: var(--vp-c-bg);
+    --vp-nav-logo-height: 24px;
+  }
 
-.hide-nav {
-  --vp-nav-height: 0px;
-}
+  .hide-nav {
+    --vp-nav-height: 0px;
+  }
 
-.hide-nav .VPSidebar {
-  --vp-nav-height: 22px;
-}
+  .hide-nav .VPSidebar {
+    --vp-nav-height: 22px;
+  }
 
-/**
+  /**
  * Component: Local Nav
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-local-nav-bg-color: var(--vp-c-bg);
-}
+  :root {
+    --vp-local-nav-bg-color: var(--vp-c-bg);
+  }
 
-/**
+  /**
  * Component: Sidebar
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-sidebar-width: 272px;
-  --vp-sidebar-bg-color: var(--vp-c-bg-alt);
-}
+  :root {
+    --vp-sidebar-width: 272px;
+    --vp-sidebar-bg-color: var(--vp-c-bg-alt);
+  }
 
-/**
+  /**
  * Colors Backdrop
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-backdrop-bg-color: rgba(0, 0, 0, 0.6);
-}
+  :root {
+    --vp-backdrop-bg-color: rgba(0, 0, 0, 0.6);
+  }
 
-/**
+  /**
  * Component: Home
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-home-hero-name-color: var(--vp-c-brand-1);
-  --vp-home-hero-name-background: transparent;
+  :root {
+    --vp-home-hero-name-color: var(--vp-c-brand-1);
+    --vp-home-hero-name-background: transparent;
 
-  --vp-home-hero-image-background-image: none;
-  --vp-home-hero-image-filter: none;
-}
+    --vp-home-hero-image-background-image: none;
+    --vp-home-hero-image-filter: none;
+  }
 
-/**
+  /**
  * Component: Badge
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-badge-info-border: transparent;
-  --vp-badge-info-text: var(--vp-c-text-2);
-  --vp-badge-info-bg: var(--vp-c-default-soft);
+  :root {
+    --vp-badge-info-border: transparent;
+    --vp-badge-info-text: var(--vp-c-text-2);
+    --vp-badge-info-bg: var(--vp-c-default-soft);
 
-  --vp-badge-tip-border: transparent;
-  --vp-badge-tip-text: var(--vp-c-tip-1);
-  --vp-badge-tip-bg: var(--vp-c-tip-soft);
+    --vp-badge-tip-border: transparent;
+    --vp-badge-tip-text: var(--vp-c-tip-1);
+    --vp-badge-tip-bg: var(--vp-c-tip-soft);
 
-  --vp-badge-warning-border: transparent;
-  --vp-badge-warning-text: var(--vp-c-warning-1);
-  --vp-badge-warning-bg: var(--vp-c-warning-soft);
+    --vp-badge-warning-border: transparent;
+    --vp-badge-warning-text: var(--vp-c-warning-1);
+    --vp-badge-warning-bg: var(--vp-c-warning-soft);
 
-  --vp-badge-danger-border: transparent;
-  --vp-badge-danger-text: var(--vp-c-danger-1);
-  --vp-badge-danger-bg: var(--vp-c-danger-soft);
-}
+    --vp-badge-danger-border: transparent;
+    --vp-badge-danger-text: var(--vp-c-danger-1);
+    --vp-badge-danger-bg: var(--vp-c-danger-soft);
+  }
 
-/**
+  /**
  * Component: Carbon Ads
  * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-carbon-ads-text-color: var(--vp-c-text-1);
-  --vp-carbon-ads-poweredby-color: var(--vp-c-text-2);
-  --vp-carbon-ads-bg-color: var(--vp-c-bg-soft);
-  --vp-carbon-ads-hover-text-color: var(--vp-c-brand-1);
-  --vp-carbon-ads-hover-poweredby-color: var(--vp-c-text-1);
-}
+  :root {
+    --vp-carbon-ads-text-color: var(--vp-c-text-1);
+    --vp-carbon-ads-poweredby-color: var(--vp-c-text-2);
+    --vp-carbon-ads-bg-color: var(--vp-c-bg-soft);
+    --vp-carbon-ads-hover-text-color: var(--vp-c-brand-1);
+    --vp-carbon-ads-hover-poweredby-color: var(--vp-c-text-1);
+  }
 
-/**
+  /**
   * Component: Local Search
   * -------------------------------------------------------------------------- */
 
-:root {
-  --vp-local-search-bg: var(--vp-c-bg);
-  --vp-local-search-result-bg: var(--vp-c-bg);
-  --vp-local-search-result-border: var(--vp-c-divider);
-  --vp-local-search-result-selected-bg: var(--vp-c-bg);
-  --vp-local-search-result-selected-border: var(--vp-c-brand-1);
-  --vp-local-search-highlight-bg: var(--vp-c-brand-1);
-  --vp-local-search-highlight-text: var(--vp-c-neutral-inverse);
+  :root {
+    --vp-local-search-bg: var(--vp-c-bg);
+    --vp-local-search-result-bg: var(--vp-c-bg);
+    --vp-local-search-result-border: var(--vp-c-divider);
+    --vp-local-search-result-selected-bg: var(--vp-c-bg);
+    --vp-local-search-result-selected-border: var(--vp-c-brand-1);
+    --vp-local-search-highlight-bg: var(--vp-c-brand-1);
+    --vp-local-search-highlight-text: var(--vp-c-neutral-inverse);
+  }
 }


### PR DESCRIPTION
**Problem I'm trying to solve:** 
I want to use Vitepress to document my own component library. The issue I have is that Vitepress' own styling sometimes override my own components. By putting all of Vitepress' own styles inside `@layer` we lower the specificity of those styles and make sure they are easily overridden.