### PR TITLE
docs: Update deploy.md

### DIFF
--- a/docs/zh/guide/deploy.md
+++ b/docs/zh/guide/deploy.md
@@ -110,7 +110,7 @@ Cache-Control: max-age=31536000,immutable
 使用仪表板创建新项目并更改这些设置：
 
 - **构建命令：** `npm run docs:build`
-- **输出目录：** `docs/.vitepress/dist`
+- **输出目录：** `.vitepress/dist`
 - **node 版本：** `18` (或更高版本)
 
 ::: warning


### PR DESCRIPTION
### Description

An output directory of `docs/.vitepress/dist` will cause vercel to be unable to find the dist directory, so you need to change the output directory to `.vitepress/dist`.

### Linked Issues

I didn't create an issue

### Additional Context

I tried to deploy vitepress on vercel, but when filling in the project output path, I found that the path in the docs didn't exist, so I deleted `docs/` before `.vitepress/dist`
