### PR TITLE
feat!: dynamic routes plugin overhaul

### DIFF
--- a/__tests__/e2e/dynamic-routes/[id].paths.ts
+++ b/__tests__/e2e/dynamic-routes/[id].paths.ts
@@ -1,14 +1,14 @@
-import type { PageData } from 'client/shared'
+import { defineRoutes } from 'vitepress'
 import paths from './paths'
 
-export default {
+export default defineRoutes({
   async paths(watchedFiles: string[]) {
-    console.log('watchedFiles', watchedFiles)
+    // console.log('watchedFiles', watchedFiles)
     return paths
   },
   watch: ['**/data-loading/**/*.json'],
-  async transformPageData(pageData: PageData) {
-    console.log('transformPageData', pageData.filePath)
+  async transformPageData(pageData) {
+    // console.log('transformPageData', pageData.filePath)
     pageData.title += ' - transformed'
   }
-}
+})

--- a/__tests__/e2e/dynamic-routes/[id].paths.ts
+++ b/__tests__/e2e/dynamic-routes/[id].paths.ts
@@ -1,3 +1,4 @@
+import type { PageData } from 'client/shared'
 import paths from './paths'
 
 export default {
@@ -5,5 +6,9 @@ export default {
     console.log('watchedFiles', watchedFiles)
     return paths
   },
-  watch: ['**/data-loading/**/*.json']
+  watch: ['**/data-loading/**/*.json'],
+  async transformPageData(pageData: PageData) {
+    console.log('transformPageData', pageData.filePath)
+    pageData.title += ' - transformed'
+  }
 }

--- a/__tests__/e2e/dynamic-routes/[id].paths.ts
+++ b/__tests__/e2e/dynamic-routes/[id].paths.ts
@@ -2,7 +2,7 @@ import paths from './paths'
 
 export default {
   async paths(watchedFiles: string[]) {
-    // console.log('watchedFiles', watchedFiles)
+    console.log('watchedFiles', watchedFiles)
     return paths
   },
   watch: ['**/data-loading/**/*.json']

--- a/__tests__/e2e/dynamic-routes/[id].paths.ts
+++ b/__tests__/e2e/dynamic-routes/[id].paths.ts
@@ -1,8 +1,9 @@
+import paths from './paths'
+
 export default {
-  async paths() {
-    return [
-      { params: { id: 'foo' }, content: `# Foo` },
-      { params: { id: 'bar' }, content: `# Bar` }
-    ]
-  }
+  async paths(watchedFiles: string[]) {
+    console.log('watchedFiles', watchedFiles)
+    return paths
+  },
+  watch: ['**/data-loading/**/*.json']
 }

--- a/__tests__/e2e/dynamic-routes/[id].paths.ts
+++ b/__tests__/e2e/dynamic-routes/[id].paths.ts
@@ -2,7 +2,7 @@ import paths from './paths'
 
 export default {
   async paths(watchedFiles: string[]) {
-    console.log('watchedFiles', watchedFiles)
+    // console.log('watchedFiles', watchedFiles)
     return paths
   },
   watch: ['**/data-loading/**/*.json']

--- a/__tests__/e2e/dynamic-routes/paths.ts
+++ b/__tests__/e2e/dynamic-routes/paths.ts
@@ -1,0 +1,4 @@
+export default [
+  { params: { id: 'foo' }, content: `# Foo` },
+  { params: { id: 'bar' }, content: `# Bar` }
+]

--- a/__tests__/unit/node/utils/moduleGraph.test.ts
+++ b/__tests__/unit/node/utils/moduleGraph.test.ts
@@ -1,0 +1,72 @@
+import { ModuleGraph } from 'node/utils/moduleGraph'
+
+describe('node/utils/moduleGraph', () => {
+  let graph: ModuleGraph
+
+  beforeEach(() => {
+    graph = new ModuleGraph()
+  })
+
+  it('should correctly delete a module and its dependents', () => {
+    graph.add('A', ['B', 'C'])
+    graph.add('B', ['D'])
+    graph.add('C', [])
+    graph.add('D', [])
+
+    expect(graph.delete('D')).toEqual(new Set(['D', 'B', 'A']))
+  })
+
+  it('should handle shared dependencies correctly', () => {
+    graph.add('A', ['B', 'C'])
+    graph.add('B', ['D'])
+    graph.add('C', ['D']) // Shared dependency
+    graph.add('D', [])
+
+    expect(graph.delete('D')).toEqual(new Set(['A', 'B', 'C', 'D']))
+  })
+
+  it('merges dependencies correctly', () => {
+    // Add module A with dependency B
+    graph.add('A', ['B'])
+    // Merge new dependency C into module A (B should remain)
+    graph.add('A', ['C'])
+
+    // Deleting B should remove A as well, since A depends on B.
+    expect(graph.delete('B')).toEqual(new Set(['B', 'A']))
+  })
+
+  it('handles cycles gracefully', () => {
+    // Create a cycle: A -> B, B -> C, C -> A.
+    graph.add('A', ['B'])
+    graph.add('B', ['C'])
+    graph.add('C', ['A'])
+
+    // Deleting any module in the cycle should delete all modules in the cycle.
+    expect(graph.delete('A')).toEqual(new Set(['A', 'B', 'C']))
+  })
+
+  it('cleans up dependencies when deletion', () => {
+    // Setup A -> B relationship.
+    graph.add('A', ['B'])
+    graph.add('B', [])
+
+    // Deleting B should remove both B and A from the graph.
+    expect(graph.delete('B')).toEqual(new Set(['B', 'A']))
+
+    // After deletion, add modules again.
+    graph.add('C', [])
+    graph.add('A', ['C']) // Now A depends only on C.
+
+    expect(graph.delete('C')).toEqual(new Set(['C', 'A']))
+  })
+
+  it('handles independent modules', () => {
+    // Modules with no dependencies.
+    graph.add('X', [])
+    graph.add('Y', [])
+
+    // Deletion of one should only remove that module.
+    expect(graph.delete('X')).toEqual(new Set(['X']))
+    expect(graph.delete('Y')).toEqual(new Set(['Y']))
+  })
+})

--- a/src/client/app/data.ts
+++ b/src/client/app/data.ts
@@ -62,7 +62,7 @@ export const siteDataRef: Ref<SiteData> = shallowRef(
 
 // hmr
 if (import.meta.hot) {
-  import.meta.hot.accept('/@siteData', (m) => {
+  import.meta.hot.accept('@siteData', (m) => {
     if (m) {
       siteDataRef.value = m.default
     }

--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -46,7 +46,7 @@ const searchIndexData = shallowRef(localSearchIndex)
 
 // hmr
 if (import.meta.hot) {
-  import.meta.hot.accept('/@localSearchIndex', (m) => {
+  import.meta.hot.accept('@localSearchIndex', (m) => {
     if (m) {
       searchIndexData.value = m.default
     }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -97,20 +97,12 @@ export async function resolveConfig(
     ? userThemeDir
     : DEFAULT_THEME_PATH
 
-  const { pages, dynamicRoutes, rewrites } = await resolvePages(
-    srcDir,
-    userConfig,
-    logger
-  )
-
   const config: SiteConfig = {
     root,
     srcDir,
     assetsDir,
     site,
     themeDir,
-    pages,
-    dynamicRoutes,
     configPath,
     configDeps,
     outDir,
@@ -135,10 +127,10 @@ export async function resolveConfig(
     transformHead: userConfig.transformHead,
     transformHtml: userConfig.transformHtml,
     transformPageData: userConfig.transformPageData,
-    rewrites,
     userConfig,
     sitemap: userConfig.sitemap,
-    buildConcurrency: userConfig.buildConcurrency ?? 64
+    buildConcurrency: userConfig.buildConcurrency ?? 64,
+    ...(await resolvePages(srcDir, userConfig, logger))
   }
 
   // to be shared with content loaders

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -5,6 +5,11 @@ export * from './contentLoader'
 export * from './init/init'
 export * from './markdown/markdown'
 export { defineLoader, type LoaderModule } from './plugins/staticDataPlugin'
+export {
+  defineRoutes,
+  type ResolvedRouteConfig,
+  type RouteModule
+} from './plugins/dynamicRoutesPlugin'
 export * from './postcss/isolateStyles'
 export * from './serve/serve'
 export * from './server'

--- a/src/node/init/init.ts
+++ b/src/node/init/init.ts
@@ -11,7 +11,7 @@ import fs from 'fs-extra'
 import template from 'lodash.template'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { bold, cyan, yellow } from 'picocolors'
+import c from 'picocolors'
 import { slash } from '../shared'
 
 export enum ScaffoldThemeType {
@@ -38,7 +38,7 @@ const getPackageManger = () => {
 }
 
 export async function init(root?: string) {
-  intro(bold(cyan('Welcome to VitePress!')))
+  intro(c.bold(c.cyan('Welcome to VitePress!')))
 
   const options = await group(
     {
@@ -232,7 +232,7 @@ export function scaffold({
   const gitignorePrefix = root ? `${slash(root)}/.vitepress` : '.vitepress'
   if (fs.existsSync('.git')) {
     tips.push(
-      `Make sure to add ${cyan(`${gitignorePrefix}/dist`)} and ${cyan(`${gitignorePrefix}/cache`)} to your ${cyan(`.gitignore`)} file.`
+      `Make sure to add ${c.cyan(`${gitignorePrefix}/dist`)} and ${c.cyan(`${gitignorePrefix}/cache`)} to your ${c.cyan(`.gitignore`)} file.`
     )
   }
 
@@ -242,11 +242,11 @@ export function scaffold({
     !userPkg.devDependencies?.['vue']
   ) {
     tips.push(
-      `Since you've chosen to customize the theme, you should also explicitly install ${cyan(`vue`)} as a dev dependency.`
+      `Since you've chosen to customize the theme, you should also explicitly install ${c.cyan(`vue`)} as a dev dependency.`
     )
   }
 
-  const tip = tips.length ? yellow([`\n\nTips:`, ...tips].join('\n- ')) : ``
+  const tip = tips.length ? c.yellow([`\n\nTips:`, ...tips].join('\n- ')) : ``
   const dir = root ? ' ' + root : ''
   const pm = getPackageManger()
 
@@ -261,8 +261,8 @@ export function scaffold({
     Object.assign(userPkg.scripts || (userPkg.scripts = {}), scripts)
     fs.writeFileSync(pkgPath, JSON.stringify(userPkg, null, 2))
 
-    return `Done! Now run ${cyan(`${pm} run ${prefix}dev`)} and start writing.${tip}`
+    return `Done! Now run ${c.cyan(`${pm} run ${prefix}dev`)} and start writing.${tip}`
   } else {
-    return `You're all set! Now run ${cyan(`${pm === 'npm' ? 'npx' : pm} vitepress dev${dir}`)} and start writing.${tip}`
+    return `You're all set! Now run ${c.cyan(`${pm === 'npm' ? 'npx' : pm} vitepress dev${dir}`)} and start writing.${tip}`
   }
 }

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -47,7 +47,7 @@ let __rewrites = new Map<string, string>()
 
 function getResolutionCache(siteConfig: SiteConfig) {
   // @ts-expect-error internal
-  if (siteConfig.__dirty !== false) {
+  if (siteConfig.__dirty) {
     __pages = siteConfig.pages.map((p) => slash(p.replace(/\.md$/, '')))
 
     __dynamicRoutes = new Map(

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -51,7 +51,7 @@ function getResolutionCache(siteConfig: SiteConfig) {
     __pages = siteConfig.pages.map((p) => slash(p.replace(/\.md$/, '')))
 
     __dynamicRoutes = new Map(
-      siteConfig.dynamicRoutes.routes.map((r) => [
+      siteConfig.dynamicRoutes.map((r) => [
         r.fullPath,
         slash(path.join(siteConfig.srcDir, r.route))
       ])

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -58,7 +58,7 @@ function getResolutionCache(siteConfig: SiteConfig) {
     )
 
     __rewrites = new Map(
-      Object.entries(siteConfig.rewrites.map || {}).map(([key, value]) => [
+      Object.entries(siteConfig.rewrites.map).map(([key, value]) => [
         slash(path.join(siteConfig.srcDir, key)),
         slash(path.join(siteConfig.srcDir, value!))
       ])

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -31,14 +31,14 @@ export interface MarkdownCompileResult {
   includes: string[]
 }
 
-export function clearCache(file?: string) {
-  if (!file) {
+export function clearCache(id?: string) {
+  if (!id) {
     cache.clear()
     return
   }
 
-  file = JSON.stringify({ file }).slice(1)
-  cache.find((_, key) => key.endsWith(file!) && cache.delete(key))
+  id = JSON.stringify({ id }).slice(1)
+  cache.find((_, key) => key.endsWith(id!) && cache.delete(key))
 }
 
 export async function createMarkdownToVueRenderFn(
@@ -83,7 +83,7 @@ export async function createMarkdownToVueRenderFn(
     file = rewrites.get(file) || file
     const relativePath = slash(path.relative(srcDir, file))
 
-    const cacheKey = JSON.stringify({ src, file: relativePath })
+    const cacheKey = JSON.stringify({ src, file: relativePath, id: fileOrig })
     if (isBuild || options.cache !== false) {
       const cached = cache.get(cacheKey)
       if (cached) {

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -429,7 +429,7 @@ export async function createVitePressPlugin(
         return [
           ...modules,
           ...importers.map((id) => {
-            clearCache(slash(path.relative(srcDir, id)))
+            clearCache(id)
             return this.environment.moduleGraph.getModuleById(id)
           })
         ].filter((mod) => mod !== undefined)

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -367,7 +367,7 @@ export async function createVitePressPlugin(
       }
     },
 
-    async handleHotUpdate(ctx) {
+    async hotUpdate(ctx) {
       const { file, read, server } = ctx
       if (file === configPath || configDeps.includes(file)) {
         siteConfig.logger.info(

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -423,7 +423,7 @@ export async function createVitePressPlugin(
 
   const hmrFix: Plugin = {
     name: 'vitepress:hmr-fix',
-    async hotUpdate({ file, server, modules }) {
+    async hotUpdate({ file, modules }) {
       const importers = [...(importerMap[slash(file)] || [])]
       if (importers.length > 0) {
         return [

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -367,7 +367,7 @@ export async function createVitePressPlugin(
       }
     },
 
-    async hotUpdate(ctx) {
+    async handleHotUpdate(ctx) {
       const { file, read, server } = ctx
       if (file === configPath || configDeps.includes(file)) {
         siteConfig.logger.info(

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -3,7 +3,6 @@ import c from 'picocolors'
 import {
   mergeConfig,
   searchForWorkspaceRoot,
-  type ModuleNode,
   type Plugin,
   type ResolvedConfig,
   type Rollup,
@@ -424,16 +423,16 @@ export async function createVitePressPlugin(
 
   const hmrFix: Plugin = {
     name: 'vitepress:hmr-fix',
-    async handleHotUpdate({ file, server, modules }) {
+    async hotUpdate({ file, server, modules }) {
       const importers = [...(importerMap[slash(file)] || [])]
       if (importers.length > 0) {
         return [
           ...modules,
           ...importers.map((id) => {
             clearCache(slash(path.relative(srcDir, id)))
-            return server.moduleGraph.getModuleById(id)
+            return this.environment.moduleGraph.getModuleById(id)
           })
-        ].filter(Boolean) as ModuleNode[]
+        ].filter((mod) => mod !== undefined)
       }
     }
   }

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -372,10 +372,7 @@ export async function createVitePressPlugin(
       if (file === configPath || configDeps.includes(file)) {
         siteConfig.logger.info(
           c.green(
-            `${path.relative(
-              process.cwd(),
-              file
-            )} changed, restarting server...\n`
+            `${path.relative(process.cwd(), file)} changed, restarting server...\n`
           ),
           { clear: true, timestamp: true }
         )

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -424,6 +424,8 @@ export async function createVitePressPlugin(
   const hmrFix: Plugin = {
     name: 'vitepress:hmr-fix',
     async hotUpdate({ file, modules }) {
+      if (this.environment.name !== 'client') return
+
       const importers = [...(importerMap[slash(file)] || [])]
       if (importers.length > 0) {
         return [

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -129,7 +129,6 @@ export async function createVitePressPlugin(
       markdownToVue = await createMarkdownToVueRenderFn(
         srcDir,
         markdown,
-        siteConfig.pages,
         config.command === 'build',
         config.base,
         lastUpdated,

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -49,6 +49,7 @@ interface ResolvedRouteModule {
 }
 
 const dynamicRouteRE = /\[(\w+?)\]/g
+const pathLoaderRE = /\.paths\.m?[jt]s$/
 
 const routeModuleCache = new Map<string, ResolvedRouteModule>()
 let moduleGraph = new ModuleGraph()
@@ -148,7 +149,7 @@ export const dynamicRoutesPlugin = async (
       }
     },
 
-    async hotUpdate({ file, modules: existingMods, type }) {
+    async hotUpdate({ file, modules: existingMods }) {
       if (this.environment.name !== 'client') return
 
       const modules = new Set<EnvironmentModuleNode>()
@@ -175,7 +176,7 @@ export const dynamicRoutesPlugin = async (
       if (
         (modules.size && !normalizedFile.endsWith('.md')) ||
         watchedFileChanged ||
-        (type === 'create' && /\.paths\.m?[jt]s$/.test(normalizedFile))
+        pathLoaderRE.test(normalizedFile)
       ) {
         // path loader module or deps updated, reset loaded routes
         Object.assign(

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -134,9 +134,7 @@ export const dynamicRoutesPlugin = async (
 
         // params are injected with special markers and extracted as part of
         // __pageData in ../markdownToVue.ts
-        return `__VP_PARAMS_START${JSON.stringify(
-          params
-        )}__VP_PARAMS_END__${baseContent}`
+        return `__VP_PARAMS_START${JSON.stringify(params)}__VP_PARAMS_END__${baseContent}`
       }
     },
 

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -69,6 +69,7 @@ interface UserRouteConfig {
 interface RouteModule {
   path: string
   config: {
+    watch?: string[] | string
     paths:
       | UserRouteConfig[]
       | ((
@@ -76,7 +77,6 @@ interface RouteModule {
         ) => UserRouteConfig[] | Promise<UserRouteConfig[]>)
   }
   dependencies: string[]
-  watch?: string[] | string
 }
 
 const routeModuleCache = new Map<string, RouteModule>()
@@ -260,8 +260,11 @@ export async function resolveDynamicRoutes(
 
     // Process custom watch files if provided.
     let watch: string[] | undefined
-    if (mod.watch) {
-      watch = typeof mod.watch === 'string' ? [mod.watch] : mod.watch
+    if (mod.config.watch) {
+      watch =
+        typeof mod.config.watch === 'string'
+          ? [mod.config.watch]
+          : mod.config.watch
       watch = watch.map((p) =>
         p.startsWith('.')
           ? normalizePath(path.resolve(path.dirname(pathsFile), p))

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -172,14 +172,15 @@ export const dynamicRoutesPlugin = async (
         }
       }
 
-      if (modules.size || watchedFileChanged) {
+      if (
+        (modules.size && !normalizedFile.endsWith('.md')) ||
+        watchedFileChanged
+      ) {
         // path loader module or deps updated, reset loaded routes
-        if (!normalizedFile.endsWith('.md') || watchedFileChanged) {
-          Object.assign(
-            config,
-            await resolvePages(config.srcDir, config.userConfig, config.logger)
-          )
-        }
+        Object.assign(
+          config,
+          await resolvePages(config.srcDir, config.userConfig, config.logger)
+        )
       }
 
       return modules.size ? [...existingMods, ...modules] : undefined

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -148,7 +148,7 @@ export const dynamicRoutesPlugin = async (
       }
     },
 
-    async hotUpdate({ file, modules: existingMods }) {
+    async hotUpdate({ file, modules: existingMods, type }) {
       if (this.environment.name !== 'client') return
 
       const modules = new Set<EnvironmentModuleNode>()
@@ -174,7 +174,8 @@ export const dynamicRoutesPlugin = async (
 
       if (
         (modules.size && !normalizedFile.endsWith('.md')) ||
-        watchedFileChanged
+        watchedFileChanged ||
+        (type === 'create' && /\.paths\.m?[jt]s$/.test(normalizedFile))
       ) {
         // path loader module or deps updated, reset loaded routes
         Object.assign(

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -141,6 +141,8 @@ export const dynamicRoutesPlugin = async (
     },
 
     async hotUpdate({ file, modules: existingMods }) {
+      if (this.environment.name !== 'client') return
+
       routeModuleCache.delete(file)
       const modules: EnvironmentModuleNode[] = []
 

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -141,6 +141,7 @@ export const dynamicRoutesPlugin = async (
     },
 
     async hotUpdate({ file, modules: existingMods }) {
+      routeModuleCache.delete(file)
       const modules: EnvironmentModuleNode[] = []
 
       const mods = config.dynamicRoutes.fileToModulesMap[file]

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -3,9 +3,9 @@ import path from 'node:path'
 import c from 'picocolors'
 import { glob } from 'tinyglobby'
 import {
-  EnvironmentModuleNode,
   loadConfigFromFile,
   normalizePath,
+  type EnvironmentModuleNode,
   type Logger,
   type Plugin
 } from 'vite'

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -152,7 +152,7 @@ export const dynamicRoutesPlugin = async (
     async hotUpdate({ file, modules: existingMods }) {
       if (this.environment.name !== 'client') return
 
-      const modules = new Set<EnvironmentModuleNode>()
+      const modules: EnvironmentModuleNode[] = []
       const normalizedFile = normalizePath(file)
 
       // Trigger update if a module or its dependencies changed.
@@ -160,7 +160,7 @@ export const dynamicRoutesPlugin = async (
         routeModuleCache.delete(id)
         const mod = this.environment.moduleGraph.getModuleById(id)
         if (mod) {
-          modules.add(mod)
+          modules.push(mod)
         }
       }
 
@@ -174,7 +174,7 @@ export const dynamicRoutesPlugin = async (
       }
 
       if (
-        (modules.size && !normalizedFile.endsWith('.md')) ||
+        (modules.length && !normalizedFile.endsWith('.md')) ||
         watchedFileChanged ||
         pathLoaderRE.test(normalizedFile)
       ) {
@@ -185,7 +185,7 @@ export const dynamicRoutesPlugin = async (
         )
       }
 
-      return modules.size ? [...existingMods, ...modules] : undefined
+      return modules.length ? [...existingMods, ...modules] : undefined
     }
   }
 }

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -57,7 +57,8 @@ export async function resolvePages(
   return {
     pages,
     dynamicRoutes,
-    rewrites
+    rewrites,
+    __dirty: true
   }
 }
 
@@ -96,6 +97,8 @@ export type ResolvedRouteConfig = UserRouteConfig & {
   fullPath: string
 }
 
+const fileToModulesMap: Record<string, Set<string>> = {}
+
 export const dynamicRoutesPlugin = async (
   config: SiteConfig
 ): Promise<Plugin> => {
@@ -120,7 +123,7 @@ export const dynamicRoutesPlugin = async (
       if (matched) {
         const { route, params, content } = matched
         const routeFile = normalizePath(path.resolve(config.srcDir, route))
-        config.dynamicRoutes.fileToModulesMap[routeFile].add(id)
+        fileToModulesMap[routeFile].add(id)
 
         let baseContent = fs.readFileSync(routeFile, 'utf-8')
 
@@ -160,7 +163,7 @@ export const dynamicRoutesPlugin = async (
 
       const modules: EnvironmentModuleNode[] = []
 
-      const mods = config.dynamicRoutes.fileToModulesMap[normalizedFile]
+      const mods = fileToModulesMap[normalizedFile]
       if (mods) {
         // path loader module or deps updated, reset loaded routes
         if (!normalizedFile.endsWith('.md')) {
@@ -186,7 +189,7 @@ export async function resolveDynamicRoutes(
   srcDir: string,
   routes: string[],
   logger: Logger
-): Promise<SiteConfig['dynamicRoutes']> {
+) {
   const pendingResolveRoutes: Promise<ResolvedRouteConfig[]>[] = []
   const routeFileToModulesMap: Record<string, Set<string>> = {}
 

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -44,13 +44,14 @@ export interface RouteModule {
   paths:
     | UserRouteConfig[]
     | ((watchedFiles: string[]) => Awaitable<UserRouteConfig[]>)
+  transformPageData?: UserConfig['transformPageData']
 }
 
 interface ResolvedRouteModule {
   watch: string[] | undefined
   routes: ResolvedRouteConfig[] | undefined
   loader: RouteModule['paths']
-  transformPageData?: UserConfig['transformPageData']
+  transformPageData?: RouteModule['transformPageData']
 }
 
 const dynamicRouteRE = /\[(\w+?)\]/g
@@ -58,6 +59,13 @@ const pathLoaderRE = /\.paths\.m?[jt]s$/
 
 const routeModuleCache = new Map<string, ResolvedRouteModule>()
 let moduleGraph = new ModuleGraph()
+
+/**
+ * Helper for defining routes with type inference
+ */
+export function defineRoutes(loader: RouteModule) {
+  return loader
+}
 
 export async function resolvePages(
   srcDir: string,

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -140,8 +140,7 @@ export const dynamicRoutesPlugin = async (
       }
     },
 
-    async hotUpdate(ctx) {
-      const file = ctx.file
+    async hotUpdate({ file, modules: existingMods }) {
       const modules: EnvironmentModuleNode[] = []
 
       const mods = config.dynamicRoutes.fileToModulesMap[file]
@@ -158,7 +157,7 @@ export const dynamicRoutesPlugin = async (
         }
       }
 
-      return modules.length > 0 ? [...ctx.modules, ...modules] : undefined
+      return modules.length > 0 ? [...existingMods, ...modules] : undefined
     }
   }
 }

--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -199,6 +199,8 @@ export async function localSearchPlugin(
     },
 
     async hotUpdate({ file }) {
+      if (this.environment.name !== 'client') return
+
       if (file.endsWith('.md')) {
         await indexFile(file)
         debug('🔍️ Updated', file)

--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -198,7 +198,7 @@ export async function localSearchPlugin(
       }
     },
 
-    async handleHotUpdate({ file }) {
+    async hotUpdate({ file }) {
       if (file.endsWith('.md')) {
         await indexFile(file)
         debug('🔍️ Updated', file)

--- a/src/node/plugins/staticDataPlugin.ts
+++ b/src/node/plugins/staticDataPlugin.ts
@@ -70,7 +70,7 @@ export const staticDataPlugin: Plugin = {
       if (existing) {
         ;({ watch, load } = existing)
       } else {
-        // use vite's load config util as a away to load Node.js file with
+        // use vite's load config util as a way to load Node.js file with
         // TS & native ESM support
         const res = await loadConfigFromFile({} as any, id.replace(/\?.*$/, ''))
 
@@ -125,8 +125,8 @@ export const staticDataPlugin: Plugin = {
 
   hotUpdate(ctx) {
     const file = ctx.file
-
     const modules: EnvironmentModuleNode[] = []
+
     // dependency of data loader changed
     // (note the dep array includes the loader file itself)
     if (file in depToLoaderModuleIdMap) {

--- a/src/node/plugins/staticDataPlugin.ts
+++ b/src/node/plugins/staticDataPlugin.ts
@@ -156,6 +156,6 @@ export const staticDataPlugin: Plugin = {
       }
     }
 
-    return modules.length > 0 ? [...existingMods, ...modules] : undefined
+    return modules.length ? [...existingMods, ...modules] : undefined
   }
 }

--- a/src/node/plugins/staticDataPlugin.ts
+++ b/src/node/plugins/staticDataPlugin.ts
@@ -124,6 +124,8 @@ export const staticDataPlugin: Plugin = {
   },
 
   hotUpdate({ file, modules: existingMods }) {
+    if (this.environment.name !== 'client') return
+
     const modules: EnvironmentModuleNode[] = []
 
     // dependency of data loader changed

--- a/src/node/plugins/staticDataPlugin.ts
+++ b/src/node/plugins/staticDataPlugin.ts
@@ -1,5 +1,5 @@
-import { isMatch } from 'picomatch'
 import path, { dirname, resolve } from 'node:path'
+import { isMatch } from 'picomatch'
 import { glob } from 'tinyglobby'
 import {
   type EnvironmentModuleNode,

--- a/src/node/plugins/staticDataPlugin.ts
+++ b/src/node/plugins/staticDataPlugin.ts
@@ -1,4 +1,4 @@
-import path, { dirname, resolve } from 'node:path'
+import path from 'node:path'
 import { isMatch } from 'picomatch'
 import { glob } from 'tinyglobby'
 import {
@@ -25,10 +25,12 @@ export function defineLoader(loader: LoaderModule) {
   return loader
 }
 
+// Map from loader module id to its module info
 const idToLoaderModulesMap: Record<string, LoaderModule | undefined> =
   Object.create(null)
 
-const depToLoaderModuleIdMap: Record<string, string> = Object.create(null)
+// Map from dependency file to a set of loader module ids
+const depToLoaderModuleIdsMap: Record<string, Set<string>> = Object.create(null)
 
 // During build, the load hook will be called on the same file twice
 // once for client and once for server build. Not only is this wasteful, it
@@ -62,7 +64,7 @@ export const staticDataPlugin: Plugin = {
         })
       }
 
-      const base = dirname(id)
+      const base = path.dirname(id)
       let watch: LoaderModule['watch']
       let load: LoaderModule['load']
 
@@ -77,7 +79,11 @@ export const staticDataPlugin: Plugin = {
         // record deps for hmr
         if (server && res) {
           for (const dep of res.dependencies) {
-            depToLoaderModuleIdMap[normalizePath(path.resolve(dep))] = id
+            const depPath = normalizePath(path.resolve(dep))
+            if (!depToLoaderModuleIdsMap[depPath]) {
+              depToLoaderModuleIdsMap[depPath] = new Set()
+            }
+            depToLoaderModuleIdsMap[depPath].add(id)
           }
         }
 
@@ -89,7 +95,7 @@ export const staticDataPlugin: Plugin = {
         if (watch) {
           watch = watch.map((p) => {
             return p.startsWith('.')
-              ? normalizePath(resolve(base, p))
+              ? normalizePath(path.resolve(base, p))
               : normalizePath(p)
           })
         }
@@ -97,9 +103,8 @@ export const staticDataPlugin: Plugin = {
       }
 
       // load the data
-      let watchedFiles
+      let watchedFiles: string[] = []
       if (watch) {
-        if (typeof watch === 'string') watch = [watch]
         watchedFiles = (
           await glob(watch, {
             ignore: ['**/node_modules/**', '**/dist/**'],
@@ -107,7 +112,7 @@ export const staticDataPlugin: Plugin = {
           })
         ).sort()
       }
-      const data = await load(watchedFiles || [])
+      const data = await load(watchedFiles)
 
       // record loader module for HMR
       if (server) {
@@ -125,19 +130,29 @@ export const staticDataPlugin: Plugin = {
     if (this.environment.name !== 'client') return
 
     const modules: EnvironmentModuleNode[] = []
+    const normalizedFile = normalizePath(file)
 
-    // dependency of data loader changed
-    // (note the dep array includes the loader file itself)
-    if (file in depToLoaderModuleIdMap) {
-      const id = depToLoaderModuleIdMap[file]!
-      delete idToLoaderModulesMap[id]
-      modules.push(this.environment.moduleGraph.getModuleById(id)!)
+    // Trigger update if a dependency (including transitive ones) changed.
+    if (normalizedFile in depToLoaderModuleIdsMap) {
+      for (const id of Array.from(
+        depToLoaderModuleIdsMap[normalizedFile] || []
+      )) {
+        delete idToLoaderModulesMap[id]
+        const mod = this.environment.moduleGraph.getModuleById(id)
+        if (mod) {
+          modules.push(mod)
+        }
+      }
     }
 
+    // Also check if the file matches any custom watch patterns.
     for (const id in idToLoaderModulesMap) {
-      const { watch } = idToLoaderModulesMap[id]!
-      if (watch && isMatch(file, watch)) {
-        modules.push(this.environment.moduleGraph.getModuleById(id)!)
+      const loader = idToLoaderModulesMap[id]
+      if (loader && loader.watch && isMatch(normalizedFile, loader.watch)) {
+        const mod = this.environment.moduleGraph.getModuleById(id)
+        if (mod && !modules.includes(mod)) {
+          modules.push(mod)
+        }
       }
     }
 

--- a/src/node/plugins/staticDataPlugin.ts
+++ b/src/node/plugins/staticDataPlugin.ts
@@ -123,8 +123,7 @@ export const staticDataPlugin: Plugin = {
     }
   },
 
-  hotUpdate(ctx) {
-    const file = ctx.file
+  hotUpdate({ file, modules: existingMods }) {
     const modules: EnvironmentModuleNode[] = []
 
     // dependency of data loader changed
@@ -142,6 +141,6 @@ export const staticDataPlugin: Plugin = {
       }
     }
 
-    return modules.length > 0 ? [...ctx.modules, ...modules] : undefined
+    return modules.length > 0 ? [...existingMods, ...modules] : undefined
   }
 }

--- a/src/node/plugins/staticDataPlugin.ts
+++ b/src/node/plugins/staticDataPlugin.ts
@@ -114,9 +114,7 @@ export const staticDataPlugin: Plugin = {
         idToLoaderModulesMap[id] = { watch, load }
       }
 
-      const result = `export const data = JSON.parse(${JSON.stringify(
-        JSON.stringify(data)
-      )})`
+      const result = `export const data = JSON.parse(${JSON.stringify(JSON.stringify(data))})`
 
       if (_resolve) _resolve(result)
       return result

--- a/src/node/siteConfig.ts
+++ b/src/node/siteConfig.ts
@@ -221,9 +221,7 @@ export interface SiteConfig<ThemeConfig = any>
   cacheDir: string
   tempDir: string
   pages: string[]
-  dynamicRoutes: {
-    routes: ResolvedRouteConfig[]
-  }
+  dynamicRoutes: ResolvedRouteConfig[]
   rewrites: {
     map: Record<string, string | undefined>
     inv: Record<string, string | undefined>

--- a/src/node/siteConfig.ts
+++ b/src/node/siteConfig.ts
@@ -4,6 +4,7 @@ import type { SitemapStreamOptions } from 'sitemap'
 import type { Logger, UserConfig as ViteConfig } from 'vite'
 import type { SitemapItem } from './build/generateSitemap'
 import type { MarkdownOptions } from './markdown/markdown'
+import type { ResolvedRouteConfig } from './plugins/dynamicRoutesPlugin'
 import type {
   Awaitable,
   HeadConfig,
@@ -28,26 +29,6 @@ export interface TransformContext {
   head: HeadConfig[]
   content: string
   assets: string[]
-}
-
-interface UserRouteConfig {
-  params: Record<string, string>
-  content?: string
-}
-
-export type ResolvedRouteConfig = UserRouteConfig & {
-  /**
-   * the raw route (relative to src root), e.g. foo/[bar].md
-   */
-  route: string
-  /**
-   * the actual path with params resolved (relative to src root), e.g. foo/1.md
-   */
-  path: string
-  /**
-   * absolute fs path
-   */
-  fullPath: string
 }
 
 export interface TransformPageContext {
@@ -242,7 +223,6 @@ export interface SiteConfig<ThemeConfig = any>
   pages: string[]
   dynamicRoutes: {
     routes: ResolvedRouteConfig[]
-    fileToModulesMap: Record<string, Set<string>>
   }
   rewrites: {
     map: Record<string, string | undefined>

--- a/src/node/utils/moduleGraph.ts
+++ b/src/node/utils/moduleGraph.ts
@@ -1,0 +1,115 @@
+export class ModuleGraph {
+  // Each module is tracked with its dependencies and dependents.
+  private nodes: Map<
+    string,
+    { dependencies: Set<string>; dependents: Set<string> }
+  > = new Map()
+
+  /**
+   * Adds or updates a module by merging the provided dependencies
+   * with any existing ones.
+   *
+   * For every new dependency, the module is added to that dependency's
+   * 'dependents' set.
+   *
+   * @param module - The module to add or update.
+   * @param dependencies - Array of module names that the module depends on.
+   */
+  add(module: string, dependencies: string[]): void {
+    // Ensure the module exists in the graph.
+    if (!this.nodes.has(module)) {
+      this.nodes.set(module, {
+        dependencies: new Set(),
+        dependents: new Set()
+      })
+    }
+    const moduleNode = this.nodes.get(module)!
+
+    // Merge the new dependencies with any that already exist.
+    for (const dep of dependencies) {
+      if (!moduleNode.dependencies.has(dep)) {
+        moduleNode.dependencies.add(dep)
+        // Ensure the dependency exists in the graph.
+        if (!this.nodes.has(dep)) {
+          this.nodes.set(dep, {
+            dependencies: new Set(),
+            dependents: new Set()
+          })
+        }
+        // Add the module as a dependent of the dependency.
+        this.nodes.get(dep)!.dependents.add(module)
+      }
+    }
+  }
+
+  /**
+   * Deletes a module and all modules that (transitively) depend on it.
+   *
+   * This method performs a depth-first search from the target module,
+   * collects all affected modules, and then removes them from the graph,
+   * cleaning up their references from other nodes.
+   *
+   * @param module - The module to delete.
+   * @returns A Set containing the deleted module and all modules that depend on it.
+   */
+  delete(module: string): Set<string> {
+    const deleted = new Set<string>()
+    const stack: string[] = [module]
+
+    // Traverse the reverse dependency graph (using dependents).
+    while (stack.length) {
+      const current = stack.pop()!
+      if (!deleted.has(current)) {
+        deleted.add(current)
+        const node = this.nodes.get(current)
+        if (node) {
+          for (const dependent of node.dependents) {
+            stack.push(dependent)
+          }
+        }
+      }
+    }
+
+    // Remove deleted nodes from the graph.
+    // For each deleted node, also remove it from its dependencies' dependents.
+    for (const mod of deleted) {
+      const node = this.nodes.get(mod)
+      if (node) {
+        for (const dep of node.dependencies) {
+          const depNode = this.nodes.get(dep)
+          if (depNode) {
+            depNode.dependents.delete(mod)
+          }
+        }
+      }
+      this.nodes.delete(mod)
+    }
+
+    return deleted
+  }
+
+  /**
+   * Clears all modules from the graph.
+   */
+  clear(): void {
+    this.nodes.clear()
+  }
+
+  /**
+   * Creates a deep clone of the ModuleGraph instance.
+   * This is useful for preserving the state of the graph
+   * before making modifications.
+   *
+   * @returns A new ModuleGraph instance with the same state as the original.
+   */
+  clone(): ModuleGraph {
+    const clone = new ModuleGraph()
+    for (const [module, { dependencies, dependents }] of this.nodes) {
+      clone.nodes.set(module, {
+        dependencies: new Set(dependencies),
+        dependents: new Set(dependents)
+      })
+    }
+    return clone
+  }
+}

--- a/src/node/utils/moduleGraph.ts
+++ b/src/node/utils/moduleGraph.ts
@@ -27,7 +27,7 @@ export class ModuleGraph {
 
     // Merge the new dependencies with any that already exist.
     for (const dep of dependencies) {
-      if (!moduleNode.dependencies.has(dep)) {
+      if (!moduleNode.dependencies.has(dep) && dep !== module) {
         moduleNode.dependencies.add(dep)
         // Ensure the dependency exists in the graph.
         if (!this.nodes.has(dep)) {

--- a/src/node/utils/task.ts
+++ b/src/node/utils/task.ts
@@ -1,7 +1,7 @@
 import ora from 'ora'
 
 export const okMark = '\x1b[32m✓\x1b[0m'
-export const failMark = '\x1b[31m✖\x1b[0m'
+export const failMark = '\x1b[31m✗\x1b[0m'
 
 export async function task(taskName: string, task: () => Promise<void>) {
   const spinner = ora({ discardStdin: false })


### PR DESCRIPTION
TODO:

- [x] Review `handleHotUpdate` code across codebase. Migrate to `hotUpdate` if needed. Avoid running same hook twice.
   - [x] main plugin
   - [x] hmr fix plugin, fixes #4567
   - [x] static data plugin
   - [x] dynamic route plugin -- handle hmr for watch files (track below) 
   - [x] local search plugin -- hmr not working (track in separate pr along with other performance fixes and stable index, needs discarding docs from index on deletion/update too)
- [x] Do full page reload on changes in path and data loader files, and their (transitive) deps. Avoid server restart if possible. Ensure that page data is updated.
   - [x] data loader
   - [x] path loader
      - [x] (transitive) deps
      - [x] watched files -- track below
      - [x] page data -- track below
- [x] Allow specifying deps for path loaders - fixes #4569, fixes #3937
   - [x] basic implementation
   - [x] cache invalidation and hmr
- [x] fixes #2637
   - [x] basic implementation
   - [x] cache invalidation and hmr (route data of dynamic routes isn't updated on hmr, it doesn't pass through the core plugin's handleHotUpdate since the files are virtual)
- [x] out of sync maps in createMarkdownToVueRenderFn (https://github.com/vuejs/vitepress/commit/c2ab5b03a8eb076a39d8117df9ccab7d2ad028f3 didn't fix that because pages are later mapped inside that function)
- [x] `import.meta.hot` now accepts id instead of url. Fix those.
- [x] Don't use stale cache after full server restart. (Ensure it's always cleared/re-created.)
- [x] Export type helper fn for path loader.
- [ ] Add e2e tests for hmr.
- [ ] Update docs.