### PR TITLE
chore: update DocSearch version

### DIFF
--- a/docs/en/reference/default-theme-search.md
+++ b/docs/en/reference/default-theme-search.md
@@ -296,7 +296,7 @@ new Crawler({
             lvl1: '.content h1',
             content: '.content p, .content li',
             lvl0: {
-              selectors: '',
+              selectors: 'section.has-active div h2',
               defaultValue: 'Documentation'
             },
             lvl2: '.content h2',

--- a/docs/es/reference/default-theme-search.md
+++ b/docs/es/reference/default-theme-search.md
@@ -289,7 +289,7 @@ new Crawler({
             lvl1: '.content h1',
             content: '.content p, .content li',
             lvl0: {
-              selectors: '',
+              selectors: 'section.has-active div h2',
               defaultValue: 'Documentation'
             },
             lvl2: '.content h2',

--- a/docs/ko/reference/default-theme-search.md
+++ b/docs/ko/reference/default-theme-search.md
@@ -296,7 +296,7 @@ new Crawler({
             lvl1: '.content h1',
             content: '.content p, .content li',
             lvl0: {
-              selectors: '',
+              selectors: 'section.has-active div h2',
               defaultValue: 'Documentation'
             },
             lvl2: '.content h2',

--- a/docs/pt/reference/default-theme-search.md
+++ b/docs/pt/reference/default-theme-search.md
@@ -289,7 +289,7 @@ new Crawler({
             lvl1: '.content h1',
             content: '.content p, .content li',
             lvl0: {
-              selectors: '',
+              selectors: 'section.has-active div h2',
               defaultValue: 'Documentation'
             },
             lvl2: '.content h2',

--- a/docs/ru/reference/default-theme-search.md
+++ b/docs/ru/reference/default-theme-search.md
@@ -299,7 +299,7 @@ new Crawler({
             lvl1: '.content h1',
             content: '.content p, .content li',
             lvl0: {
-              selectors: '',
+              selectors: 'section.has-active div h2',
               defaultValue: 'Documentation'
             },
             lvl2: '.content h2',

--- a/docs/zh/reference/default-theme-search.md
+++ b/docs/zh/reference/default-theme-search.md
@@ -289,7 +289,7 @@ new Crawler({
             lvl1: '.content h1',
             content: '.content p, .content li',
             lvl0: {
-              selectors: '',
+              selectors: 'section.has-active div h2',
               defaultValue: 'Documentation'
             },
             lvl2: '.content h2',

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
     "*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@docsearch/css": "^3.6.1",
-    "@docsearch/js": "^3.6.1",
+    "@docsearch/css": "^3.6.2",
+    "@docsearch/js": "^3.6.2",
     "@shikijs/core": "^1.15.2",
     "@shikijs/transformers": "^1.15.2",
     "@types/markdown-it": "^14.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,11 +17,11 @@ importers:
   .:
     dependencies:
       '@docsearch/css':
-        specifier: ^3.6.1
-        version: 3.6.1
+        specifier: ^3.6.2
+        version: 3.6.2
       '@docsearch/js':
-        specifier: ^3.6.1
-        version: 3.6.1(@algolia/client-search@4.24.0)
+        specifier: ^3.6.2
+        version: 3.6.2(@algolia/client-search@4.24.0)
       '@shikijs/core':
         specifier: ^1.15.2
         version: 1.15.2
@@ -428,14 +428,14 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@docsearch/css@3.6.1':
-    resolution: {integrity: sha512-VtVb5DS+0hRIprU2CO6ZQjK2Zg4QU5HrDM1+ix6rT0umsYvFvatMAnf97NHZlVWDaaLlx7GRfR/7FikANiM2Fg==}
+  '@docsearch/css@3.6.2':
+    resolution: {integrity: sha512-vKNZepO2j7MrYBTZIGXvlUOIR+v9KRf70FApRgovWrj3GTs1EITz/Xb0AOlm1xsQBp16clVZj1SY/qaOJbQtZw==}
 
-  '@docsearch/js@3.6.1':
-    resolution: {integrity: sha512-erI3RRZurDr1xES5hvYJ3Imp7jtrXj6f1xYIzDzxiS7nNBufYWPbJwrmMqWC5g9y165PmxEmN9pklGCdLi0Iqg==}
+  '@docsearch/js@3.6.2':
+    resolution: {integrity: sha512-pS4YZF+VzUogYrkblCucQ0Oy2m8Wggk8Kk7lECmZM60hTbaydSIhJTTiCrmoxtBqV8wxORnOqcqqOfbmkkQEcA==}
 
-  '@docsearch/react@3.6.1':
-    resolution: {integrity: sha512-qXZkEPvybVhSXj0K7U3bXc233tk5e8PfhoZ6MhPOiik/qUQxYC+Dn9DnoS7CxHQQhHfCvTiN0eY9M12oRghEXw==}
+  '@docsearch/react@3.6.2':
+    resolution: {integrity: sha512-rtZce46OOkVflCQH71IdbXSFK+S8iJZlUF56XBW5rIgx/eG5qoomC7Ag3anZson1bBac/JFQn7XOBfved/IMRA==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
       react: '>= 16.8.0 < 19.0.0'
@@ -2912,11 +2912,11 @@ snapshots:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
 
-  '@docsearch/css@3.6.1': {}
+  '@docsearch/css@3.6.2': {}
 
-  '@docsearch/js@3.6.1(@algolia/client-search@4.24.0)':
+  '@docsearch/js@3.6.2(@algolia/client-search@4.24.0)':
     dependencies:
-      '@docsearch/react': 3.6.1(@algolia/client-search@4.24.0)
+      '@docsearch/react': 3.6.2(@algolia/client-search@4.24.0)
       preact: 10.23.2
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -2925,11 +2925,11 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@docsearch/react@3.6.1(@algolia/client-search@4.24.0)':
+  '@docsearch/react@3.6.2(@algolia/client-search@4.24.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)
       '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)
-      '@docsearch/css': 3.6.1
+      '@docsearch/css': 3.6.2
       algoliasearch: 4.24.0
     transitivePeerDependencies:
       - '@algolia/client-search'


### PR DESCRIPTION
### Description

This PR updates DocSearch to its latest version.

There was a regression on the DocSearch indexing side, which broke the `lvl0` header (used to create search results section). We released a library side fix in order to prevent impacting the quality of the searches in the meantime of the indexing fix, and also prevent future regressions.

I also updated your Crawler config (cc @yyx990803), so that search results are not grouped under `documentation`, but the same nav title as the website's sidebar

A release of vitepress with this fix applied should also fix the https://vuejs.org/ and other vitepress powered websites

### Preview

The current https://vitepress.dev/ results:

<img width="610" alt="Screenshot 2024-09-28 at 16 24 43" src="https://github.com/user-attachments/assets/37c8b68f-0c60-4c69-9943-898a6f9cada1">

With the fix applied:

<img width="841" alt="Screenshot 2024-09-28 at 16 25 09" src="https://github.com/user-attachments/assets/66886287-f259-4c88-bb27-71711abed26d">
