### PR TITLE
feat(defaultTheme): make "Take me home" button's link customizable

### DIFF
--- a/src/client/theme-default/NotFound.vue
+++ b/src/client/theme-default/NotFound.vue
@@ -22,7 +22,7 @@ const { currentLang } = useLangs()
     <div class="action">
       <a
         class="link"
-        :href="withBase(currentLang.link)"
+        :href="withBase(theme.notFound?.link ?? currentLang.link)"
         :aria-label="theme.notFound?.linkLabel ?? 'go to home'"
       >
         {{ theme.notFound?.linkText ?? 'Take me home' }}

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -481,6 +481,13 @@ export namespace DefaultTheme {
     quote?: string
 
     /**
+     * Target of the home link.
+     *
+     * @default '/'
+     */
+    link?: string
+
+    /**
      * Set aria label for home link.
      *
      * @default 'go to home'


### PR DESCRIPTION
### Description

Added an optional configuration entry `themeConfig.notFound.link` that overrides the link target of "Take me home" button in `NotFound.vue`

### Linked Issues

fixes #4657 

### Additional Context

N/A
<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.

> There is nothing to preview for now.
