### PR TITLE
Update srcExclude type

### DIFF
--- a/docs/en/reference/site-config.md
+++ b/docs/en/reference/site-config.md
@@ -387,7 +387,7 @@ export default {
 
 ### srcExclude
 
-- Type: `string`
+- Type: `string[]`
 - Default: `undefined`
 
 A [glob pattern](https://github.com/mrmlnc/fast-glob#pattern-syntax) for matching markdown files that should be excluded as source content.


### PR DESCRIPTION
### Description

`srcExclude` type definition supports an array of strings.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
