### PR TITLE
Fix documentation regarding anchor links

### DIFF
--- a/docs/en/guide/markdown.md
+++ b/docs/en/guide/markdown.md
@@ -44,7 +44,7 @@ And providing you are in `foo/one.md`:
 ```md
 [Home](/) <!-- sends the user to the root index.md -->
 [foo](/foo/) <!-- sends the user to index.html of directory foo -->
-[foo heading](./#heading) <!-- anchors user to a heading in the foo index file -->
+[foo heading](#heading) <!-- anchors user to a heading in the foo index file -->
 [bar - three](../bar/three) <!-- you can omit extension -->
 [bar - three](../bar/three.md) <!-- you can append .md -->
 [bar - four](../bar/four.html) <!-- or you can append .html -->


### PR DESCRIPTION
Working with vitepress v1.3.3, I noticed a link in the format `./#heading` does not work / leads to a docs generation error, whereas `#heading` works for me. Hence this PR.

### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
