### PR TITLE
refactor: avoid assigning to bundle object

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -366,15 +366,12 @@ export async function createVitePressPlugin(
             pageToHashMap![chunk.name.toLowerCase()] = hash
 
             // inject another chunk with the content stripped
-            bundle[name + '-lean'] = {
-              ...chunk,
+            this.emitFile({
+              type: 'asset',
+              name: name + '-lean',
               fileName: chunk.fileName.replace(/\.js$/, '.lean.js'),
-              preliminaryFileName: chunk.preliminaryFileName.replace(
-                /\.js$/,
-                '.lean.js'
-              ),
-              code: chunk.code.replace(staticStripRE, `""`)
-            }
+              source: chunk.code.replace(staticStripRE, `""`)
+            })
 
             // remove static markers from original code
             chunk.code = chunk.code.replace(staticRestoreRE, '')


### PR DESCRIPTION
### Description

[Assigning to `bundle` object is discouraged by rollup](https://rollupjs.org/plugin-development/#generatebundle:~:text=DANGER,this.emitFile.) and is not supported by rolldown.

This PR changes the code using assignment to use `this.emitFile` instead. This would make vitepress work with Rolldown powered Vite.

It should not cause any change unless there's a code that expects the lean chunks to be `type: 'chunk'` instead of `type: 'asset'`.

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
