### PR TITLE
 Add rel=edit attribute to "Edit this page on GitHub" link

### DIFF
--- a/src/client/theme-default/components/VPDocFooter.vue
+++ b/src/client/theme-default/components/VPDocFooter.vue
@@ -30,7 +30,7 @@ const showFooter = computed(
 
     <div v-if="hasEditLink || hasLastUpdated" class="edit-info">
       <div v-if="hasEditLink" class="edit-link">
-        <VPLink class="edit-link-button" :href="editLink.url" :no-icon="true">
+        <VPLink class="edit-link-button" :href="editLink.url" :no-icon="true" :rel="edit">
           <span class="vpi-square-pen edit-link-icon" />
           {{ editLink.text }}
         </VPLink>


### PR DESCRIPTION
### Description

This PR adds the `rel="edit"` attribute to the "Edit this page on GitHub" edit link.

rel=edit lets a page indicate that the linked resource can be used to edit the page. It is defined at https://microformats.org/wiki/rel-edit. This can then be parsed by tools like the Universal Edit Button and custom bookmarklets to open the edit page corresponding with a website.

### Linked Issues

N/A

### Additional Context

N/A

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
