### PR TITLE
feat: add `data-title` attribute for code group label tag

### DIFF
--- a/src/node/markdown/plugins/containers.ts
+++ b/src/node/markdown/plugins/containers.ts
@@ -111,7 +111,7 @@ function createCodeGroup(options: Options): ContainerArgs {
 
               if (title) {
                 const id = nanoid(7)
-                tabs += `<input type="radio" name="group-${name}" id="tab-${id}" ${checked}><label for="tab-${id}">${title}</label>`
+                tabs += `<input type="radio" name="group-${name}" id="tab-${id}" ${checked}><label data-title="${title}" for="tab-${id}">${title}</label>`
 
                 if (checked && !isHtml) tokens[i].info += ' active'
                 checked = ''

--- a/src/node/markdown/plugins/containers.ts
+++ b/src/node/markdown/plugins/containers.ts
@@ -48,7 +48,7 @@ export const containerPlugin = (
       render: (tokens: Token[], idx: number) =>
         tokens[idx].nesting === 1 ? `<div class="vp-raw">\n` : `</div>\n`
     })
-    .use(...createCodeGroup(options))
+    .use(...createCodeGroup(options, md))
 }
 
 type ContainerArgs = [typeof container, string, { render: RenderRule }]
@@ -79,7 +79,7 @@ function createContainer(
   ]
 }
 
-function createCodeGroup(options: Options): ContainerArgs {
+function createCodeGroup(options: Options, md: MarkdownIt): ContainerArgs {
   return [
     container,
     'code-group',
@@ -111,7 +111,7 @@ function createCodeGroup(options: Options): ContainerArgs {
 
               if (title) {
                 const id = nanoid(7)
-                tabs += `<input type="radio" name="group-${name}" id="tab-${id}" ${checked}><label data-title="${title}" for="tab-${id}">${title}</label>`
+                tabs += `<input type="radio" name="group-${name}" id="tab-${id}" ${checked}><label data-title="${md.utils.escapeHtml(title)}" for="tab-${id}">${title}</label>`
 
                 if (checked && !isHtml) tokens[i].info += ' active'
                 checked = ''


### PR DESCRIPTION
### Description

This PR add a new attribute called `data-title` for code group label tag. Will be helpful when downstream plugins want to get the title data.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

[Previous discussion](https://github.com/vuejs/vitepress/pull/4147#issuecomment-2294905461)

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
