### PR TITLE
fix: markdown extensions typo

### DIFF
--- a/docs/en/guide/markdown.md
+++ b/docs/en/guide/markdown.md
@@ -22,7 +22,7 @@ Both internal and external links get special treatment.
 
 ### Internal Links
 
-Internal links are converted to router link for SPA navigation. Also, every `index.md` contained in each sub-directory will automatically be converted to `index.html`, with corresponding URL `/`.
+Internal links are converted to router links for SPA navigation. Also, every `index.md` contained in each sub-directory will automatically be converted to `index.html`, with corresponding URL `/`.
 
 For example, given the following directory structure:
 


### PR DESCRIPTION
### Description

Simple typo fix for the https://vitepress.dev/guide/markdown#links page—changed "Internal links are converted to router link" to "Internal links are converted to router link**s**".

### Linked Issues

N/A

### Additional Context

N/A

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
