### PR TITLE
feat(cli): support custom `srcDir`

### DIFF
--- a/src/node/init/init.ts
+++ b/src/node/init/init.ts
@@ -21,6 +21,7 @@ export enum ScaffoldThemeType {
 
 export interface ScaffoldOptions {
   root: string
+  srcDir: string
   title?: string
   description?: string
   theme: ScaffoldThemeType
@@ -47,6 +48,13 @@ export async function init(root: string | undefined) {
           validate(value) {
             // TODO make sure directory is inside
           }
+        })
+      },
+
+      srcDir: async () => {
+        return text({
+          message: 'Where should VitePress look for your markdown files?',
+          initialValue: './'
         })
       },
 
@@ -108,6 +116,7 @@ export async function init(root: string | undefined) {
 
 export function scaffold({
   root = './',
+  srcDir = './',
   title = 'My Awesome Project',
   description = 'A VitePress Site',
   theme,
@@ -115,12 +124,14 @@ export function scaffold({
   injectNpmScripts
 }: ScaffoldOptions): string {
   const resolvedRoot = path.resolve(root)
+  const resolvedSrcDir = path.resolve(root, srcDir)
   const templateDir = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     '../../template'
   )
 
   const data = {
+    srcDir: srcDir === './' ? undefined : JSON.stringify(srcDir), // omit if default
     title: JSON.stringify(title),
     description: JSON.stringify(description),
     useTs,
@@ -139,14 +150,20 @@ export function scaffold({
   const renderFile = (file: string) => {
     const filePath = path.resolve(templateDir, file)
     let targetPath = path.resolve(resolvedRoot, file)
+
     if (useMjs && file === '.vitepress/config.js') {
       targetPath = targetPath.replace(/\.js$/, '.mjs')
     }
     if (useTs) {
       targetPath = targetPath.replace(/\.(m?)js$/, '.$1ts')
     }
-    const src = fs.readFileSync(filePath, 'utf-8')
-    const compiled = template(src)(data)
+    if (file.endsWith('.md')) {
+      targetPath = path.resolve(resolvedSrcDir, file)
+    }
+
+    const content = fs.readFileSync(filePath, 'utf-8')
+    const compiled = template(content)(data)
+
     fs.outputFileSync(targetPath, compiled)
   }
 

--- a/template/.vitepress/config.js
+++ b/template/.vitepress/config.js
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitepress'
 
 // https://vitepress.dev/reference/site-config
-export default defineConfig({
+export default defineConfig({<% if (srcDir) { %>
+  srcDir: <%= srcDir %>,
+  <% } %>
   title: <%= title %>,
   description: <%= description %><% if (defaultTheme) { %>,
   themeConfig: {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

Hello 👋,

This PR introduces a new scaffolding parameter to ask the developer where Markdown files should be stored. This is related to the [`srcDir`](https://vitepress.dev/reference/site-config#srcdir) parameter in the `vitepress.config.js` file.

For blogs, portfolios, and marketing sites, or any sites that use VitePress as the main project (without a `docs` folder), having a `src` folder is more intuitive and I think a better architecture than having every Markdown files at the root of the project. The file `.vitepress/config.{js,ts}` can stay at the root of the project.

The architecture of the project will look like this:

```txt
.
├── src
|   ├── file.md
|   └── file2.md
└── .vitepress
    └── config.{js,ts}
```

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
I'm building a tutorial on how to [create a blog with VitePress and Vue.js from scratch](https://soubiran.dev/series/create-a-blog-with-vitepress-and-vue-js-from-scratch). I used a lot VitePress for documentation, and it was fine. But for blogs, portfolios, and marketing sites, as mentioned in the [VitePress documentation](https://vitepress.dev/guide/what-is-vitepress#:~:text=Blogs%2C%20Portfolios%2C%20and,on%20local%20content.), I think the CLI needs some adjustments to make it easier to use and less documentation's oriented.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
