### PR TITLE
fix: set correct oldURL and newURL for hashchange

### DIFF
--- a/src/client/app/router.ts
+++ b/src/client/app/router.ts
@@ -325,12 +325,12 @@ async function changeRoute(
   { smoothScroll = false, initialLoad = false } = {}
 ): Promise<boolean> {
   const loc = normalizeHref(location.href)
-  const { pathname, hash } = new URL(href, fakeHost)
-  const currentLoc = new URL(loc, fakeHost)
+  const nextUrl = new URL(href, location.origin)
+  const currentUrl = new URL(loc, location.origin)
 
   if (href === loc) {
     if (!initialLoad) {
-      scrollTo(hash, smoothScroll)
+      scrollTo(nextUrl.hash, smoothScroll)
       return false
     }
   } else {
@@ -338,16 +338,16 @@ async function changeRoute(
     history.replaceState({ scrollPosition: window.scrollY }, '')
     history.pushState({}, '', href)
 
-    if (pathname === currentLoc.pathname) {
+    if (nextUrl.pathname === currentUrl.pathname) {
       // scroll between hash anchors on the same page, avoid duplicate entries
-      if (hash !== currentLoc.hash) {
+      if (nextUrl.hash !== currentUrl.hash) {
         window.dispatchEvent(
           new HashChangeEvent('hashchange', {
-            oldURL: currentLoc.href,
-            newURL: href
+            oldURL: currentUrl.href,
+            newURL: nextUrl.href
           })
         )
-        scrollTo(hash, smoothScroll)
+        scrollTo(nextUrl.hash, smoothScroll)
       }
 
       return false


### PR DESCRIPTION
### Description

The `oldURL` and `newURL` used to look like this:

```
"http://a.com/rules#foo"
"/rules#bar"
```

It should be a full URL instead according to the [browser behaviour](https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event#event_properties). This PR updates them to:

```
"http://example.com/rules#foo"
"http://example.com/rules#bar"
```

Where `http://example.com` is the current origin of the site, so it could also be something like `http://localhost:5173` locally.

### Linked Issues

N/A

### Additional Context

I tested this manually locally. I was using it [here](https://github.com/publint/publint/blob/b875509f234ea1af1a08d507734df8a521c67b4a/site/src/pages/rules.md?plain=1#L20-L21).
