### PR TITLE
fix(theme): remove some explicit fonts

### DIFF
--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -270,9 +270,8 @@
 
 :root:where(:lang(zh)) {
   --vp-font-family-base: 'Punctuation SC', 'Inter', ui-sans-serif, system-ui,
-    'PingFang SC', 'Noto Sans CJK SC', 'Noto Sans SC', 'Heiti SC',
-    'Microsoft YaHei', 'DengXian', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  'PingFang SC', 'Noto Sans CJK SC', 'Noto Sans SC', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+  'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
 /**

--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -270,8 +270,8 @@
 
 :root:where(:lang(zh)) {
   --vp-font-family-base: 'Punctuation SC', 'Inter', ui-sans-serif, system-ui,
-  'PingFang SC', 'Noto Sans CJK SC', 'Noto Sans SC', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-  'Segoe UI Symbol', 'Noto Color Emoji';
+    'PingFang SC', 'Noto Sans CJK SC', 'Noto Sans SC', sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
 /**


### PR DESCRIPTION
### Description

These fonts before `sans-serif` have poor rendering on Windows, remove them so that users who don't have `PingFang SC` & `Noto Sans SC'` installed can still set their preferred fonts.
![image](https://github.com/user-attachments/assets/62bed7c1-377c-4f85-9a8e-c4795a11367d)


> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
