### PR TITLE
fix: External link icon is not visible in doc content.

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -545,6 +545,7 @@
 /* prettier-ignore */
 :is(.vp-external-link-icon, .vp-doc a[href*='://'], .vp-doc a[target='_blank']):not(:is(.no-icon, svg a, :has(img, svg)))::after {
   display: inline-block;
+  content: '';
   margin-top: -1px;
   margin-left: 4px;
   width: 11px;


### PR DESCRIPTION
### Description

While the external link icon indicator is visible for the header links, the style definition is incomplete for doc content. This PR extends the rule to make it visible there too, so all external non-excepted links have a suitable indicator.

### Additional Context

<img width="117" alt="Screenshot 2025-04-22 at 15 00 54" src="https://github.com/user-attachments/assets/261b427f-954f-4633-8c84-2c0ad9cfb452" />
