### PR TITLE
chore: remove redundant spaces in theme template css

### DIFF
--- a/template/.vitepress/theme/style.css
+++ b/template/.vitepress/theme/style.css
@@ -8,7 +8,7 @@
  *
  * Each colors have exact same color scale system with 3 levels of solid
  * colors with different brightness, and 1 soft color.
- * 
+ *
  * - `XXX-1`: The most solid color used mainly for colored text. It must
  *   satisfy the contrast ratio against when used on top of `XXX-soft`.
  *
@@ -43,7 +43,7 @@
  *   in custom container, badges, etc.
  * -------------------------------------------------------------------------- */
 
- :root {
+:root {
   --vp-c-default-1: var(--vp-c-gray-1);
   --vp-c-default-2: var(--vp-c-gray-2);
   --vp-c-default-3: var(--vp-c-gray-3);


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

Removed redundant spaces in `style.css` in theme template. The first one is at the end of a comment line. The second one is before the `:root` selector.

### Linked Issues

<!-- e.g. fixes #123 -->

None.

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

None.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
