### PR TITLE
fix(search): hide search input cancel button

### DIFF
--- a/src/client/theme-default/components/VPLocalSearchBox.vue
+++ b/src/client/theme-default/components/VPLocalSearchBox.vue
@@ -663,6 +663,10 @@ function onMouseMove(e: MouseEvent) {
   width: 100%;
 }
 
+.search-input::-webkit-search-cancel-button {
+  display: none;
+}
+
 @media (max-width: 767px) {
   .search-input {
     padding: 6px 4px;


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
After enabling `provider: 'local'`, a redundant native clear icon appears alongside the existing search action clear button.

Remove the native clear icon for better UI consistency, as the search action clear button is sufficient.

before
<img width="869" alt="image" src="https://github.com/user-attachments/assets/5f57d559-b007-4508-bc98-4c1a2983784f" />


after
<img width="869" alt="image" src="https://github.com/user-attachments/assets/2cdcbc9e-6206-4665-aa1b-9d8242385631" />

