### PR TITLE
refactor/use shiki's `transformerMetaHighlight()` and add support for multi-key meta notation like `add={1} remove={2}`

### DIFF
--- a/src/node/build/bundle.ts
+++ b/src/node/build/bundle.ts
@@ -121,7 +121,10 @@ export async function bundle(
                 manualChunks(id, ctx) {
                   // move known framework code into a stable chunk so that
                   // custom theme changes do not invalidate hash for all pages
-                  if (id.startsWith('\0vite')) {
+                  if (
+                    id.startsWith('\0vite') ||
+                    ctx.getModuleInfo(id)?.meta['vite:asset']
+                  ) {
                     return 'framework'
                   }
                   if (id.includes('plugin-vue:export-helper')) {

--- a/src/node/markdown/plugins/highlightLines.ts
+++ b/src/node/markdown/plugins/highlightLines.ts
@@ -1,8 +1,10 @@
 // Modified from https://github.com/egoist/markdown-it-highlight-lines
+// Now this plugin is only used to normalize line attrs.
 // The else part of line highlights logic is in './highlight.ts'.
-// Restore the `{0}` syntax recognized and processed by the markdown-it-attrs plugin
 
 import type { MarkdownItAsync } from 'markdown-it-async'
+
+const RE = /{([\d,-]+)}/
 
 export const highlightLinePlugin = (md: MarkdownItAsync) => {
   const fence = md.renderer.rules.fence!
@@ -10,28 +12,39 @@ export const highlightLinePlugin = (md: MarkdownItAsync) => {
     const [tokens, idx] = args
     const token = tokens[idx]
 
-    // due to use of markdown-it-attrs, the last `{0}` syntax would have been
+    // due to use of markdown-it-attrs, the {0} syntax would have been
     // converted to attrs on the token
-    // e.g.: `js add={1} remove={2}` => `js add={1} remove=`
-    //       `{2}` is stored in token.attrs
     const attr = token.attrs && token.attrs[0]
 
-    let removedLines = null
+    let lines = null
 
     if (!attr) {
-      return fence(...args)
+      // markdown-it-attrs maybe disabled
+      const rawInfo = token.info
+
+      if (!rawInfo || !RE.test(rawInfo)) {
+        return fence(...args)
+      }
+
+      const langName = rawInfo.replace(RE, '').trim()
+
+      // ensure the next plugin get the correct lang
+      token.info = langName
+
+      lines = RE.exec(rawInfo)![1]
     }
 
-    removedLines = attr[0]
-    if (!removedLines || !/[\d,-]+/.test(removedLines)) {
-      return fence(...args)
+    if (!lines) {
+      lines = attr![0]
+
+      if (!lines || !/[\d,-]+/.test(lines)) {
+        return fence(...args)
+      }
     }
 
-    // except for case like `js{1}`, no trailing space
-    token.info += token.info.endsWith('=') ? '' : ' '
-    // add the line numbers back to the token
-    token.info += "{" + removedLines + "}"
-
+    token.info += '{' + lines + '}'
+    // ensure there is a space between the lang and the line numbers
+    token.info = token.info.replace(/(?<![=])\{/g, " {")
     return fence(...args)
   }
 }


### PR DESCRIPTION
### Description

#### Use `transformerMetaHighlight()`

Use [shiki's transformer](https://shiki.style/packages/transformers#transformermetahighlight) to do meta highlight.

#### Support for multi-key line numbers notation in meta

Modified `highlightLinePlugin()` to support multi-key meta notation like `add={1} remove={2}`. 

In details, `markdown-it-attrs` plugin will parse and remove the **last** `{0}` notation in meta string, e.g. `js add={1} remove={2}` => `js add={1} remove=`. The original handling add the line numbers back to token but without braces `{}`, causing `transformerMetaHighlight()` unable to match the notations. So the braces is added in this PR. Also make sure there is a space between language name and `{0}` notations.

### Linked Issues

#4704 