### PR TITLE
Do not copy`lang` when copying text.

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -514,6 +514,7 @@
   z-index: 2;
   font-size: 12px;
   font-weight: 500;
+  user-select: none;
   color: var(--vp-code-lang-color);
   transition:
     color 0.4s,


### PR DESCRIPTION
### Description

Selecting all or using the mouse to select a long text will also copy the `language`, which is not desired.
<img width="798" alt="image" src="https://github.com/user-attachments/assets/84bf61a7-2727-48a1-b02e-fcb1ce9568a5">

The effect of Pr:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/0adafd2a-7dfa-415b-a98c-6771510bba9e">

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
