### PR TITLE
fix(sidebar): folder/index should be active with base option

### DIFF
--- a/src/client/theme-default/support/sidebar.ts
+++ b/src/client/theme-default/support/sidebar.ts
@@ -112,7 +112,8 @@ function addBase(items: SidebarItem[], _base?: string): SidebarItem[] {
   return [...items].map((_item) => {
     const item = { ..._item }
     const base = item.base || _base
-    if (base && item.link) item.link = (base + item.link).replace('//', '/')
+    if (base && item.link)
+      item.link = base + item.link.replace(/^\//, base.endsWith('/') ? '' : '/')
     if (item.items) item.items = addBase(item.items, base)
     return item
   })

--- a/src/client/theme-default/support/sidebar.ts
+++ b/src/client/theme-default/support/sidebar.ts
@@ -112,7 +112,7 @@ function addBase(items: SidebarItem[], _base?: string): SidebarItem[] {
   return [...items].map((_item) => {
     const item = { ..._item }
     const base = item.base || _base
-    if (base && item.link) item.link = base + item.link
+    if (base && item.link) item.link = (base + item.link).replace('//', '/')
     if (item.items) item.items = addBase(item.items, base)
     return item
   })


### PR DESCRIPTION
### Description

Fixes:
If you set SidebarItem options like below and access `/folder/` page, the folder item in sidebar won't become active color.

```ts
{
  text: 'Folder',
  base: '/folder/',
  link: '/', // for `/folder/index.md`
  items: [
    { text: 'Example', link: 'example' },
    // ...
  ],
},
```

repro: https://stackblitz.com/edit/vite-8m53bdn5?file=docs%2F.vitepress%2Fconfig.ts

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

`base: '/folder', link: '/'` (base without trailing slash) and child items with starting slash could solve the problem, but setting base with trailing slash is kind a convention as official examples do like that?

Some vitepress helper repos may be thinking base with trailing slash as standard
- https://github.com/jooy2/vitepress-sidebar 's `generateSidebar({ scanStartPath: 'folder' })` returns `[{ link: 'text' }]` instead of `[{ link: '/text' }]`
