### PR TITLE
docs: change the translation in the file

### DIFF
--- a/docs/pt/guide/routing.md
+++ b/docs/pt/guide/routing.md
@@ -109,7 +109,7 @@ Se você deseja vincular a uma página em seu site que não é gerada pelo ViteP
 
 [Link para pure.html](/pure.html){target="_self"}
 
-::: dica Nota
+::: tip Nota
 
 Nos links Markdown, a `base` é automaticamente adicionada à URL. Isso significa que, se você deseja vincular a uma página fora da sua base, será necessário algo como `../../pure.html` no link (resolvido em relação à página atual pelo navegador).
 


### PR DESCRIPTION
### Description of problem

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

In line 112, the word `dica` in Portuguese corresponds to the word `tip` in English. The content is not properly formatted in the documentation because it is necessary to use `tip` in the output generation of the [Linking to Non-VitePress Pages](https://vitepress.dev/pt/guide/routing#linking-to-non-vitepress-pages) view. https://github.com/vuejs/vitepress/blob/21bd34a2aaecdac91328b369c19a8d99bb64c037/docs/pt/guide/routing.md?plain=1#L112-L122

### Note

In the English documentation, the output format is correct. See the output [Linking to Non-VitePress Pages](https://vitepress.dev/guide/routing#linking-to-non-vitepress-pages) view.

https://github.com/vuejs/vitepress/blob/21bd34a2aaecdac91328b369c19a8d99bb64c037/docs/en/guide/routing.md?plain=1#L112-L122
