### PR TITLE
fix(theme): avoid header shake when refresh page

### DIFF
--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useWindowScroll } from '@vueuse/core'
-import { ref, watchPostEffect } from 'vue'
+import { ref, watchEffect } from 'vue'
 import { useData } from '../composables/data'
 import { useSidebar } from '../composables/sidebar'
 import VPNavBarAppearance from './VPNavBarAppearance.vue'
@@ -26,7 +26,7 @@ const { frontmatter } = useData()
 
 const classes = ref<Record<string, boolean>>({})
 
-watchPostEffect(() => {
+watchEffect(() => {
   classes.value = {
     'has-sidebar': hasSidebar.value,
     'home': frontmatter.value.layout === 'home',


### PR DESCRIPTION
### Description

`watchPostEffect` is trigger after the page rendered, which will let header shake when refresh page. So I use `watchEffect` replace it.

| Before (watchPostEffect) | After (watchEffect) |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/d2fb4fbf-0976-4eec-af1a-44ad3d4d076a) | ![After](https://github.com/user-attachments/assets/f3a502c4-83e3-4d6c-b315-f3b3538a2c3e) |

### Linked Issues

resolves #4351

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
