### PR TITLE
docs: add VS Code IntelliSense Support section

### DIFF
--- a/docs/en/guide/using-vue.md
+++ b/docs/en/guide/using-vue.md
@@ -254,3 +254,38 @@ import ComponentInHeader from '../../components/ComponentInHeader.vue'
   padding: 0 20px;
 }
 </style>
+
+
+## VS Code IntelliSense Support
+
+<!-- Based on https://github.com/vuejs/language-tools/pull/4321 -->
+
+Vue provides IntelliSense support out of the box via the [Vue - Official VS Code plugin](https://marketplace.visualstudio.com/items?itemName=Vue.volar). However, to enable it for `.md` files, you need to make some adjustments to the configuration files.
+
+
+1. Add `.md` pattern to the `include` and `vueCompilerOptions.vitePressExtensions` options in the tsconfig/jsconfig file:
+
+::: code-group
+```json [tsconfig.json]
+{
+  "include": [
+    "docs/**/*.ts",
+    "docs/**/*.vue",
+    "docs/**/*.md",
+  ],
+  "vueCompilerOptions": {
+    "vitePressExtensions": [".md"],
+  },
+}
+```
+:::
+
+2. Add `markdown` to the `vue.server.includeLanguages` option in the VS Code setting:
+
+::: code-group
+```json [.vscode/settings.json]
+{
+  "vue.server.includeLanguages": ["vue", "markdown"]
+}
+```
+:::

--- a/docs/es/guide/using-vue.md
+++ b/docs/es/guide/using-vue.md
@@ -254,3 +254,36 @@ import ComponentInHeader from '../../components/ComponentInHeader.vue'
   padding: 0 20px;
 }
 </style>
+
+## Soporte de IntelliSense en VS Code
+
+<!-- Based on https://github.com/vuejs/language-tools/pull/4321 -->
+
+Vue ofrece soporte para IntelliSense de forma predeterminada mediante el [Plugin oficial de Vue para VS Code](https://marketplace.visualstudio.com/items?itemName=Vue.volar). Sin embargo, para habilitarlo en archivos `.md`, es necesario realizar algunos ajustes en los archivos de configuración.
+
+1. Agrega el patrón `.md` a las opciones `include` y `vueCompilerOptions.vitePressExtensions` en el archivo tsconfig/jsconfig:
+
+::: code-group
+```json [tsconfig.json]
+{
+  "include": [
+    "docs/**/*.ts",
+    "docs/**/*.vue",
+    "docs/**/*.md",
+  ],
+  "vueCompilerOptions": {
+    "vitePressExtensions": [".md"],
+  },
+}
+```
+:::
+
+2. Agrega `markdown` a la opción `vue.server.includeLanguages` en el archivo de configuración de VS Code
+
+::: code-group
+```json [.vscode/settings.json]
+{
+  "vue.server.includeLanguages": ["vue", "markdown"]
+}
+```
+:::


### PR DESCRIPTION
### Description
 
 Based on this [Vue Language Tools - Merged PR](https://github.com/vuejs/language-tools/pull/4321), the steps to enable IntelliSense on `.md` files were added to the documentation on `english`  and `spanish`

### Linked Issues

closes #4290 
