### PR TITLE
fix(theme): change the order of CSS rules of  `VPFlyout`

### DIFF
--- a/src/client/theme-default/components/VPFlyout.vue
+++ b/src/client/theme-default/components/VPFlyout.vue
@@ -78,16 +78,16 @@ function onBlur() {
   color: var(--vp-c-brand-2);
 }
 
+.button[aria-expanded="false"] + .menu {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(0);
+}
+
 .VPFlyout:hover .menu,
 .button[aria-expanded="true"] + .menu {
   opacity: 1;
   visibility: visible;
-  transform: translateY(0);
-}
-
-.button[aria-expanded="false"] + .menu {
-  opacity: 0;
-  visibility: hidden;
   transform: translateY(0);
 }
 


### PR DESCRIPTION
### Description

This PR changes the order of CSS rules of `VPFlyout`, making it work without JavaScript.

### Linked Issues

Fixes #4224

<!-- e.g. fixes #123 -->

### Additional Context

```
|--------|
| CSS is |
| awe-   | some.
|--------|
```

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
