### PR TITLE
docs: optimize doc descriptions

### DIFF
--- a/docs/en/guide/asset-handling.md
+++ b/docs/en/guide/asset-handling.md
@@ -20,6 +20,10 @@ All referenced assets, including those using absolute paths, will be copied to t
 
 All **static** path references, including absolute paths, should be based on your working directory structure.
 
+::: tip If you use `srcDir`
+If you use [`srcDir`](../reference/site-config#srcdir), [`public`](#the-public-directory) directory should be placed under the `srcDir` directory.
+:::
+
 ## The Public Directory
 
 Sometimes you may need to provide static assets that are not directly referenced in any of your Markdown or theme components, or you may want to serve certain files with the original filename. Examples of such files include `robots.txt`, favicons, and PWA icons.

--- a/docs/en/reference/default-theme-search.md
+++ b/docs/en/reference/default-theme-search.md
@@ -43,7 +43,7 @@ export default defineConfig({
       provider: 'local',
       options: {
         locales: {
-          zh: { // make this `root` if you want to translate the default locale
+          zh: {
             translations: {
               button: {
                 buttonText: '搜索',
@@ -64,6 +64,43 @@ export default defineConfig({
                   closeKeyAriaLabel: 'esc'
                 }
               }
+            }
+          }
+        }
+      }
+    }
+  }
+})
+```
+
+If you only want to translate the default language, you can configure it like this:
+
+```ts
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  themeConfig: {
+    search: {
+      provider: 'local',
+      options: {
+        translations: {
+          button: {
+            buttonText: '搜索',
+            buttonAriaLabel: '搜索'
+          },
+          modal: {
+            displayDetails: '显示详细列表',
+            resetButtonTitle: '重置搜索',
+            backButtonTitle: '关闭搜索',
+            noResultsText: '没有结果',
+            footer: {
+              selectText: '选择',
+              selectKeyAriaLabel: '输入',
+              navigateText: '导航',
+              navigateUpKeyAriaLabel: '上箭头',
+              navigateDownKeyAriaLabel: '下箭头',
+              closeText: '关闭',
+              closeKeyAriaLabel: 'esc'
             }
           }
         }

--- a/docs/zh/guide/asset-handling.md
+++ b/docs/zh/guide/asset-handling.md
@@ -20,6 +20,10 @@
 
 所有**静态**路径引用，包括绝对路径，都应基于你的工作目录的结构。
 
+::: tip 如果你使用了 `srcDir`
+如果你使用了 [`srcDir`](../reference/site-config#srcdir) 配置项，[`public`](#the-public-directory) 目录应放置于 `srcDir` 目录下。
+:::
+
 ## public 目录 {#the-public-directory}
 
 有时可能需要一些静态资源，但这些资源没有直接被 Markdown 或主题组件直接引用，或者你可能想以原始文件名提供某些文件，像 `robots.txt`，favicons 和 PWA 图标这样的文件。

--- a/docs/zh/reference/default-theme-search.md
+++ b/docs/zh/reference/default-theme-search.md
@@ -42,17 +42,61 @@ export default defineConfig({
           zh: {
             translations: {
               button: {
-                buttonText: '搜索文档',
-                buttonAriaLabel: '搜索文档'
+                buttonText: '搜索',
+                buttonAriaLabel: '搜索'
               },
               modal: {
-                noResultsText: '无法找到相关结果',
-                resetButtonTitle: '清除查询条件',
+                displayDetails: '显示详细列表',
+                resetButtonTitle: '重置搜索',
+                backButtonTitle: '关闭搜索',
+                noResultsText: '没有结果',
                 footer: {
                   selectText: '选择',
-                  navigateText: '切换'
+                  selectKeyAriaLabel: '输入',
+                  navigateText: '导航',
+                  navigateUpKeyAriaLabel: '上箭头',
+                  navigateDownKeyAriaLabel: '下箭头',
+                  closeText: '关闭',
+                  closeKeyAriaLabel: 'esc'
                 }
               }
+            }
+          } 
+        }
+      }
+    }
+  }
+})
+```
+
+如果你只想翻译默认语言，可以像这样配置：
+
+```ts
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  themeConfig: {
+    search: {
+      provider: 'local',
+      options: {
+        translations: {
+          button: {
+            buttonText: '搜索',
+            buttonAriaLabel: '搜索'
+          },
+          modal: {
+            displayDetails: '显示详细列表',
+            resetButtonTitle: '重置搜索',
+            backButtonTitle: '关闭搜索',
+            noResultsText: '没有结果',
+            footer: {
+              selectText: '选择',
+              selectKeyAriaLabel: '输入',
+              navigateText: '导航',
+              navigateUpKeyAriaLabel: '上箭头',
+              navigateDownKeyAriaLabel: '下箭头',
+              closeText: '关闭',
+              closeKeyAriaLabel: 'esc'
             }
           }
         }


### PR DESCRIPTION
### Description

Completing the configuration of i18n content in the English documentation. Also optimize the document description and add examples of translate the default language to avoid troubles.

I found that if I use [srcDir](https://vitepress.dev/reference/site-config#srcdir), `public` must be placed in the `srcDir` directory and I added that description.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
