### PR TITLE
feat: use `oxc-minify` instead of `transformWithEsbuild` when rolldown-vite is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "minimist": "^1.2.8",
     "nanoid": "^5.1.5",
     "ora": "^8.2.0",
+    "oxc-minify": "^0.69.0",
     "p-map": "^7.0.3",
     "path-to-regexp": "^6.3.0",
     "picocolors": "^1.1.1",
@@ -192,6 +193,7 @@
   },
   "peerDependencies": {
     "markdown-it-mathjax3": "^4",
+    "oxc-minify": "^0.69.0",
     "postcss": "^8"
   },
   "peerDependenciesMeta": {
@@ -199,6 +201,9 @@
       "optional": true
     },
     "postcss": {
+      "optional": true
+    },
+    "oxc-minify": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         version: 3.4.0
       '@vitejs/plugin-vue':
         specifier: ^5.2.4
-        version: 5.2.4(vite@6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
+        version: 5.2.4(vite@6.3.5(@types/node@22.15.17)(jiti@1.21.7)(lightningcss@1.30.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
       '@vue/devtools-api':
         specifier: ^7.7.6
         version: 7.7.6
@@ -66,7 +66,7 @@ importers:
         version: 3.4.0
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1)
+        version: 6.3.5(@types/node@22.15.17)(jiti@1.21.7)(lightningcss@1.30.0)(yaml@2.7.1)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.8.3)
@@ -224,6 +224,9 @@ importers:
       ora:
         specifier: ^8.2.0
         version: 8.2.0
+      oxc-minify:
+        specifier: ^0.69.0
+        version: 0.69.0
       p-map:
         specifier: ^7.0.3
         version: 7.0.3
@@ -289,7 +292,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1)
       vue-tsc:
         specifier: ^3.0.0-alpha.6
         version: 3.0.0-alpha.6(typescript@5.8.3)
@@ -477,6 +480,15 @@ packages:
         optional: true
       search-insights:
         optional: true
+
+  '@emnapi/core@1.4.3':
+    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
+
+  '@emnapi/runtime@1.4.3':
+    resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
+
+  '@emnapi/wasi-threads@1.0.2':
+    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
   '@esbuild/aix-ppc64@0.25.4':
     resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
