### PR TITLE
docs(ko): fix typos in documentation

### DIFF
--- a/docs/ko/guide/i18n.md
+++ b/docs/ko/guide/i18n.md
@@ -27,7 +27,7 @@ export default defineConfig({
     fr: {
       label: '프랑스어',
       lang: 'fr', // 선택 사항, `html` 태그에 `lang` 어트리뷰트로 추가됩니다
-      link: '/fr/guide' // 기본적으로 /fr/ -- navbar 변역 메뉴에 표시됩니다 (외부 링크 가능)
+      link: '/fr/guide' // 기본적으로 /fr/ -- navbar 번역 메뉴에 표시됩니다 (외부 링크 가능)
 
       // 다른 로케일 특유의 프로퍼티...
     }


### PR DESCRIPTION
### Description

변역 -> 번역

fix typos

### Linked Issues



### Additional Context

