### PR TITLE
fix(deadlinks): Check if public file exists

### DIFF
--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -176,9 +176,15 @@ export async function createMarkdownToVueRenderFn(
         )
         resolved =
           siteConfig?.rewrites.inv[resolved + '.md']?.slice(0, -3) || resolved
+
+        const htmlFileExists = fs.existsSync(path.resolve(dir, publicDir, `${resolved}.html`))
+        const checkIfPublicFileExists = fs.existsSync(path.resolve(dir, publicDir, resolved))
+
         if (
           !pages.includes(resolved) &&
-          !fs.existsSync(path.resolve(dir, publicDir, `${resolved}.html`)) &&
+          (
+            !htmlFileExists && !checkIfPublicFileExists
+          ) &&
           !shouldIgnoreDeadLink(url)
         ) {
           recordDeadLink(url)
@@ -273,15 +279,14 @@ function injectPageDataCode(tags: string[], data: PageData) {
     tags[existingScriptIndex] = tagSrc.replace(
       scriptRE,
       code +
-        (hasDefaultExport
-          ? ``
-          : `\nexport default {name:${JSON.stringify(data.relativePath)}}`) +
-        `</script>`
+      (hasDefaultExport
+        ? ``
+        : `\nexport default {name:${JSON.stringify(data.relativePath)}}`) +
+      `</script>`
     )
   } else {
     tags.unshift(
-      `<script ${
-        isUsingTS ? 'lang="ts"' : ''
+      `<script ${isUsingTS ? 'lang="ts"' : ''
       }>${code}\nexport default {name:${JSON.stringify(
         data.relativePath
       )}}</script>`

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -177,14 +177,17 @@ export async function createMarkdownToVueRenderFn(
         resolved =
           siteConfig?.rewrites.inv[resolved + '.md']?.slice(0, -3) || resolved
 
-        const htmlFileExists = fs.existsSync(path.resolve(dir, publicDir, `${resolved}.html`))
-        const checkIfPublicFileExists = fs.existsSync(path.resolve(dir, publicDir, resolved))
+        const htmlFileExists = fs.existsSync(
+          path.resolve(dir, publicDir, `${resolved}.html`)
+        )
+        const checkIfPublicFileExists = fs.existsSync(
+          path.resolve(dir, publicDir, resolved)
+        )
 
         if (
           !pages.includes(resolved) &&
-          (
-            !htmlFileExists && !checkIfPublicFileExists
-          ) &&
+          !htmlFileExists &&
+          !checkIfPublicFileExists &&
           !shouldIgnoreDeadLink(url)
         ) {
           recordDeadLink(url)
@@ -279,14 +282,15 @@ function injectPageDataCode(tags: string[], data: PageData) {
     tags[existingScriptIndex] = tagSrc.replace(
       scriptRE,
       code +
-      (hasDefaultExport
-        ? ``
-        : `\nexport default {name:${JSON.stringify(data.relativePath)}}`) +
-      `</script>`
+        (hasDefaultExport
+          ? ``
+          : `\nexport default {name:${JSON.stringify(data.relativePath)}}`) +
+        `</script>`
     )
   } else {
     tags.unshift(
-      `<script ${isUsingTS ? 'lang="ts"' : ''
+      `<script ${
+        isUsingTS ? 'lang="ts"' : ''
       }>${code}\nexport default {name:${JSON.stringify(
         data.relativePath
       )}}</script>`


### PR DESCRIPTION
### Description

Currently if you have a file inside the `public/` folder like such as `public/files/example.xlsx` it will be flagged a dead link. So this just updates the `markdownToVue` file to check if it's a public file and it exists so it doesn't flag as dead link. 
Ie.
```md
[here](/files/example.xlsx)
```
The above would result in a dead link.

This was causing some build issues with a team of 10 people writing docs. Means they don't have to specify the full path to the file.

Happy to hear any feedback!

Thanks.