### PR TITLE
fix(localSearch): parse headings with non-anchor a tags as titles properly

### DIFF
--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -212,7 +212,7 @@ export async function localSearchPlugin(
 }
 
 const headingRegex = /<h(\d*).*?>(.*?<a.*? href="#.*?".*?>.*?<\/a>)<\/h\1>/gi
-const headingContentRegex = /(.*?)<a.*? href="#(.*?)".*?>.*?<\/a>/i
+const headingContentRegex = /(.*)<a.*? href="#(.*?)".*?>.*?<\/a>/i
 
 /**
  * Splits HTML into sections based on headings


### PR DESCRIPTION
### Description

This pull request fixes a bug where the search result doesn't show full heading properly when using `localSearchPlugin`.

I prepared two environments to describe this pull request:

- https://moreal.github.io/vitepress-bug-reproduction/: An environment to reproduce the error with minimum dependencies with VitePress 1.6.3.
- https://moreal.github.io/vitepress-with-patch/: Based on the reproduction environment but applied a patch (this pull request change) on VitePress package.

Those environments are created with `yarn vitepress init` and I just added two headings `## With <a>a tag</a> heading` and `## With <code>code tag</code> heading` for testing. (If you want to see real case (not reproduction), you can search `KvKey` in https://fedify.dev/.)

<img width="739" alt="image" src="https://github.com/user-attachments/assets/4ec250b3-9881-4e6d-b057-a5efccdfe47b" />

If you search `With` In https://moreal.github.io/vitepress-bug-reproduction/, I expect it shows both `> WIth a tag heading` and `> With code tag heading` but it shows like the following screenshot.

<img width="989" alt="image" src="https://github.com/user-attachments/assets/74cce8ce-59a7-43d2-bf1a-5e7cb86a0326" />

This bug occurs only for headings with `<a>` tag. The text after `<a>` tag is all removed. The reason is localSearchPlugin's `headingContentRegex` regex.

```
/(.*?)<a.*? href="#(.*?)".*?>.*?<\/a>/i
```

I understood that the intent of that regex was to get the anchor value at the end of the header, and that expression would no longer include anything after the `<a>` tag in the middle of the header in the first result.

I understood it to be because the `?` quantifier after `*` quantifier makes it non-greedy. So I removed the `?` quantifier

The execution result of the regex and this pull request's regex, is same with the following:

```javascript
>>> /(.*?)<a.*? href="#(.*?)".*?>.*?<\/a>/i.exec('With <a href="https://example.com">a tag</a> heading <a href="#anchor"></a>')
Array(3) [ 'With <a href="https://example.com/">a tag</a> heading <a href="#anchor"></a>', "With ", "anchor" ]

>>> /(.*)<a.*? href="#(.*?)".*?>.*?<\/a>/i.exec('With <a href="https://example.com">a tag</a> heading <a href="#anchor"></a>')
Array(3) [ 'With <a href="https://example.com/">a tag</a> heading <a href="#anchor"></a>', 'With <a href="https://example.com/">a tag</a> heading ', "anchor" ]
```

### Linked Issues

There is no issues to link.

### Additional Context

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Quantifiers#types

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
