### PR TITLE
fix(theme): allow interactions behind scroll shadow

### DIFF
--- a/src/client/theme-default/components/VPDoc.vue
+++ b/src/client/theme-default/components/VPDoc.vue
@@ -154,6 +154,7 @@ const pageName = computed(() =>
   width: 224px;
   height: 32px;
   background: linear-gradient(transparent, var(--vp-c-bg) 70%);
+  pointer-events: none;
 }
 
 .aside-content {


### PR DESCRIPTION
###  Issue  
Items behind the top and bottom scroll shadow were not interactive. The shadow elements were intercepting pointer events, preventing **clicks** and **hover effects** from reaching the elements beneath them.  

###  Solution  
Added `pointer-events: none;` to the shadow element.  

### Before

https://github.com/user-attachments/assets/a2c5bd88-83a0-4c02-8683-f1fedcee35c2

### After

https://github.com/user-attachments/assets/2f8d0f2a-d31f-4102-984f-c6a7e23dfdb3

