### PR TITLE
Fix typo

### DIFF
--- a/template/.vitepress/theme/style.css
+++ b/template/.vitepress/theme/style.css
@@ -24,7 +24,7 @@
  *
  *   The soft color must be semi transparent alpha channel. This is crucial
  *   because it allows adding multiple "soft" colors on top of each other
- *   to create a accent, such as when having inline code block inside
+ *   to create an accent, such as when having inline code block inside
  *   custom containers.
  *
  * - `default`: The color used purely for subtle indication without any


### PR DESCRIPTION
### Description

This PR simply fixes a typo in the `style.css`: "a accent" should be "an accent".

### Linked Issues

N/A

### Additional Context

N/A

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
