### PR TITLE
fix(types): support preload built-in shiki languages as string

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -24,7 +24,7 @@ import MarkdownIt from 'markdown-it'
 import anchorPlugin from 'markdown-it-anchor'
 import attrsPlugin from 'markdown-it-attrs'
 import { full as emojiPlugin } from 'markdown-it-emoji'
-import type { BuiltinTheme, Highlighter } from 'shiki'
+import type { BuiltinLanguage, BuiltinTheme, Highlighter } from 'shiki'
 import type { Logger } from 'vite'
 import { containerPlugin, type ContainerOptions } from './plugins/containers'
 import { gitHubAlertsPlugin } from './plugins/githubAlerts'
@@ -81,10 +81,10 @@ export interface MarkdownOptions extends Options {
    */
   theme?: ThemeOptions
   /**
-   * Languages for syntax highlighting.
+   * Custom languages for syntax highlighting or pre-load built-in languages.
    * @see https://shiki.style/languages
    */
-  languages?: LanguageInput[]
+  languages?: (LanguageInput | BuiltinLanguage)[]
   /**
    * Custom language aliases.
    *


### PR DESCRIPTION
This PR only updates types. As `markdown.langugages` are passed to `createHighlighter`, it also supports string literals. This allows users to pre-load built-in languages if they know they would need them anyway.