### PR TITLE
chore: fix typo in theme template

### DIFF
--- a/template/.vitepress/theme/style.css
+++ b/template/.vitepress/theme/style.css
@@ -28,7 +28,7 @@
  *   custom containers.
  *
  * - `default`: The color used purely for subtle indication without any
- *   special meanings attched to it such as bg color for menu hover state.
+ *   special meanings attached to it such as bg color for menu hover state.
  *
  * - `brand`: Used for primary brand colors, such as link text, button with
  *   brand theme, etc.


### PR DESCRIPTION
### Description

When choosing the `Default Theme + Customization` option in the Theme section while running `vitepress init`, the generated "`.vitepress/theme/style.css`" contains a typo, so I fixed it.

### Linked Issues

None.

### Additional Context

None.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
