### PR TITLE
fix(VPNav): Allow clicks on custom navbar

### DIFF
--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -45,7 +45,7 @@ watchEffect(() => {
   left: 0;
   z-index: var(--vp-z-index-nav);
   width: 100%;
-  pointer-events: none;
+  pointer-events: auto;
   transition: background-color 0.5s;
 }
 


### PR DESCRIPTION
### Description

in my vitepress project I wanted to use a custom navbar instead of the default vitepress one

so i made an alias in `vite.config.ts`

```
resolve: {
        alias: [
            {
                find:        /^.*\/VPNavBar\.vue$/,
                replacement: resolve(__dirname, '.vitepress/theme/Components/MyCustomNavbar.vue'),
            },
        ],
    },
```
the navbar got replaced but I couldn't be able to click any link on it. this PR fixes it by setting the pointer-events to auto


---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
