### PR TITLE
style: adjust lists style

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -138,7 +138,7 @@
 
 .vp-doc ul,
 .vp-doc ol {
-  padding-left: 1.25rem;
+  list-style-position: inside;
   margin: 16px 0;
 }
 


### PR DESCRIPTION
### Description

In the lists, specially in the ordered list, there is a small misalignment comparing number 1 to the others numbers
![image](https://github.com/user-attachments/assets/bbd23c3a-7364-48ee-8e64-8423bc64808b)

This will be fixed on this PR, but will also change the line style as you can see in the pictures
![image](https://github.com/user-attachments/assets/8b7cfe97-064c-4630-a0ea-a172d897630e)

### Linked Issues

N/A

### Additional Context

N/A

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
