### PR TITLE
typo: wrong translation in markdown.md

### DIFF
--- a/docs/zh/guide/markdown.md
+++ b/docs/zh/guide/markdown.md
@@ -891,7 +891,7 @@ $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 export default {
   markdown: {
     image: {
-      // 默认启用图片懒加载
+      // 默认禁用；设置为 true 可为所有图片启用懒加载。
       lazyLoading: true
     }
   }

--- a/docs/zh/guide/markdown.md
+++ b/docs/zh/guide/markdown.md
@@ -891,7 +891,7 @@ $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 export default {
   markdown: {
     image: {
-      // 默认禁用图片懒加载
+      // 默认启用图片懒加载
       lazyLoading: true
     }
   }


### PR DESCRIPTION
### Description

in Chinese ver of markdown.md, there is an translation error

### Linked Issues

no

### Additional Context

nothing