### PR TITLE
feat: support same page navigation in router.go

### DIFF
--- a/src/client/app/index.ts
+++ b/src/client/app/index.ts
@@ -159,7 +159,7 @@ function newRouter(): Router {
 if (inBrowser) {
   createApp().then(({ app, router, data }) => {
     // wait until page component is fetched before mounting
-    router.go().then(() => {
+    router.go(location.href, { initialLoad: true }).then(() => {
       // dynamically update head tags
       useUpdateHead(router.route, data.site)
       app.mount('#app')

--- a/src/client/app/index.ts
+++ b/src/client/app/index.ts
@@ -166,12 +166,7 @@ if (inBrowser) {
 
       // scroll to hash on new tab during dev
       if (import.meta.env.DEV && location.hash) {
-        const target = document.getElementById(
-          decodeURIComponent(location.hash).slice(1)
-        )
-        if (target) {
-          scrollTo(target, location.hash)
-        }
+        scrollTo(location.hash)
       }
     })
   })

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -7,8 +7,8 @@ import { getScrollOffset, inBrowser, withBase } from './utils'
 
 export interface Route {
   path: string
-  hash?: string
-  query?: string
+  hash: string
+  query: string
   data: PageData
   component: Component | null
 }
@@ -57,6 +57,8 @@ const fakeHost = 'http://a.com'
 
 const getDefaultRoute = (): Route => ({
   path: '/',
+  hash: '',
+  query: '',
   component: null,
   data: notFoundPageData
 })
@@ -108,6 +110,7 @@ export function createRouter(
         route.data = import.meta.env.PROD
           ? markRaw(__pageData)
           : (readonly(__pageData) as PageData)
+        syncRouteQueryAndHash(targetLoc)
 
         if (inBrowser) {
           nextTick(() => {
@@ -160,14 +163,18 @@ export function createRouter(
               .replace(/^\//, '')
           : '404.md'
         route.data = { ...notFoundPageData, relativePath }
+        syncRouteQueryAndHash(targetLoc)
       }
     }
   }
 
-  function syncRouteQueryAndHash() {
-    if (!inBrowser) return
-    route.query = location.search
-    route.hash = decodeURIComponent(location.hash)
+  function syncRouteQueryAndHash(
+    loc: { search: string; hash: string } = inBrowser
+      ? location
+      : { search: '', hash: '' }
+  ) {
+    route.query = loc.search
+    route.hash = decodeURIComponent(loc.hash)
   }
 
   if (inBrowser) {

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -72,10 +72,10 @@ export function createRouter(
   }
 
   async function go(href: string = inBrowser ? location.href : '/') {
-    if ((await router.onBeforeRouteChange?.(href)) === false) return
-
     href = normalizeHref(href)
     const loc = inBrowser ? normalizeHref(location.href) : null
+
+    if ((await router.onBeforeRouteChange?.(href)) === false) return
 
     if (loc !== null && href !== loc) {
       const { pathname, hash } = new URL(href, fakeHost)

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -167,7 +167,7 @@ export function createRouter(
   function syncRouteQueryAndHash() {
     if (!inBrowser) return
     route.query = location.search
-    route.hash = location.hash
+    route.hash = decodeURIComponent(location.hash)
   }
 
   if (inBrowser) {

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -165,6 +165,7 @@ export function createRouter(
   }
 
   function syncRouteQueryAndHash() {
+    if (!inBrowser) return
     route.query = location.search
     route.hash = location.hash
   }

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -78,23 +78,22 @@ export function createRouter(
     if (inBrowser) {
       loc = normalizeHref(location.href)
 
-      const { pathname, search, hash } = new URL(href, fakeHost)
+      const { pathname, hash } = new URL(href, fakeHost)
       const currentLoc = new URL(loc, fakeHost)
 
-      if (
-        pathname === currentLoc.pathname &&
-        search === currentLoc.search &&
-        hash !== currentLoc.hash
-      ) {
+      if (pathname === currentLoc.pathname && href !== loc) {
         history.pushState({}, '', href)
-        window.dispatchEvent(
-          new HashChangeEvent('hashchange', {
-            oldURL: currentLoc.href,
-            newURL: href
-          })
-        )
 
-        hash ? scrollTo(hash) : window.scrollTo(0, 0)
+        if (hash !== currentLoc.hash) {
+          window.dispatchEvent(
+            new HashChangeEvent('hashchange', {
+              oldURL: currentLoc.href,
+              newURL: href
+            })
+          )
+
+          hash ? scrollTo(hash) : window.scrollTo(0, 0)
+        }
 
         return
       }

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -95,11 +95,15 @@ export function createRouter(
       if (href === loc) {
         if (!initialLoad) return scrollTo(hash, smoothScroll)
       } else {
+        // save scroll position before changing url
         history.replaceState({ scrollPosition: window.scrollY }, '')
         history.pushState({}, '', href)
 
         if (pathname === currentLoc.pathname) {
+          // scroll between hash anchors in the same page
+          // avoid duplicate history entries when the hash is same
           if (hash !== currentLoc.hash) {
+            // still emit the event so we can listen to it in themes
             window.dispatchEvent(
               new HashChangeEvent('hashchange', {
                 oldURL: currentLoc.href,
@@ -238,6 +242,7 @@ export function createRouter(
         // only intercept inbound html links
         if (origin === currentLoc.origin && treatAsHtml(pathname)) {
           e.preventDefault()
+          // use smooth scroll when clicking on header anchor links
           go(href, { smoothScroll: link.classList.contains('header-anchor') })
         }
       },

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -71,7 +71,10 @@ export function createRouter(
     go
   }
 
-  async function go(href: string = inBrowser ? location.href : '/') {
+  async function go(
+    href: string = inBrowser ? location.href : '/',
+    cause: Element | null = null
+  ) {
     href = normalizeHref(href)
     const loc = inBrowser ? normalizeHref(location.href) : null
 
@@ -94,7 +97,14 @@ export function createRouter(
             })
           )
 
-          hash ? scrollTo(hash) : window.scrollTo(0, 0)
+          if (hash) {
+            scrollTo(
+              hash,
+              cause ? cause.classList.contains('header-anchor') : false
+            )
+          } else {
+            window.scrollTo(0, 0)
+          }
         }
 
         return
@@ -262,7 +272,7 @@ export function useRoute(): Route {
   return useRouter().route
 }
 
-export function scrollTo(hash: string) {
+export function scrollTo(hash: string, smooth = false) {
   let target: Element | null = null
 
   try {
@@ -285,11 +295,9 @@ export function scrollTo(hash: string) {
 
     function scrollToTarget() {
       // only smooth scroll if distance is smaller than screen height.
-      if (Math.abs(targetTop - window.scrollY) > window.innerHeight) {
+      if (!smooth || Math.abs(targetTop - window.scrollY) > window.innerHeight)
         window.scrollTo(0, targetTop)
-      } else {
-        window.scrollTo({ left: 0, top: targetTop, behavior: 'smooth' })
-      }
+      else window.scrollTo({ left: 0, top: targetTop, behavior: 'smooth' })
     }
 
     requestAnimationFrame(scrollToTarget)

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -72,15 +72,12 @@ export function createRouter(
   }
 
   async function go(href: string = inBrowser ? location.href : '/') {
-    href = normalizeHref(href)
-    let loc: string | null = null
-
     if ((await router.onBeforeRouteChange?.(href)) === false) return
 
-    if (inBrowser) {
-      loc = normalizeHref(location.href)
-      if (href === loc) return
+    href = normalizeHref(href)
+    const loc = inBrowser ? normalizeHref(location.href) : null
 
+    if (loc !== null && href !== loc) {
       const { pathname, hash } = new URL(href, fakeHost)
       const currentLoc = new URL(loc, fakeHost)
 

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -71,10 +71,7 @@ export function createRouter(
     go
   }
 
-  async function go(
-    href: string = inBrowser ? location.href : '/',
-    cause: Element | null = null
-  ) {
+  async function go(href: string = inBrowser ? location.href : '/') {
     href = normalizeHref(href)
     let loc: string | null = null
 
@@ -96,11 +93,8 @@ export function createRouter(
             newURL: href
           })
         )
-        if (hash) {
-          scrollTo(cause, hash, cause?.classList.contains('header-anchor'))
-        } else {
-          window.scrollTo(0, 0)
-        }
+
+        hash ? scrollTo(hash) : window.scrollTo(0, 0)
 
         return
       }
@@ -158,7 +152,7 @@ export function createRouter(
             }
 
             if (targetLoc.hash && !scrollPosition) {
-              scrollTo(null, targetLoc.hash)
+              scrollTo(targetLoc.hash)
             } else {
               window.scrollTo(0, scrollPosition)
             }
@@ -238,7 +232,7 @@ export function createRouter(
         // only intercept inbound html links
         if (origin === currentLoc.origin && treatAsHtml(pathname)) {
           e.preventDefault()
-          go(href, link)
+          go(href)
         }
       },
       { capture: true }
@@ -273,13 +267,11 @@ export function useRoute(): Route {
   return useRouter().route
 }
 
-export function scrollTo(from: Element | null, hash: string, smooth = false) {
+export function scrollTo(hash: string) {
   let target: Element | null = null
 
   try {
-    target = from?.classList.contains('header-anchor')
-      ? from
-      : document.getElementById(decodeURIComponent(hash).slice(1))
+    target = document.getElementById(decodeURIComponent(hash).slice(1))
   } catch (e) {
     console.warn(e)
   }
@@ -289,17 +281,22 @@ export function scrollTo(from: Element | null, hash: string, smooth = false) {
       window.getComputedStyle(target).paddingTop,
       10
     )
+
     const targetTop =
       window.scrollY +
       target.getBoundingClientRect().top -
       getScrollOffset() +
       targetPadding
+
     function scrollToTarget() {
       // only smooth scroll if distance is smaller than screen height.
-      if (!smooth || Math.abs(targetTop - window.scrollY) > window.innerHeight)
+      if (Math.abs(targetTop - window.scrollY) > window.innerHeight) {
         window.scrollTo(0, targetTop)
-      else window.scrollTo({ left: 0, top: targetTop, behavior: 'smooth' })
+      } else {
+        window.scrollTo({ left: 0, top: targetTop, behavior: 'smooth' })
+      }
     }
+
     requestAnimationFrame(scrollToTarget)
   }
 }

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -97,14 +97,8 @@ export function createRouter(
             })
           )
 
-          if (hash) {
-            scrollTo(
-              hash,
-              cause ? cause.classList.contains('header-anchor') : false
-            )
-          } else {
-            window.scrollTo(0, 0)
-          }
+          if (hash) scrollTo(hash, cause?.classList.contains('header-anchor'))
+          else window.scrollTo(0, 0)
         }
 
         return
@@ -156,11 +150,8 @@ export function createRouter(
               history.replaceState({}, '', href)
             }
 
-            if (targetLoc.hash && !scrollPosition) {
-              scrollTo(targetLoc.hash)
-            } else {
-              window.scrollTo(0, scrollPosition)
-            }
+            if (targetLoc.hash && !scrollPosition) scrollTo(targetLoc.hash)
+            else window.scrollTo(0, scrollPosition)
           })
         }
       }

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -84,11 +84,11 @@ export function createRouter(
     { smoothScroll = false, initialLoad = false } = {}
   ) {
     href = normalizeHref(href)
-    const loc = inBrowser ? normalizeHref(location.href) : null
-
     if ((await router.onBeforeRouteChange?.(href)) === false) return
 
-    if (loc !== null) {
+    if (inBrowser) {
+      const loc = normalizeHref(location.href)
+
       const { pathname, hash } = new URL(href, fakeHost)
       const currentLoc = new URL(loc, fakeHost)
 

--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -93,11 +93,7 @@ export function createRouter(
       const currentLoc = new URL(loc, fakeHost)
 
       if (href === loc) {
-        if (!initialLoad) {
-          if (hash) scrollTo(hash, smoothScroll)
-          else window.scrollTo(0, 0)
-          return
-        }
+        if (!initialLoad) return scrollTo(hash, smoothScroll)
       } else {
         history.replaceState({ scrollPosition: window.scrollY }, '')
         history.pushState({}, '', href)
@@ -111,8 +107,7 @@ export function createRouter(
               })
             )
 
-            if (hash) scrollTo(hash, smoothScroll)
-            else window.scrollTo(0, 0)
+            return scrollTo(hash, smoothScroll)
           }
 
           return
@@ -166,8 +161,7 @@ export function createRouter(
               history.replaceState({}, '', href)
             }
 
-            if (targetLoc.hash && !scrollPosition) scrollTo(targetLoc.hash)
-            else window.scrollTo(0, scrollPosition)
+            return scrollTo(targetLoc.hash, false, scrollPosition)
           })
         }
       }
@@ -277,7 +271,12 @@ export function useRoute(): Route {
   return useRouter().route
 }
 
-export function scrollTo(hash: string, smooth = false) {
+export function scrollTo(hash: string, smooth = false, scrollPosition = 0) {
+  if (!hash || scrollPosition) {
+    window.scrollTo(0, scrollPosition)
+    return
+  }
+
   let target: Element | null = null
 
   try {


### PR DESCRIPTION
closes #4461
closes #4510 (makes e0350275b39258a61ee867840ce1c6f5b2cecf2a permanent)
closes #277

TODO:
- [x] handle query changes
- [x] ~~emit custom event on location change (lets wait for some consensus at [vueuse/vueuse#4529](https://github.com/vueuse/vueuse/issues/4529))~~
- [x] expose query and hash from route object
- [x] normalize hash