### PR TITLE
fix(doc):fix bun command example from Setup Wizard section

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -80,7 +80,7 @@ $ yarn vitepress init
 ```
 
 ```sh [bun]
-$ bun vitepress init
+$ bunx vitepress init
 ```
 
 :::


### PR DESCRIPTION
fix  bun command example from Setup Wizard section

### Description

the original given command will result in error: `error: Script not found "vitepress"`,
fix it by using `bunx`

### Linked Issues

null

### Additional Context

null

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
