### PR TITLE
fix: skip fields not supported by rolldown for rolldown-vite

### DIFF
--- a/src/node/build/bundle.ts
+++ b/src/node/build/bundle.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import * as vite from 'vite'
 import {
   build,
   normalizePath,
@@ -98,9 +99,12 @@ export async function bundle(
           app: path.resolve(APP_PATH, ssr ? 'ssr.js' : 'index.js'),
           ...input
         },
-        // important so that each page chunk and the index export things for each
-        // other
-        preserveEntrySignatures: 'allow-extension',
+        // @ts-ignore skip setting it for rolldown-vite since it doesn't support `preserveEntrySignatures` yet
+        ...(vite.rolldownVersion
+          ? undefined
+          : // important so that each page chunk and the index export things for each
+            // other
+            { preserveEntrySignatures: 'allow-extension' }),
         output: {
           sanitizeFileName,
           ...rollupOptions?.output,
@@ -118,44 +122,52 @@ export async function bundle(
                     ? `${config.assetsDir}/chunks/ui-custom.[hash].js`
                     : `${config.assetsDir}/chunks/[name].[hash].js`
                 },
-                manualChunks(id, ctx) {
-                  // move known framework code into a stable chunk so that
-                  // custom theme changes do not invalidate hash for all pages
-                  if (
-                    id.startsWith('\0vite') ||
-                    ctx.getModuleInfo(id)?.meta['vite:asset']
-                  ) {
-                    return 'framework'
-                  }
-                  if (id.includes('plugin-vue:export-helper')) {
-                    return 'framework'
-                  }
-                  if (
-                    id.includes(`${clientDir}/app`) &&
-                    id !== `${clientDir}/app/index.js`
-                  ) {
-                    return 'framework'
-                  }
-                  if (
-                    isEagerChunk(id, ctx.getModuleInfo) &&
-                    /@vue\/(runtime|shared|reactivity)/.test(id)
-                  ) {
-                    return 'framework'
-                  }
+                // @ts-ignore skip setting it for rolldown-vite since it doesn't support `manualChunks`
+                ...(vite.rolldownVersion
+                  ? undefined
+                  : {
+                      manualChunks(
+                        id: string,
+                        ctx: Pick<Rollup.PluginContext, 'getModuleInfo'>
+                      ) {
+                        // move known framework code into a stable chunk so that
+                        // custom theme changes do not invalidate hash for all pages
+                        if (
+                          id.startsWith('\0vite') ||
+                          ctx.getModuleInfo(id)?.meta['vite:asset']
+                        ) {
+                          return 'framework'
+                        }
+                        if (id.includes('plugin-vue:export-helper')) {
+                          return 'framework'
+                        }
+                        if (
+                          id.includes(`${clientDir}/app`) &&
+                          id !== `${clientDir}/app/index.js`
+                        ) {
+                          return 'framework'
+                        }
+                        if (
+                          isEagerChunk(id, ctx.getModuleInfo) &&
+                          /@vue\/(runtime|shared|reactivity)/.test(id)
+                        ) {
+                          return 'framework'
+                        }
 
-                  if (
-                    (id.startsWith(`${clientDir}/theme-default`) ||
-                      !excludedModules.some((i) => id.includes(i))) &&
-                    staticImportedByEntry(
-                      id,
-                      ctx.getModuleInfo,
-                      cacheTheme,
-                      themeEntryRE
-                    )
-                  ) {
-                    return 'theme'
-                  }
-                }
+                        if (
+                          (id.startsWith(`${clientDir}/theme-default`) ||
+                            !excludedModules.some((i) => id.includes(i))) &&
+                          staticImportedByEntry(
+                            id,
+                            ctx.getModuleInfo,
+                            cacheTheme,
+                            themeEntryRE
+                          )
+                        ) {
+                          return 'theme'
+                        }
+                      }
+                    })
               })
         }
       }


### PR DESCRIPTION
### Description

Skip fields that are not supported by rolldown when it's running with rolldown-vite.

This PR will make ecosystem-ci pass with rolldown-vite.

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
