### PR TITLE
fix(docs): pnpm init command

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -72,7 +72,7 @@ $ npx vitepress init
 ```
 
 ```sh [pnpm]
-$ pnpm vitepress init
+$ pnpm dlx vitepress init
 ```
 
 ```sh [yarn]


### PR DESCRIPTION
### Description

In the Getting Started Page, the cli init command is listed as `npx vitepress init`. While for many things, pnpm can be a drop in replacement, for download and execute commands, it is not. `pnpm vitepress init` looks for a `vitepress` script in the current node project. The correct command would be `pnpm dlx vitepress init`

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
