### PR TITLE
fix(theme): bind missing no icon prop in the menu link component

### DIFF
--- a/src/client/theme-default/components/VPMenuLink.vue
+++ b/src/client/theme-default/components/VPMenuLink.vue
@@ -18,6 +18,7 @@ const { page } = useData()
       :href="item.link"
       :target="item.target"
       :rel="item.rel"
+      :no-icon="item.noIcon"
     >
       {{ item.text }}
     </VPLink>

--- a/src/client/theme-default/components/VPMenuLink.vue
+++ b/src/client/theme-default/components/VPMenuLink.vue
@@ -19,9 +19,8 @@ const { page } = useData()
       :target="item.target"
       :rel="item.rel"
       :no-icon="item.noIcon"
-    >
-      {{ item.text }}
-    </VPLink>
+      v-html="item.text"
+    />
   </div>
 </template>
 

--- a/src/client/theme-default/components/VPNavBarMenuLink.vue
+++ b/src/client/theme-default/components/VPNavBarMenuLink.vue
@@ -22,13 +22,12 @@ const { page } = useData()
       )
     }"
     :href="item.link"
-    :noIcon="item.noIcon"
     :target="item.target"
     :rel="item.rel"
+    :no-icon="item.noIcon"
     tabindex="0"
-  >
-    <span v-html="item.text"></span>
-  </VPLink>
+    v-html="item.text"
+  />
 </template>
 
 <style scoped>

--- a/src/client/theme-default/components/VPNavScreenMenuGroupLink.vue
+++ b/src/client/theme-default/components/VPNavScreenMenuGroupLink.vue
@@ -16,10 +16,10 @@ const closeScreen = inject('close-screen') as () => void
     :href="item.link"
     :target="item.target"
     :rel="item.rel"
+    :no-icon="item.noIcon"
     @click="closeScreen"
-  >
-    {{ item.text }}
-  </VPLink>
+    v-html="item.text"
+  />
 </template>
 
 <style scoped>

--- a/src/client/theme-default/components/VPNavScreenMenuLink.vue
+++ b/src/client/theme-default/components/VPNavScreenMenuLink.vue
@@ -16,6 +16,7 @@ const closeScreen = inject('close-screen') as () => void
     :href="item.link"
     :target="item.target"
     :rel="item.rel"
+    :no-icon="item.noIcon"
     @click="closeScreen"
     v-html="item.text"
   />


### PR DESCRIPTION
Building upon #3607 it would be nice to have such control over the dropdown menu links as well.

## Use Case

```js
export default {
  themeConfig: {
    nav: [
      {
        text: 'Current release',
        items: [
          text: 'Next release',
          link: 'https://next.example.com',
          target: '_self',
          noIcon: true, // don't want the external link icon here, even though it's on a different domain
        ],
      },
    ],
  },
}
```