### PR TITLE
docs: fix vitepress execution via bunx not bun

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -80,7 +80,7 @@ $ yarn vitepress init
 ```
 
 ```sh [bun]
-$ bun vitepress init
+$ bunx vitepress init
 ```
 
 :::
@@ -198,7 +198,7 @@ $ yarn vitepress dev docs
 ```
 
 ```sh [bun]
-$ bun vitepress dev docs
+$ bunx vitepress dev docs
 ```
 
 :::


### PR DESCRIPTION
### Description
When I am trying to start new project using bun, this problem happen.
The docs said using this command to init new vitepress project.
```bash
bun vitepress init
```

I got error:
`error: Script not found "vitepress"`

As i know what should i do, it's no problem for me.
Immediately i run bunx command like this.
```bash
bunx vitepress init
```
Everything ok, right now.

But, i think something need to do at the docs.
Then, i make this pull request.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
