### PR TITLE
feat(default-theme): make VPButton slottable

### DIFF
--- a/src/client/theme-default/components/VPButton.vue
+++ b/src/client/theme-default/components/VPButton.vue
@@ -7,7 +7,7 @@ interface Props {
   tag?: string
   size?: 'medium' | 'big'
   theme?: 'brand' | 'alt' | 'sponsor'
-  text: string
+  text?: string
   href?: string
   target?: string;
   rel?: string;
@@ -35,7 +35,7 @@ const component = computed(() => {
     :target="props.target ?? (isExternal ? '_blank' : undefined)"
     :rel="props.rel ?? (isExternal ? 'noreferrer' : undefined)"
   >
-    {{ text }}
+    <slot>{{ text }}</slot>
   </component>
 </template>
 


### PR DESCRIPTION
### Description

This PR makes the `text` prop of the `VPButton` component optional and allows using a slot instead, falling back to the text prop if the slot is not used.

Using a slot allows adding SVGs or more complex constructs (e.g. styling through spans).