### PR TITLE
fix(theme): code block contrast ratio

### DIFF
--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -337,10 +337,10 @@
   --vp-code-block-bg: var(--vp-c-bg-alt);
   --vp-code-block-divider-color: var(--vp-c-gutter);
 
-  --vp-code-lang-color: var(--vp-c-text-3);
+  --vp-code-lang-color: var(--vp-c-text-2);
 
   --vp-code-line-highlight-color: var(--vp-c-default-soft);
-  --vp-code-line-number-color: var(--vp-c-text-3);
+  --vp-code-line-number-color: var(--vp-c-text-2);
 
   --vp-code-line-diff-add-color: var(--vp-c-success-soft);
   --vp-code-line-diff-add-symbol-color: var(--vp-c-success-1);


### PR DESCRIPTION
fix #4486 

### Description

This PR moves the underlying colors for `—vp-code-lang-color` and `--vp-code-line-number-color` from `--vp-c-text-3` to `--vp-c-text-2` which bumps the threshold enough to meet AA compliance.

<img width="700" alt="gs-light-post" src="https://github.com/user-attachments/assets/90fc3fa8-2ba9-430e-9fcc-d27d0b649594" />

<img width="700" alt="gs-dark-post" src="https://github.com/user-attachments/assets/634cf745-edf4-4d4e-8667-2ea33eba8bfe" />

### Additional images & considerations

`--vp-c-text-2` is the same color used by the code block tabs as well and it seems nicely balanced.

<img width="473" alt="" src="https://github.com/user-attachments/assets/bc71571f-1812-4d78-ab23-da6f22f1b5cd" />
<img width="497" alt="" src="https://github.com/user-attachments/assets/88202553-185d-43a8-96c3-7ee4d0d0a33d" />


Visual examples of the updates for line number

<img width="696" alt="lnl-post" src="https://github.com/user-attachments/assets/8d4afe62-f4b5-4939-8bec-ecce22ddabef" />

<img width="696" alt="lnd-post" src="https://github.com/user-attachments/assets/c5e1e375-0f34-416e-a31b-2f0f5a852d1b" />



> [!Note]
> The Shiki theme also doesn't meet the threshold, but I thought since that was an example of custom theming it was better to leave as is. There might be a consideration to update the bg color of shiki code blocks, but that is out of scope for this work.