### PR TITLE
fix(markdown/plugins/containers): use `Token.attrJoin` for rendering additional className

### DIFF
--- a/src/node/markdown/plugins/containers.ts
+++ b/src/node/markdown/plugins/containers.ts
@@ -64,15 +64,16 @@ function createContainer(
     {
       render(tokens, idx, _options, env: MarkdownEnv & { references?: any }) {
         const token = tokens[idx]
-        const info = token.info.trim().slice(klass.length).trim()
-        const attrs = md.renderer.renderAttrs(token)
         if (token.nesting === 1) {
+          token.attrJoin('class', `${klass} custom-block`)
+          const attrs = md.renderer.renderAttrs(token)
+          const info = token.info.trim().slice(klass.length).trim()
           const title = md.renderInline(info || defaultTitle, {
             references: env.references
           })
           if (klass === 'details')
-            return `<details class="${klass} custom-block"${attrs}><summary>${title}</summary>\n`
-          return `<div class="${klass} custom-block"${attrs}><p class="custom-block-title">${title}</p>\n`
+            return `<details ${attrs}><summary>${title}</summary>\n`
+          return `<div ${attrs}><p class="custom-block-title">${title}</p>\n`
         } else return klass === 'details' ? `</details>\n` : `</div>\n`
       }
     }


### PR DESCRIPTION
### Description

while there is an additional css className, for eg: `.my-class` onto the custom containers, vitepress is crashed with sth like:

```
11:19:56 PM [vitepress] Internal server error: Duplicate attribute.
```

The markdown content like below,

```
::: info {.my-class id=test}
hello
:::
```

Using the `Token.attrJoin` method is solved this problem, rendering as below:

```html
<div class="my-class info custom-block" id="test">
  <p class="custom-block-title">INFO</p>
  <p>hello</p>
</div>
```

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
