### PR TITLE
Fix `vueRE` conflicting with `lineNoRE`

### DIFF
--- a/src/node/markdown/plugins/highlight.ts
+++ b/src/node/markdown/plugins/highlight.ts
@@ -90,7 +90,7 @@ export async function highlight(
     }
   ]
 
-  const vueRE = /-vue$/
+  const vueRE = /-vue(?=:|$)/
   const lineNoStartRE = /=(\d*)/
   const lineNoRE = /:(no-)?line-numbers(=\d*)?$/
   const mustacheRE = /\{\{.*?\}\}/g


### PR DESCRIPTION
This resolves, e.g.:
````md
```json-vue:line-numbers
{{ theme }}
```
````
and
````md
```json-vue:no-line-numbers
{{ theme }}
```
````
