### PR TITLE
fix(theme-default): ensure proper sizing of SVG hero images

### DIFF
--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -323,7 +323,7 @@ const heroImageSlotExists = inject('hero-image-slot-exists') as Ref<boolean>
   max-width: 192px;
   max-height: 192px;
   width: 100%;
-  height: 100%
+  height: 100%;
   object-fit: contain;
   /*rtl:ignore*/
   transform: translate(-50%, -50%);

--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -322,8 +322,9 @@ const heroImageSlotExists = inject('hero-image-slot-exists') as Ref<boolean>
   left: 50%;
   max-width: 192px;
   max-height: 192px;
-  height: 100%;
-  aspect-ratio: 1;
+  width: 100%;
+  height: 100%
+  object-fit: contain;
   /*rtl:ignore*/
   transform: translate(-50%, -50%);
 }

--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -322,6 +322,8 @@ const heroImageSlotExists = inject('hero-image-slot-exists') as Ref<boolean>
   left: 50%;
   max-width: 192px;
   max-height: 192px;
+  height: 100%;
+  aspect-ratio: 1;
   /*rtl:ignore*/
   transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
### Description

When using vector graphics (SVGs) without specified dimensions as hero images, they can render at unexpectedly small sizes in certain viewport widths. This creates inconsistent presentation compared to bitmap images.

### Before/After Comparison

|            | WebP                                                         | SVG                                                          |
| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
| **Before** | ![before-webp](https://github.com/user-attachments/assets/2e438e91-e13e-4427-924a-c08c1c7a9379) | ![before-svg](https://github.com/user-attachments/assets/d6a6fe8e-d007-467f-b400-0252e4a05a45) |
| **After**  | ![after-webp](https://github.com/user-attachments/assets/ccd72335-7d29-42da-aac4-9b1903d699cc) | ![after-svg](https://github.com/user-attachments/assets/82b02a3b-d2fe-47ee-8964-0700d4bb2607) |
