### PR TITLE
docs: change the translation in the file

### DIFF
--- a/docs/pt/guide/markdown.md
+++ b/docs/pt/guide/markdown.md
@@ -625,7 +625,7 @@ Também suporta [destaque de linha](#line-highlighting-in-code-blocks):
 
 <<< @/snippets/snippet.js{2}
 
-::: dica
+::: tip
 O valor de `@` corresponde à raiz do código fonte. Por padrão, é a raiz do projeto VitePress, a menos que `srcDir` seja configurado. Alternativamente, você também pode importar de caminhos relativos:
 
 ```md
@@ -834,7 +834,7 @@ Pode ser criada usando `.foorc.json`.
 
 O formato do intervalo de linhas selecionado pode ser: `{3,}`, `{,10}`, `{1,10}`
 
-::: aviso
+::: warning
 Observe que isso não gera erros se o arquivo não estiver presente. Portanto, ao usar esse recurso, certifique-se de que o conteúdo está sendo mostrado como esperado.
 :::
 


### PR DESCRIPTION
### Description of problem

The same rendering error addressed in change #4470 is present on lines 628 and 837 of this file.

On line 837, the word `aviso` in Portuguese corresponds to the word `warning` in English. The content is not formatted correctly in the documentation because `warning` is required to generate the preview in [Markdown File Inclusion](https://vitepress.dev/pt/guide/markdown#markdown-file-inclusion).

https://github.com/vuejs/vitepress/blob/6442e174838aec9668325bb1199419908e7dd728/docs/pt/guide/markdown.md?plain=1#L628-L635

https://github.com/vuejs/vitepress/blob/6442e174838aec9668325bb1199419908e7dd728/docs/pt/guide/markdown.md?plain=1#L837-L839

### Note

In the English documentation, the output format is correct. See the output [Import Code Snippets](https://vitepress.dev/guide/markdown#import-code-snippets) and [Markdown File Inclusion](https://vitepress.dev/guide/markdown#markdown-file-inclusion).
