### PR TITLE
docs: markdown file inclusion example config line-numbers

### DIFF
--- a/docs/en/guide/markdown.md
+++ b/docs/en/guide/markdown.md
@@ -824,7 +824,7 @@ It also supports selecting a line range:
 
 **Input**
 
-```md
+```md:line-numbers
 # Docs
 
 ## Basics
@@ -834,7 +834,7 @@ It also supports selecting a line range:
 
 **Part file** (`parts/basics.md`)
 
-```md
+```md:line-numbers
 Some getting started stuff.
 
 ### Configuration
@@ -844,7 +844,7 @@ Can be created using `.foorc.json`.
 
 **Equivalent code**
 
-```md
+```md:line-numbers
 # Docs
 
 ## Basics
@@ -860,7 +860,7 @@ You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/co
 
 **Input**
 
-```md
+```md:line-numbers
 # Docs
 
 ## Basics
@@ -871,7 +871,7 @@ You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/co
 
 **Part file** (`parts/basics.md`)
 
-```md
+```md:line-numbers
 <!-- #region basic-usage -->
 ## Usage Line 1
 
@@ -883,7 +883,7 @@ You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/co
 
 **Equivalent code**
 
-```md
+```md:line-numbers
 # Docs
 
 ## Basics


### PR DESCRIPTION
### Description
The markdown file inclusion sample code clearly states the supported line ranges. I think marking the line numbers at this time can help you quickly locate the specific equivalent effects. (Sometimes I subconsciously start counting from 0 :)
![image](https://github.com/user-attachments/assets/45ee8252-2fea-4e79-baaf-aee5471aec63)

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
