### PR TITLE
fix(theme/a11y): enable quick keyboard navigation for screen readers

### DIFF
--- a/src/client/theme-default/components/VPContent.vue
+++ b/src/client/theme-default/components/VPContent.vue
@@ -18,6 +18,7 @@ const { hasSidebar } = useSidebar()
       'has-sidebar': hasSidebar,
       'is-home': frontmatter.layout === 'home'
     }"
+    role="main"
   >
     <slot name="not-found" v-if="page.isNotFound"><NotFound /></slot>
 


### PR DESCRIPTION
### Description

This PR added a `role="main"` attribute to the `<div id="#VPContent">` area to improve accessibility for screen readers used broadly by visually impaired users.

Visually impaired users usually use screen reader software to acquire information on web pages. `role="main"` attribute will tell the screen reader that the indicated element is an anchor for the main content on a specific webpage. Users can press <kbd>D</kbd> to quickly navigate screen readers to read the `main` area. 

I tested this fix with a friend who is using a screen reader to read the world. This 
fix (feature?) benefits him from reaching the main contents more quickly.
