### PR TITLE
docs: add group icon

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -4,6 +4,7 @@ import { search as ptSearch } from './pt'
 import { search as ruSearch } from './ru'
 import { search as esSearch } from './es'
 import { search as koSearch } from './ko'
+import { groupIconPlugin } from 'vitepress-plugin-group-icons'
 
 export const shared = defineConfig({
   title: 'VitePress',
@@ -25,7 +26,10 @@ export const shared = defineConfig({
           return code.replace(/\[\!\!code/g, '[!code')
         }
       }
-    ]
+    ],
+    config: (md) => {
+      md.use(groupIconPlugin)
+    }
   },
 
   sitemap: {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,10 @@
+import DefaultTheme from 'vitepress/theme'
+import type { EnhanceAppContext } from 'vitepress'
+import { GroupIconComponent } from 'vitepress-plugin-group-icons/client'
+
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }: EnhanceAppContext) {
+    app.use(GroupIconComponent)
+  },
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -6,5 +6,5 @@ export default {
   extends: DefaultTheme,
   enhanceApp({ app }: EnhanceAppContext) {
     app.use(GroupIconComponent)
-  },
+  }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "@lunariajs/core": "^0.1.1",
     "markdown-it-mathjax3": "^4.3.2",
     "open-cli": "^8.0.0",
-    "vitepress": "workspace:*"
+    "vitepress": "workspace:*",
+    "vitepress-plugin-group-icons": "^0.0.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       vitepress:
         specifier: workspace:*
         version: link:..
+      vitepress-plugin-group-icons:
+        specifier: ^0.0.9
+        version: 0.0.9(vitepress@)(vue@3.4.38(typescript@5.5.4))
 
 packages:
 
@@ -742,6 +745,17 @@ packages:
   '@hutson/parse-repository-url@5.0.0':
     resolution: {integrity: sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==}
     engines: {node: '>=10.13.0'}
+
+  '@iconify-json/logos@1.1.44':
+    resolution: {integrity: sha512-sIc355/sSq4GihU4eFTDVbXoeg2rZD3yH6tNOJTNouDu9Fx259BSWH+XEEQwm/YImDIllcGqmJuNBjAu4UVs2g==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/vue@4.1.2':
+    resolution: {integrity: sha512-CQnYqLiQD5LOAaXhBrmj1mdL2/NCJvwcC4jtW2Z8ukhThiFkLDkutarTOV2trfc9EXqUqRs0KqXOL9pZ/IyysA==}
+    peerDependencies:
+      vue: '>=3'
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2648,6 +2662,12 @@ packages:
       terser:
         optional: true
 
+  vitepress-plugin-group-icons@0.0.9:
+    resolution: {integrity: sha512-6kWyZZsf1xg9GuG+PK0CxKBFuCrxqwAfG/hurq3EaxBhCZY6KGJZG9neqJQwzKymor3+os4PRTv4KicdWCqcrA==}
+    peerDependencies:
+      vitepress: ^1.0.0
+      vue: ^3.0.0
+
   vitest@2.0.5:
     resolution: {integrity: sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3085,6 +3105,17 @@ snapshots:
       '@hapi/hoek': 9.3.0
 
   '@hutson/parse-repository-url@5.0.0': {}
+
+  '@iconify-json/logos@1.1.44':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/vue@4.1.2(vue@3.4.38(typescript@5.5.4))':
+    dependencies:
+      '@iconify/types': 2.0.0
+      vue: 3.4.38(typescript@5.5.4)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5026,6 +5057,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.4.0
       fsevents: 2.3.3
+
+  vitepress-plugin-group-icons@0.0.9(vitepress@)(vue@3.4.38(typescript@5.5.4)):
+    dependencies:
+      '@iconify-json/logos': 1.1.44
+      '@iconify/vue': 4.1.2(vue@3.4.38(typescript@5.5.4))
+      vitepress: 'link:'
+      vue: 3.4.38(typescript@5.5.4)
 
   vitest@2.0.5(@types/node@22.4.0)(supports-color@9.4.0):
     dependencies:


### PR DESCRIPTION
### Description

This PR add [vitepress-plugin-group-icons](https://github.com/yuyinws/vitepress-plugin-group-icons) to enhance the readability for `code-group`: 

#### After

<img width="766" alt="image" src="https://github.com/user-attachments/assets/31163b79-c7e1-4351-91ee-2efb71cb202c">


### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

This plugin already using by:

- [Rolldown](https://github.com/rolldown/rolldown/blob/main/docs/.vitepress/config.ts) 
- [UnoCSS](https://github.com/unocss/unocss/blob/main/docs/.vitepress/config.ts)
- [vue-macros](https://github.com/vue-macros/vue-macros/blob/main/docs/.vitepress/config.ts)

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
