### PR TITLE
feat(theme): introduce independent search page

### DIFF
--- a/src/client/theme-default/Search.vue
+++ b/src/client/theme-default/Search.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import {
+  defineAsyncComponent,
+  ref
+} from 'vue'
+import { useData } from './composables/data'
+const { theme, site } = useData()
+
+const VPLocalSearchBox = __VP_LOCAL_SEARCH__
+  ? defineAsyncComponent(() => import('./components/VPLocalSearchBox.vue'))
+  : () => null
+
+const VPAlgoliaSearchBox = __ALGOLIA__
+  ? defineAsyncComponent(() => import('./components/VPAlgoliaSearchBox.vue'))
+  : () => null
+
+const provider = __ALGOLIA__ ? 'algolia' : __VP_LOCAL_SEARCH__ ? 'local' : ''
+
+const filterText = ref('');
+const handleFilterTextChange = (text: string) => {
+  filterText.value = text;
+  const newUrl = (new URL(window.location.href));
+  if (text) {
+    newUrl.searchParams.set('q', text)
+  } else {
+    newUrl.searchParams.delete('q');
+  }
+  history.replaceState({}, '', newUrl.href)
+}
+
+const title = site.value.title;
+</script>
+
+<template>
+  <div class="Search">
+    
+    <div class="search-wrapper">
+        <h1 class="title">{{ filterText ? `Search Results For "${filterText}"` : `Search ${title}` }}</h1>
+
+        <template v-if="provider === 'local'">
+            <VPLocalSearchBox @filter-change="handleFilterTextChange"/>
+        </template>
+
+        <template v-else-if="provider === 'algolia'">
+            <VPAlgoliaSearchBox
+                :algolia="theme.search?.options ?? theme.algolia"
+            />
+        </template>
+    </div>
+
+  </div>
+</template>
+
+<style scoped>
+  .search-wrapper {
+    position: relative;
+    padding: 12px;
+    margin: 32px auto 0;
+    width: min(100vw - 60px, 900px);
+  }
+  .title {
+    margin-bottom: 12px;
+    letter-spacing: -0.02em;
+    line-height: 40px;
+    font-size: 32px;
+    font-weight: 600;
+    outline: none;
+  }
+</style>

--- a/src/client/theme-default/components/VPContent.vue
+++ b/src/client/theme-default/components/VPContent.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import NotFound from '../NotFound.vue'
+import Search from '../Search.vue'
 import { useData } from '../composables/data'
 import { useSidebar } from '../composables/sidebar'
 import VPDoc from './VPDoc.vue'
@@ -19,7 +20,8 @@ const { hasSidebar } = useSidebar()
       'is-home': frontmatter.layout === 'home'
     }"
   >
-    <slot name="not-found" v-if="page.isNotFound"><NotFound /></slot>
+    <slot name="search" v-if="page.isSearch"><Search /></slot>
+    <slot name="not-found" v-else-if="page.isNotFound"><NotFound /></slot>
 
     <VPPage v-else-if="frontmatter.layout === 'page'">
       <template #page-top><slot name="page-top" /></template>

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -22,7 +22,9 @@ defineEmits<{
 
 const { y } = useWindowScroll()
 const { hasSidebar } = useSidebar()
-const { frontmatter } = useData()
+const { frontmatter, page } = useData()
+
+const isSearchPage = page.value.isSearch
 
 const classes = ref<Record<string, boolean>>({})
 
@@ -50,7 +52,7 @@ watchPostEffect(() => {
         <div class="content">
           <div class="content-body">
             <slot name="nav-bar-content-before" />
-            <VPNavBarSearch class="search" />
+            <VPNavBarSearch class="search" v-if="!isSearchPage"/>
             <VPNavBarMenu class="menu" />
             <VPNavBarTranslations class="translations" />
             <VPNavBarAppearance class="appearance" />

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -31,7 +31,20 @@ export const notFoundPageData: PageData = {
   headers: [],
   frontmatter: { sidebar: false, layout: 'page' },
   lastUpdated: 0,
-  isNotFound: true
+  isNotFound: true,
+  isSearch: false
+}
+
+export const searchPageData: PageData = {
+  relativePath: 'search.md',
+  filePath: '',
+  title: 'Search',
+  description: 'Search Page',
+  headers: [],
+  frontmatter: { sidebar: false, layout: 'page' },
+  lastUpdated: 0,
+  isNotFound: false,
+  isSearch: true
 }
 
 export function isActive(

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -19,6 +19,7 @@ export interface PageData {
   frontmatter: Record<string, any>
   params?: Record<string, any>
   isNotFound?: boolean
+  isSearch?: boolean
   lastUpdated?: number
 }
 


### PR DESCRIPTION
### Description

Implements an independent search page on the route `/search/` to allow for OpenSearch / Custom Search Engines to query the site.

Utilises the `q` search parameter to preload the search term on page load. E.G `https://localhost:5713/search?q=api`

<img width="1330" alt="image" src="https://github.com/user-attachments/assets/78f812e6-c480-409b-abc7-7b5cbf07d361">

### Linked Issues
 
#2983 
#4327 

### Additional Context

- Currently only Local Search is supported. Algolia needs further work due to the modal.
- Primarily looking for feedback on the approach. Not a JS/FE dev, so apologies in advance for any bastardising. 
