### PR TITLE
use `usePreferredDark` with `appearance: "force-auto"`

### DIFF
--- a/src/client/app/data.ts
+++ b/src/client/app/data.ts
@@ -80,14 +80,14 @@ export function initData(route: Route): VitePressData {
     appearance === 'force-dark'
       ? ref(true)
       : appearance === 'force-auto'
-      ? usePreferredDark()
-      : appearance
-      ? useDark({
-          storageKey: APPEARANCE_KEY,
-          initialValue: () => (appearance === 'dark' ? 'dark' : 'auto'),
-          ...(typeof appearance === 'object' ? appearance : {})
-        })
-      : ref(false)
+        ? usePreferredDark()
+        : appearance
+          ? useDark({
+              storageKey: APPEARANCE_KEY,
+              initialValue: () => (appearance === 'dark' ? 'dark' : 'auto'),
+              ...(typeof appearance === 'object' ? appearance : {})
+            })
+          : ref(false)
 
   const hashRef = ref(inBrowser ? location.hash : '')
 

--- a/src/client/app/data.ts
+++ b/src/client/app/data.ts
@@ -1,5 +1,5 @@
 import siteData from '@siteData'
-import { useDark } from '@vueuse/core'
+import { useDark, usePreferredDark } from '@vueuse/core'
 import {
   computed,
   inject,
@@ -79,13 +79,15 @@ export function initData(route: Route): VitePressData {
   const isDark =
     appearance === 'force-dark'
       ? ref(true)
+      : appearance === 'force-auto'
+      ? usePreferredDark()
       : appearance
-        ? useDark({
-            storageKey: APPEARANCE_KEY,
-            initialValue: () => (appearance === 'dark' ? 'dark' : 'auto'),
-            ...(typeof appearance === 'object' ? appearance : {})
-          })
-        : ref(false)
+      ? useDark({
+          storageKey: APPEARANCE_KEY,
+          initialValue: () => (appearance === 'dark' ? 'dark' : 'auto'),
+          ...(typeof appearance === 'object' ? appearance : {})
+        })
+      : ref(false)
 
   const hashRef = ref(inBrowser ? location.hash : '')
 


### PR DESCRIPTION
### Description

The `appearance: "force-auto"` implemented in #3946 1e8bb48 has a small bug where if the user had previously set the preferred color scheme using the appearance toggle, then `useDark` would retain that preference from local storage rather than respecting the system color scheme. This switches to [`usePreferredDark`](https://vueuse.org/core/usePreferredDark/) for `"force-auto"`, thereby ignoring whatever is (or was) in local storage and always respecting the system color scheme.

### Linked Issues

#3946

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
