### PR TITLE
docs: change the translation in the file

### DIFF
--- a/docs/pt/guide/markdown.md
+++ b/docs/pt/guide/markdown.md
@@ -758,7 +758,7 @@ Você também pode [importar _snippets_ de código](#import-code-snippets) em gr
 
 Você pode incluir um arquivo markdown em outro arquivo markdown, mesmo aninhado.
 
-::: dica
+::: tip
 Você também pode prefixar o caminho do markdown com `@`, ele atuará como a raiz de origem. Por padrão, é a raiz do projeto VitePress, a menos que `srcDir` seja configurado.
 :::
 


### PR DESCRIPTION
### Use the word `tip` to correctly generate the custom container

In line 761, the word `dica` in Portuguese corresponds to the word `tip` in English. It is necessary to use the word `tip` to correctly render the custom container in the [Markdown File Inclusion](https://vitepress.dev/pt/guide/markdown#markdown-file-inclusion), as per the changes made in #4481.

https://github.com/vuejs/vitepress/blob/060971d3b90783003b873f74edfeffe576ec37a9/docs/pt/guide/markdown.md?plain=1#L761-L763