### PR TITLE
feat(theme): find best locale match to format last update

### DIFF
--- a/src/client/theme-default/components/VPDocFooterLastUpdated.vue
+++ b/src/client/theme-default/components/VPDocFooterLastUpdated.vue
@@ -9,12 +9,14 @@ const date = computed(
 )
 const isoDatetime = computed(() => date.value.toISOString())
 const datetime = ref('')
+const timeRef = ref<HTMLTimeElement>()
 
 // set time on mounted hook to avoid hydration mismatch due to
 // potential differences in timezones of the server and clients
 onMounted(() => {
+  const defaultLocale = Intl.DateTimeFormat().resolvedOptions().locale
   function findBestLocaleMatch(pageLocale: string) {
-    return navigator.languages.find((userLang) => {
+    const lang = navigator.languages.find((userLang) => {
       if (pageLocale === userLang)
         return true
 
@@ -27,7 +29,16 @@ onMounted(() => {
         return true
 
       return userLang.startsWith(pageLocale)
-    })
+    }) ?? defaultLocale
+
+    if (lang !== pageLocale) {
+      timeRef.value?.setAttribute('lang', lang)
+    }
+    else {
+      timeRef.value?.removeAttribute('lang')
+    }
+
+    return lang
   }
   watchEffect(() => {
     datetime.value = new Intl.DateTimeFormat(
@@ -46,7 +57,7 @@ onMounted(() => {
 <template>
   <p class="VPLastUpdated">
     {{ theme.lastUpdated?.text || theme.lastUpdatedText || 'Last updated' }}:
-    <time :datetime="isoDatetime">{{ datetime }}</time>
+    <time ref="timeRef" :datetime="isoDatetime">{{ datetime }}</time>
   </p>
 </template>
 

--- a/src/client/theme-default/components/VPDocFooterLastUpdated.vue
+++ b/src/client/theme-default/components/VPDocFooterLastUpdated.vue
@@ -13,20 +13,20 @@ const datetime = ref('')
 // set time on mounted hook to avoid hydration mismatch due to
 // potential differences in timezones of the server and clients
 onMounted(() => {
-  function findBestLocaleMatch(pageLocale: string): string | undefined {
+  function findBestLocaleMatch(pageLocale: string) {
     return navigator.languages.find((userLang) => {
       if (pageLocale === userLang)
-        return pageLocale
+        return true
 
       // Edge browser: case for ca-valencia
       if (pageLocale === 'ca-valencia' && userLang === 'ca-Es-VALENCIA')
-        return pageLocale
+        return true
 
       // add iso-639 support for Latin America
       if (userLang.startsWith('es-') && userLang !== 'es-ES' && pageLocale === 'es-419')
-        return pageLocale
+        return true
 
-      return userLang.startsWith(pageLocale) ? pageLocale : undefined
+      return userLang.startsWith(pageLocale)
     })
   }
   watchEffect(() => {

--- a/src/client/theme-default/components/VPDocFooterLastUpdated.vue
+++ b/src/client/theme-default/components/VPDocFooterLastUpdated.vue
@@ -13,9 +13,27 @@ const datetime = ref('')
 // set time on mounted hook to avoid hydration mismatch due to
 // potential differences in timezones of the server and clients
 onMounted(() => {
+  function findBestLocaleMatch(pageLocale: string): string | undefined {
+    return navigator.languages.find((userLang) => {
+      if (pageLocale === userLang)
+        return pageLocale
+
+      // Edge browser: case for ca-valencia
+      if (pageLocale === 'ca-valencia' && userLang === 'ca-Es-VALENCIA')
+        return pageLocale
+
+      // add iso-639 support for Latin America
+      if (userLang.startsWith('es-') && userLang !== 'es-ES' && pageLocale === 'es-419')
+        return pageLocale
+
+      return userLang.startsWith(pageLocale) ? pageLocale : undefined
+    })
+  }
   watchEffect(() => {
     datetime.value = new Intl.DateTimeFormat(
-      theme.value.lastUpdated?.formatOptions?.forceLocale ? lang.value : undefined,
+      theme.value.lastUpdated?.formatOptions?.forceLocale
+        ? lang.value
+        : findBestLocaleMatch(lang.value),
       theme.value.lastUpdated?.formatOptions ?? {
         dateStyle: 'short',
         timeStyle: 'short'


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR includes the logic to find the best locale match from `navigator.languages` including:
- iso-639 support for Latin America: `es-419`
- Edge browser case for ca-valencia lang (Spanish co-official: Valencià)
- the new logic will be applied only when not enabling `forceLocale` (per locale) and will return `undefined` (current logic) if not found
- add time `lang` attribute logic
- use browser/OS language via `Intl.DateTimeFormat().resolvedOptions().locale` when best match not found

When testing this PR with Spanish, you should change replace `lang: 'es-CO',`  with `lang: 'es',` (using medium for time style, that's why we have the seconds in the screenshots below) in the `es.ts` module.

You can add the languages to your browser sorting them (at least on Chrome).

**NOTE** about using browser/OS default language:
- using `english` page the text in english => no time lang attr (`en`, `en-GB`, `en-US` should be present  in languages)
- accessing `spanish` page with `es-ES`=> time lang with `es-ES` with proper format HH24 (`es-ES` should be be present  inlanguages)
- moving `es-ES` after `es-AR` => time lang with `es-AR` with proper format AM/PM (`es-ES` should be present in languages)
- other VP lang (`pt`, `jp`...) => using default browser/OS language, in my case `es-ES` => time lang with `es-ES` with proper format HH24 (doesn't matter if I put `es-AR` before `es-ES`)

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
<details>
<summary>Testing Intl.DateTimeFormat script</summary>

```js
[new Date()].forEach((d) => {
  const acc = {}

  Array.from(['es', 'es-419', 'es-ES', 'es-AR', 'es-CO', 'es-VE', 'es-MX', 'pt-PT', 'pt-BR']).forEach((l) => {
    const format = new Intl.DateTimeFormat(l, {
    dateStyle: 'short', timeStyle: 'short'
  }).format
    acc[l] = {
      date: d,
      format: format(d),
    }
  })
  console.table(acc)
})
```
</details>
<details>
<summary>Spanish translation with es-AR</summary>

![imagen](https://github.com/user-attachments/assets/2b1706e5-b6b8-4b20-b580-4be116a3d2ed)

![imagen](https://github.com/user-attachments/assets/d2463259-55b2-455f-89a0-22ae80f27bb5)
</details>

<details>
<summary>Spanish translation with es-ES</summary>

![imagen](https://github.com/user-attachments/assets/711d082a-0e0e-402e-b515-b0c5834a4fd1)

![imagen](https://github.com/user-attachments/assets/5c0e1844-98a4-4a55-aa11-cb0ebc00aa46)
</details>
---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
