### PR TITLE
fix(localSearch): update indexing logic to handle MiniSearch duplicate ID

### DIFF
--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -134,6 +134,9 @@ export async function localSearchPlugin(
       if (!section || !(section.text || section.titles)) break
       const { anchor, text, titles } = section
       const id = anchor ? [fileId, anchor].join('#') : fileId
+      if (index.has(id)) {
+        index.discard(id)
+      }
       index.add({
         id,
         text,


### PR DESCRIPTION
### Description
Introduce a check to discard duplicate IDs before adding them to the index in the localSearchPlugin. This ensures that each ID is uniquely indexed, preventing any potential overwriting of existing entries. The modification enhances the reliability and accuracy of the local search functionality.

### Linked Issues
fixes #4251
