### PR TITLE
feat: add custom-block-title-default class for defaultTitle

### DIFF
--- a/src/node/markdown/plugins/containers.ts
+++ b/src/node/markdown/plugins/containers.ts
@@ -69,9 +69,11 @@ function createContainer(
           const title = md.renderInline(info || defaultTitle, {
             references: env.references
           })
+          const titleClass =
+            'custom-block-title' + (info ? '' : ' custom-block-title-default')
           if (klass === 'details')
             return `<details ${attrs}><summary>${title}</summary>\n`
-          return `<div ${attrs}><p class="custom-block-title">${title}</p>\n`
+          return `<div ${attrs}><p class="${titleClass}">${title}</p>\n`
         } else return klass === 'details' ? `</details>\n` : `</div>\n`
       }
     }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

Add a `custom-block-title-default` for default titles, which allows for better control over custom block without an explicit `info`.

### Linked Issues

<!-- e.g. fixes #123 -->

N/A

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

N/A

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
