### PR TITLE
feat: switch tab to sync multiple group status

### DIFF
--- a/src/client/app/composables/codeGroups.ts
+++ b/src/client/app/composables/codeGroups.ts
@@ -14,17 +14,26 @@ export function useCodeGroups() {
 
   if (inBrowser) {
     function syncMultipleCodeGroups(group: HTMLElement) {
-      const selector = group.className.split(' ').filter(Boolean).map((c) => `.${c}`).join('')
-      let checkTabText = group.querySelector('input:checked')?.nextElementSibling?.textContent || ''
+      const selector = group.className
+        .split(' ')
+        .filter(Boolean)
+        .map((c) => `.${c}`)
+        .join('')
+      let checkTabText =
+        group.querySelector('input:checked')?.nextElementSibling?.textContent ||
+        ''
       document.querySelectorAll(selector).forEach((groupEl) => {
         if (group === groupEl) {
           return
         }
         const labels = groupEl.querySelectorAll('label')
         if (!labels.length) return
-        const targetIndex = Array.from(labels).findIndex((label) => label.textContent === checkTabText)
+        const targetIndex = Array.from(labels).findIndex(
+          (label) => label.textContent === checkTabText
+        )
         if (targetIndex < 0) return
-        const input = labels[targetIndex].previousElementSibling as HTMLInputElement
+        const input = labels[targetIndex]
+          .previousElementSibling as HTMLInputElement
         input.checked = true
         const blocks = groupEl.querySelector('.blocks')
         if (!blocks) return
@@ -34,7 +43,6 @@ export function useCodeGroups() {
           child.classList.remove('active')
         })
         blocks.children[targetIndex].classList.add('active')
-        
       })
     }
     window.addEventListener('click', (e) => {

--- a/src/client/app/composables/codeGroups.ts
+++ b/src/client/app/composables/codeGroups.ts
@@ -13,6 +13,30 @@ export function useCodeGroups() {
   }
 
   if (inBrowser) {
+    function syncMultipleCodeGroups(group: HTMLElement) {
+      const selector = group.className.split(' ').filter(Boolean).map((c) => `.${c}`).join('')
+      let checkTabText = group.querySelector('input:checked')?.nextElementSibling?.textContent || ''
+      document.querySelectorAll(selector).forEach((groupEl) => {
+        if (group === groupEl) {
+          return
+        }
+        const labels = groupEl.querySelectorAll('label')
+        if (!labels.length) return
+        const targetIndex = Array.from(labels).findIndex((label) => label.textContent === checkTabText)
+        if (targetIndex < 0) return
+        const input = labels[targetIndex].previousElementSibling as HTMLInputElement
+        input.checked = true
+        const blocks = groupEl.querySelector('.blocks')
+        if (!blocks) return
+        const current = blocks.children[targetIndex]
+        if (!current) return
+        Array.from(blocks.children).forEach((child) => {
+          child.classList.remove('active')
+        })
+        blocks.children[targetIndex].classList.add('active')
+        
+      })
+    }
     window.addEventListener('click', (e) => {
       const el = e.target as HTMLInputElement
 
@@ -37,6 +61,8 @@ export function useCodeGroups() {
 
         current.classList.remove('active')
         next.classList.add('active')
+
+        syncMultipleCodeGroups(group)
 
         const label = group?.querySelector(`label[for="${el.id}"]`)
         label?.scrollIntoView({ block: 'nearest' })


### PR DESCRIPTION
### Description
When there are multiple groups of similar structures in the grouped tabs, click to switch one of the groups, and the tab status of other groups will be synchronized.
![vitepress](https://github.com/user-attachments/assets/f10bb467-ef2e-45d8-97e0-e42a669c4564)

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