@@ -695,6 +707,9 @@ packages:
   '@mdit-vue/types@2.1.4':
     resolution: {integrity: sha512-QiGNZslz+zXUs2X8D11UQhB4KAMZ0DZghvYxa7+1B+VMLcDtz//XHpWbcuexjzE3kBXSxIUTPH3eSQCa0puZHA==}
 
+  '@napi-rs/wasm-runtime@0.2.9':
+    resolution: {integrity: sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -707,12 +722,159 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-minify/binding-darwin-arm64@0.69.0':
+    resolution: {integrity: sha512-GkA53C8uPPR9S080ZxFs72f8fegVlb7IcFJiYd9qWB4sjkut2LtjlQPlMmefK3RolGjpwKgHCDhENwb6Nj+BHA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-minify/binding-darwin-x64@0.69.0':
+    resolution: {integrity: sha512-vlbu/tfqg1kEIGtEITxzScOYNXLojroeg2XCG5S6GOZKM7dkerDU/Freds5QEFyW4Eykc3NXMlor4aQCq0L1uA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-minify/binding-freebsd-x64@0.69.0':
+    resolution: {integrity: sha512-t5Ae+3hrfAxcl0Xmkxc3hjWRVBaX04pBLa1xgBAJuKP8KkCmzlRgmxe9YX6rQE8EOALyUDePv0NnhaAVuJfVRA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-minify/binding-linux-arm-gnueabihf@0.69.0':
+    resolution: {integrity: sha512-w1BR/Xk5qUzrFofwTfi+dclUBTfTaHm+O7uHraX981DH3+qbOYWKhPR1RamS52AlQgJqzmckV2w6OitSOsRW9Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-minify/binding-linux-arm64-gnu@0.69.0':
+    resolution: {integrity: sha512-OdJo1Uhfdr5u1ZbNfupE0rYffVumvP27UxEGtptOeAbAYVIaLhwuLIo7y/7xBMFBEDyulPMbMWE7HGObA/aATg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-minify/binding-linux-arm64-musl@0.69.0':
+    resolution: {integrity: sha512-JNl65iqV+ca4Yq5R6zW7XE3cKFhyXvMtfPCKbMIoRM3XjYaxynQc7djm9w8mwbVA/jrPN8MEh2dFuR8H5DNqyA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-minify/binding-linux-riscv64-gnu@0.69.0':
+    resolution: {integrity: sha512-emOPhLyt5BXb0twWt2+zqSYbE8mPHExmazszCmC7o+MEbxBOoPRw12o2ucua8u3mMsXSWkToxgVBI9FKIMp1Dw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-minify/binding-linux-s390x-gnu@0.69.0':
+    resolution: {integrity: sha512-YDFZQkQvbqJdAomA8Z9Hf26Gg55ieBzPCdzHRpNLUxcih/eRiBxCNm19dfExMz49MK1cTAJaqt7SGvvyHtNFJQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-minify/binding-linux-x64-gnu@0.69.0':
+    resolution: {integrity: sha512-uD+2JCWHAq20C5d45C9aaxM/70RHwLU9PW/4altiklM98nFFTftcYi7UbJy4tNGTf5/5STsmBB/KeKAlWB+jAw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-minify/binding-linux-x64-musl@0.69.0':
+    resolution: {integrity: sha512-SAQdffOinw2yMGygSipkvEHd5/fBCC5ZuNdO9Ag7ZR39PS+2dKbKfQXQ6qL2kUvwOAglHDg49qDdRSUkanRMrg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-minify/binding-wasm32-wasi@0.69.0':
+    resolution: {integrity: sha512-s+SDrjW6IUB5oLqIKeUprTtWCJ3NuucaBZPdTTO+tzgUEKx+FNr1fw3Y5f7ALoqIV2UiQmOtV3AGP/hAvnYcHg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-minify/binding-win32-arm64-msvc@0.69.0':
+    resolution: {integrity: sha512-gA8HSO97hi2T6M344gmxIkwwG82TIB6EjHvVO/7KBDmzwQH5ZTzaIEzS7SVk5yeDOo39dkY19YDK+HJ66+knjw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-minify/binding-win32-x64-msvc@0.69.0':
+    resolution: {integrity: sha512-UleNZqdw72QxvgrqdAkorWzQABg1Gx286R8QE2WLdOx1YnlQsbKLzSeP4ItPqAeVIl116hw/ScUXpCgUDUgTiA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/runtime@0.69.0':
+    resolution: {integrity: sha512-v4WCEJEktTuWY+DEaR1XNITKZD9S0BCyoBeCTyHUH3ppgrb4IlMeDTkwNyfvaIXBFfhlCX4DI445TJ4cqiK0FA==}
+    engines: {node: '>=6.9.0'}
+
+  '@oxc-project/types@0.69.0':
+    resolution: {integrity: sha512-bu3gzdAlLgncoaqyqWVpMAKx4axo+j3ewvvdAt5iCLtvHB/n3Qeif67NU+2TM/ami1nV5/KVO9lxCH8paPATBA==}
+
   '@polka/compression@1.0.0-next.28':
     resolution: {integrity: sha512-aDmrBhgHJtxE+jy145WfhW9WmTAFmES/dNnn1LAs8UnnkFgBUj4T8I4ScQ9+rOkpDZStvnVP5iqhN3tvt7O1NA==}
     engines: {node: '>=6'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-ccQdWbP9dUv5XfvY+jKQPJL1bTT3vg4XI2gO60sL8iG5A77Kn5l8NQDlgqezL+tX9ayfgHZn83l/xLfg/w+MMg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-PLbKS1relWlkK4HBfr2OMUg7zUSyA/8bJfc2t5quQNHTuDCrZf9vHLIvuYWwzLmasgJBpMCipKFJ0quxz8SOCg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-AltIXTVrSl7Axp0YFV2O3vBzwdK4vfkwfiHM42YzEkbOmHiL+9su+QkzNzlJoOxmM5/W9JhxQcj6VmtHsNvx+w==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-7Qn3XE+8r03yeO+eWVw1xtMkjLsFx0TOAE9+INABF3qABvKpAJgX8edhZpR9jPPkQ8iN0d4UNF/2pMeOuOGMmw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-Y35shEzqlvso2JZNCn969U5mftD+hY5Xpp3mkV8mVILFYmupZCAjzrzATh+SUHbjUBAdk0YyPzVF42TNSqaZbA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-DUiIyXJUvVmy1s5EFNAOC4qADOTxfME5y1Z9JoFYCPvTiazeMqEfYQUUF0n46CpR2LBrMYSe64PYUFAkLt/AcA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-lVhPuDuPhXfvFkNK8A6DHsZmd15WTmFQGSo36LuELbdN+Cc2ETouiY/UF92ALw0O9suP0T0rbqQnce3y6SSPuw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-PbyEo7AElXiwbSsp4hEwzIK/mjNEg+pc4TKXTmxA1N/ZHZY4xtZFXQ+Fk2aWxkGKZI0PFT1lywC4yJ68pKczcg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-iAhw6VWj973h2DOVJowvstA4otMfjk7xkQACk6eQR80TQ7CDbEi3NNhE/q1XNNv3U+sbzNfHvpAbMWCphTKkAg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-jp5guKSx6296lDCFwyYCFHkS0uReqXeLrHyqD5MaqBThgGhTizp1jdKYqkvoEhtcN0VigKAVrlDfil5+TyaOsQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-9yPFf9kXFCVR+bvzU883X9RTkWM5sEGyxelW736jbGymyW8trXVm4wCoG+N5c+Jq/+mRTkGnxwd6llCkWzr1hg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-zGvEYtt6xose5gMWQvW/4TU6l+bbRTu4gy+rqdS6BEjP60v84wo+pteVCuuCWqXbJiex/+L2WEPgN69QJFOnUQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.8-commit.8951737':
+    resolution: {integrity: sha512-dx9SoAb0lLSZp3Jhy5jRCdJg5OJXv7S7bdF+qpLjPMoRPfvFcwIRi9QPdtprqjdkOR72+peteBYTdlx1LWmQSA==}
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -910,6 +1072,9 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
@@ -1203,6 +1368,10 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  ansis@4.0.0:
+    resolution: {integrity: sha512-P8nrHI1EyW9OfBt1X7hMSwGN2vwRuqHSKJAT1gbLWZRzDa24oHjYwGHvEgHeBepupzk878yS/HBZ0NMPYtbolw==}
+    engines: {node: '>=14'}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -1490,6 +1659,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -1947,6 +2120,70 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
+  lightningcss-darwin-arm64@1.30.0:
+    resolution: {integrity: sha512-L9lhvW4rTHL6vaG1WU3Itj0ivtdBuwu7ufrKEbijRCPhS1pt1haXEXI8h9g73qCQsOaYs1GCc9chvSgxPmhpRA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.0:
+    resolution: {integrity: sha512-+qNst+L3GGwG5LypEFTmDUOtNarQVh717Enk4AfmKfwlTrKCSe9kAiPyK7ces269a+f0jNSa8Uww8WwGFXzt8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.0:
+    resolution: {integrity: sha512-/sfAWALScgggjjk5ZlmGdpFELwGPIwzAdfcBJcT6UTgQoDHzQ4aP41XTq3N4LL01U9dsJp6uAvCvmHX7snqTdg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.0:
+    resolution: {integrity: sha512-3B5val/f61unLgfZHEfkZGzunlyyL76l8xRoxFx+G0uwxK7rvaFcnkyf6k4Zto2STVj05FsLs+aTZoTqslPaug==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.0:
+    resolution: {integrity: sha512-Q45+fvm7eAAmorsEzc1ZBwajGnXDocB/nRaSldpHQa36QbP93GrzmBqfSdi2pEks2yXMxST4yznio24Q6en7Sg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.0:
+    resolution: {integrity: sha512-RNZNW/AyKax8wWR4xMKoyAb40dqhzOtnAw4knjbyxJUUEL0wzBEXO3k44AS3UFRjxTyd/s46adVQXxE/vOaSgg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.0:
+    resolution: {integrity: sha512-ExVnSepsAyQb547i7SvPhS0SrgIDUjA1dYTT0DNFt/YsqfKhkxg405VDtMoV2MQGAyoEQIub+YK5NQo9Lw7IzQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.0:
+    resolution: {integrity: sha512-e/nHeX5SAEcfAzyLob5H1Jhm8uHLKwpOIHzcURKnXTMFdBqIDOsETMhmcB5AGDqsr6Q5D9u0QVswDdRo+btSgg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.0:
+    resolution: {integrity: sha512-Fd9XejM6GPHx5rv7I8aqsc8mBHs+TpHEVDalP5PVP986tF6rmiVfwQzM2Ic4Cn0rXbS3z95Ru8x50hnzfR2GDA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.0:
+    resolution: {integrity: sha512-2BhpVDbNa+HpXPu63EYfcsL2TCBKLeuMckx4d6UZCzaj1KVuSRXi6r7H3rUeaADuX5NB/BT2smP4HI3s6I1/Ag==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.0:
+    resolution: {integrity: sha512-uuurN2onfoNwQtaWnX9UYLz6DlZHnUd88SceOXDAQzQ5+FJ+ELPgcC/EVtRJoFOveXe44zRE+foh2KMD/vQxqQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -2284,6 +2521,10 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  oxc-minify@0.69.0:
+    resolution: {integrity: sha512-QaPB3syyTEE7PSgSIL+CrFr5MfL43tEJi5KjpD4Ko29I6ZBbevQKMZ0wnBXz82bkzzyru08g0dMTaLbjPmOsXw==}
+    engines: {node: '>=14.0.0'}
+
   p-map@7.0.3:
     resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
     engines: {node: '>=18'}
@@ -2510,6 +2751,55 @@ packages:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  rolldown-vite@6.3.9:
+    resolution: {integrity: sha512-A4MasNEixPEcBOWrgO2pAsmLW9YbtaXpyRz6irfptllOcZu2yL4U+qKxxjmVs0v9Ch05yGqoQN26hI12kyviWA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      esbuild: ^0.25.0
+      jiti: '>=1.21.0'
+      less: '*'
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  rolldown@1.0.0-beta.8-commit.8951737:
+    resolution: {integrity: sha512-wivu32OtHnJ1C0L3hPhEx/zniMoaE1jn+pjB3T+UOy1NGm323unnLlcOv2A6xSrNMiM6cBp2JlRRInQ9i/zJHA==}
+    hasBin: true
+    peerDependencies:
+      '@oxc-project/runtime': 0.69.0
+    peerDependenciesMeta:
+      '@oxc-project/runtime':
+        optional: true
 
   rollup-plugin-dts@6.1.1:
     resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
@@ -3213,6 +3503,22 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
+  '@emnapi/core@1.4.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.4.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
@@ -3404,6 +3710,13 @@ snapshots:
 
   '@mdit-vue/types@2.1.4': {}
 
+  '@napi-rs/wasm-runtime@0.2.9':
+    dependencies:
+      '@emnapi/core': 1.4.3
+      '@emnapi/runtime': 1.4.3
+      '@tybys/wasm-util': 0.9.0
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3416,9 +3729,94 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@oxc-minify/binding-darwin-arm64@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-darwin-x64@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-freebsd-x64@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-linux-arm-gnueabihf@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-linux-arm64-gnu@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-linux-arm64-musl@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-linux-riscv64-gnu@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-linux-s390x-gnu@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-linux-x64-gnu@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-linux-x64-musl@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-wasm32-wasi@0.69.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.9
+    optional: true
+
+  '@oxc-minify/binding-win32-arm64-msvc@0.69.0':
+    optional: true
+
+  '@oxc-minify/binding-win32-x64-msvc@0.69.0':
+    optional: true
+
+  '@oxc-project/runtime@0.69.0': {}
+
+  '@oxc-project/types@0.69.0': {}
+
   '@polka/compression@1.0.0-next.28': {}
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.8-commit.8951737':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.9
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.8-commit.8951737':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.8-commit.8951737': {}
 
   '@rollup/plugin-alias@5.1.1(rollup@4.40.2)':
     optionalDependencies:
@@ -3579,6 +3977,11 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/cross-spawn@6.0.6':
     dependencies:
       '@types/node': 22.15.17
@@ -3680,9 +4083,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@22.15.17)(jiti@1.21.7)(lightningcss@1.30.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
-      vite: 6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.15.17)(jiti@1.21.7)(lightningcss@1.30.0)(yaml@2.7.1)
       vue: 3.5.13(typescript@5.8.3)
 
   '@vitest/expect@3.1.3':
@@ -3692,13 +4095,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1))':
+  '@vitest/mocker@3.1.3(rolldown-vite@6.3.9(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1)
+      vite: rolldown-vite@6.3.9(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1)
 
   '@vitest/pretty-format@3.1.3':
     dependencies:
@@ -3892,6 +4295,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.1: {}
+
+  ansis@4.0.0: {}
 
   arg@5.0.2: {}
 
@@ -4170,6 +4575,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  detect-libc@2.0.4: {}
 
   devlop@1.1.0:
     dependencies:
@@ -4641,6 +5048,51 @@ snapshots:
 
   kolorist@1.8.0: {}
 
+  lightningcss-darwin-arm64@1.30.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.0:
+    optional: true
+
+  lightningcss@1.30.0:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.30.0
+      lightningcss-darwin-x64: 1.30.0
+      lightningcss-freebsd-x64: 1.30.0
+      lightningcss-linux-arm-gnueabihf: 1.30.0
+      lightningcss-linux-arm64-gnu: 1.30.0
+      lightningcss-linux-arm64-musl: 1.30.0
+      lightningcss-linux-x64-gnu: 1.30.0
+      lightningcss-linux-x64-musl: 1.30.0
+      lightningcss-win32-arm64-msvc: 1.30.0
+      lightningcss-win32-x64-msvc: 1.30.0
+
   lilconfig@3.1.3: {}
 
   linkify-it@5.0.0:
@@ -5101,6 +5553,22 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
+  oxc-minify@0.69.0:
+    optionalDependencies:
+      '@oxc-minify/binding-darwin-arm64': 0.69.0
+      '@oxc-minify/binding-darwin-x64': 0.69.0
+      '@oxc-minify/binding-freebsd-x64': 0.69.0
+      '@oxc-minify/binding-linux-arm-gnueabihf': 0.69.0
+      '@oxc-minify/binding-linux-arm64-gnu': 0.69.0
+      '@oxc-minify/binding-linux-arm64-musl': 0.69.0
+      '@oxc-minify/binding-linux-riscv64-gnu': 0.69.0
+      '@oxc-minify/binding-linux-s390x-gnu': 0.69.0
+      '@oxc-minify/binding-linux-x64-gnu': 0.69.0
+      '@oxc-minify/binding-linux-x64-musl': 0.69.0
+      '@oxc-minify/binding-wasm32-wasi': 0.69.0
+      '@oxc-minify/binding-win32-arm64-msvc': 0.69.0
+      '@oxc-minify/binding-win32-x64-msvc': 0.69.0
+
   p-map@7.0.3: {}
 
   package-json-from-dist@1.0.1: {}
@@ -5317,6 +5785,42 @@ snapshots:
     dependencies:
       glob: 11.0.2
       package-json-from-dist: 1.0.1
+
+  rolldown-vite@6.3.9(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1):
+    dependencies:
+      '@oxc-project/runtime': 0.69.0
+      fdir: 6.4.4(picomatch@4.0.2)
+      lightningcss: 1.30.0
+      picomatch: 4.0.2
+      postcss: 8.5.3
+      rolldown: 1.0.0-beta.8-commit.8951737(@oxc-project/runtime@0.69.0)
+      tinyglobby: 0.2.13
+    optionalDependencies:
+      '@types/node': 22.15.17
+      esbuild: 0.25.4
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      yaml: 2.7.1
+
+  rolldown@1.0.0-beta.8-commit.8951737(@oxc-project/runtime@0.69.0):
+    dependencies:
+      '@oxc-project/types': 0.69.0
+      '@rolldown/pluginutils': 1.0.0-beta.8-commit.8951737
+      ansis: 4.0.0
+    optionalDependencies:
+      '@oxc-project/runtime': 0.69.0
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.8-commit.8951737
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.8-commit.8951737
 
   rollup-plugin-dts@6.1.1(rollup@4.40.2)(typescript@5.8.3):
     dependencies:
@@ -5688,18 +6192,18 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.1.3(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1):
+  vite-node@3.1.3(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1)
+      vite: rolldown-vite@6.3.9(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@types/node'
+      - esbuild
       - jiti
       - less
-      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -5709,7 +6213,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1):
+  vite@6.3.5(@types/node@22.15.17)(jiti@1.21.7)(lightningcss@1.30.0)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
@@ -5721,6 +6225,7 @@ snapshots:
       '@types/node': 22.15.17
       fsevents: 2.3.3
       jiti: 1.21.7
+      lightningcss: 1.30.0
       yaml: 2.7.1
 
   vitepress-plugin-group-icons@1.5.2:
@@ -5747,10 +6252,10 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
-  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1):
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1))
+      '@vitest/mocker': 3.1.3(rolldown-vite@6.3.9(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -5767,16 +6272,16 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1)
-      vite-node: 3.1.3(@types/node@22.15.17)(jiti@1.21.7)(yaml@2.7.1)
+      vite: rolldown-vite@6.3.9(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1)
+      vite-node: 3.1.3(@types/node@22.15.17)(esbuild@0.25.4)(jiti@1.21.7)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.15.17
     transitivePeerDependencies:
+      - esbuild
       - jiti
       - less
-      - lightningcss
       - msw
       - sass
       - sass-embedded

--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from 'node:url'
 import pMap from 'p-map'
 import { packageDirectorySync } from 'pkg-dir'
 import { rimraf } from 'rimraf'
+import * as vite from 'vite'
 import type { BuildOptions, Rollup } from 'vite'
 import { resolveConfig, type SiteConfig } from '../config'
 import { clearCache } from '../markdownToVue'
@@ -28,6 +29,19 @@ export async function build(
   } = {}
 ) {
   const start = Date.now()
+
+  // @ts-ignore only exists for rolldown-vite
+  if (vite.rolldownVersion) {
+    try {
+      await import('oxc-minify')
+    } catch {
+      throw new Error(
+        '`oxc-minify` is not installed.' +
+          ' vitepress requires `oxc-minify` to be installed when rolldown-vite is used.' +
+          ' Please run `npm install oxc-minify`.'
+      )
+    }
+  }
 
   process.env.NODE_ENV = 'production'
   const siteConfig = await resolveConfig(root, 'build', 'production')

--- a/src/node/build/bundle.ts
+++ b/src/node/build/bundle.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import * as vite from 'vite'
 import {
   build,
   normalizePath,
@@ -98,9 +99,12 @@ export async function bundle(
           app: path.resolve(APP_PATH, ssr ? 'ssr.js' : 'index.js'),
           ...input
         },
-        // important so that each page chunk and the index export things for each
-        // other
-        preserveEntrySignatures: 'allow-extension',
+        // @ts-ignore skip setting it for rolldown-vite since it doesn't support `preserveEntrySignatures` yet
+        ...(vite.rolldownVersion
+          ? undefined
+          : // important so that each page chunk and the index export things for each
+            // other
+            { preserveEntrySignatures: 'allow-extension' }),
         output: {
           sanitizeFileName,
           ...rollupOptions?.output,
@@ -118,44 +122,52 @@ export async function bundle(
                     ? `${config.assetsDir}/chunks/ui-custom.[hash].js`
                     : `${config.assetsDir}/chunks/[name].[hash].js`
                 },
-                manualChunks(id, ctx) {
-                  // move known framework code into a stable chunk so that
-                  // custom theme changes do not invalidate hash for all pages
-                  if (
-                    id.startsWith('\0vite') ||
-                    ctx.getModuleInfo(id)?.meta['vite:asset']
-                  ) {
-                    return 'framework'
-                  }
-                  if (id.includes('plugin-vue:export-helper')) {
-                    return 'framework'
-                  }
-                  if (
-                    id.includes(`${clientDir}/app`) &&
-                    id !== `${clientDir}/app/index.js`
-                  ) {
-                    return 'framework'
-                  }
-                  if (
-                    isEagerChunk(id, ctx.getModuleInfo) &&
-                    /@vue\/(runtime|shared|reactivity)/.test(id)
-                  ) {
-                    return 'framework'
-                  }
+                // @ts-ignore skip setting it for rolldown-vite since it doesn't support `manualChunks`
+                ...(vite.rolldownVersion
+                  ? undefined
+                  : {
+                      manualChunks(
+                        id: string,
+                        ctx: Pick<Rollup.PluginContext, 'getModuleInfo'>
+                      ) {
+                        // move known framework code into a stable chunk so that
+                        // custom theme changes do not invalidate hash for all pages
+                        if (
+                          id.startsWith('\0vite') ||
+                          ctx.getModuleInfo(id)?.meta['vite:asset']
+                        ) {
+                          return 'framework'
+                        }
+                        if (id.includes('plugin-vue:export-helper')) {
+                          return 'framework'
+                        }
+                        if (
+                          id.includes(`${clientDir}/app`) &&
+                          id !== `${clientDir}/app/index.js`
+                        ) {
+                          return 'framework'
+                        }
+                        if (
+                          isEagerChunk(id, ctx.getModuleInfo) &&
+                          /@vue\/(runtime|shared|reactivity)/.test(id)
+                        ) {
+                          return 'framework'
+                        }
 
-                  if (
-                    (id.startsWith(`${clientDir}/theme-default`) ||
-                      !excludedModules.some((i) => id.includes(i))) &&
-                    staticImportedByEntry(
-                      id,
-                      ctx.getModuleInfo,
-                      cacheTheme,
-                      themeEntryRE
-                    )
-                  ) {
-                    return 'theme'
-                  }
-                }
+                        if (
+                          (id.startsWith(`${clientDir}/theme-default`) ||
+                            !excludedModules.some((i) => id.includes(i))) &&
+                          staticImportedByEntry(
+                            id,
+                            ctx.getModuleInfo,
+                            cacheTheme,
+                            themeEntryRE
+                          )
+                        ) {
+                          return 'theme'
+                        }
+                      }
+                    })
               })
         }
       }


### PR DESCRIPTION
### Description

Built on top of #4747.

Replaced `transformWithEsbuild` with `oxc-minify` when rolldown-vite is used.

`transformWithEsbuild` still exists for rolldown-vite, but it requires users to install `esbuild` and it'll be deprecated in favor of `transformWithOxc` in the future. That said, `transformWithOxc` does not have minify feature built-in. I replaced it with `oxc-minify` instead. Currently users that wants to use vitepress with rolldown-vite has to install `oxc-minify`, but after Vite migrates to rolldown-vite, vitepress can make `oxc-minify` a normal dependency so that it will be installed automatically.


<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
