### PR TITLE
fix: prevent JS error into handleSearchHotKey method when algolia is enabled

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -51,9 +51,9 @@ onMounted(() => {
 
   preconnect()
 
-  const handleSearchHotKey = (event: KeyboardEvent) => {
+  const handleSearchHotKey = (event?: KeyboardEvent) => {
     if (
-      (event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey)) ||
+      (event?.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey)) ||
       (!isEditingContent(event) && event.key === '/')
     ) {
       event.preventDefault()

--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -51,9 +51,9 @@ onMounted(() => {
 
   preconnect()
 
-  const handleSearchHotKey = (event?: KeyboardEvent) => {
+  const handleSearchHotKey = (event: KeyboardEvent) => {
     if (
-      (event?.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey)) ||
+      (event.key?.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey)) ||
       (!isEditingContent(event) && event.key === '/')
     ) {
       event.preventDefault()


### PR DESCRIPTION
### Description

Hi,

<img width="460" alt="image" src="https://github.com/user-attachments/assets/71e8b5ca-9df9-44a5-a617-8e726624f249" />

Fix error in handleSearchHotKey when event.key is undefined

I'm using VitePress 2.0.0-alpha.5.

This PR fixes a runtime error that occurs when event.key is undefined:

```js
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at handleSearchHotKey (VPNavBarSearch.vue:56:18)
The fix adds optional chaining (event.key?.toLowerCase()) to prevent the crash.
```

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
