### PR TITLE
fix(theme): respect custom tag prop in VPButton component

### DIFF
--- a/src/client/theme-default/components/VPButton.vue
+++ b/src/client/theme-default/components/VPButton.vue
@@ -22,7 +22,7 @@ const isExternal = computed(
 )
 
 const component = computed(() => {
-  return props.tag || props.href ? 'a' : 'button'
+  return props.tag || (props.href ? 'a' : 'button')
 })
 </script>
 


### PR DESCRIPTION
### Description

This PR fixes a bug in the VPButton component of the default VitePress theme. Previously, the `tag` prop was not being properly respected when determining the component to render. This change ensures that the `tag` prop takes precedence, falling back to `a` or `button` based on the presence of the `href` prop only if no custom tag is specified.

Here's a simple script that demonstrates the effect of this change:

```javascript
const props = {
  tag: 'div',
  href: undefined,
}

// Before: Incorrectly evaluates to 'a'
const component = props.tag || props.href ? 'a' : 'button'

// After: Correctly evaluates to 'div'
const fixed = props.tag || (props.href ? 'a' : 'button')
```

In this example, even though we specify a custom tag 'div' and there's no href, the original code would incorrectly choose 'a'. The fixed version correctly respects the custom tag 'div'.

### Linked Issues

None.

### Additional Context

None.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
