### PR TITLE
docs: add EdgeOne deployment template introduction

### DIFF
--- a/docs/en/guide/deploy.md
+++ b/docs/en/guide/deploy.md
@@ -105,7 +105,7 @@ Note: the `vercel.json` file should be placed at the root of your **repository**
 
 ## Platform Guides
 
-### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render
+### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render / EdgeOne
 
 Set up a new project and change these settings using your dashboard:
 
@@ -337,3 +337,9 @@ The try_files resolution must not default to index.html like in other Vue applic
 :::
 
 Further information can be found in the [official nginx documentation](https://nginx.org/en/docs/), in these issues [#2837](https://github.com/vuejs/vitepress/discussions/2837), [#3235](https://github.com/vuejs/vitepress/issues/3235) as well as in this [blog post](https://blog.mehdi.cc/articles/vitepress-cleanurls-on-nginx-environment#readings) by Mehdi Merah.
+
+### EdgeOne
+
+EdgeOne Pages now offers a VitePress [deployment template](https://edgeone.ai/pages/templates/vitepress-template), enabling one-click deployment of your VitePress projects.
+
+For more flexible deployment options, please refer to the [documentation](https://edgeone.ai/document/173005620251889664?product=edgedeveloperplatform) and configure them by editing the `edgeone.json` file.

--- a/docs/es/guide/deploy.md
+++ b/docs/es/guide/deploy.md
@@ -105,7 +105,7 @@ Nota: el archivo `vercel.json` debe ser colocado en la raiz de su **repositório
 
 ## Guias de Plataforma {#platform-guides}
 
-### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render
+### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render / EdgeOne
 
 Configure un nuevo proyecto y altere estas configuraciones usando su panel:
 
@@ -290,3 +290,9 @@ Consulte [Crear e Implantar una Aplicación VitePress en Edgio](https://docs.edg
 ### Kinsta Static Site Hosting {#kinsta-static-site-hosting}
 
 Puede implantar su sitio VitePress em [Kinsta](https://kinsta.com/static-site-hosting/) siguiendo estas [instrucciones](https://kinsta.com/docs/vitepress-static-site-example/).
+
+### EdgeOne
+
+EdgeOne Pages ya ofrece una [plantilla de despliegue](https://edgeone.ai/pages/templates/vitepress-template) de VitePress, permitiendo el despliegue con un solo clic de sus proyectos VitePress.
+
+Para opciones de despliegue más flexibles, consulte la [documentación](https://edgeone.ai/document/173005620251889664?product=edgedeveloperplatform) y configúrelas editando el archivo `edgeone.json`.

--- a/docs/fa/guide/deploy.md
+++ b/docs/fa/guide/deploy.md
@@ -105,7 +105,7 @@ Cache-Control: max-age=31536000,immutable
 
 ## راهنمای‌های پلتفرم {#platform-guides}
 
-### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render {#netlify-vercel-cloudflare-pages-aws-amplify-render}
+### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render / EdgeOne {#netlify-vercel-cloudflare-pages-aws-amplify-render-edgeone}
 
 یک پروژه جدید راه‌اندازی کرده و این تنظیمات را با استفاده از داشبورد خود تغییر دهید:
 
@@ -335,3 +335,9 @@ server {
 :::
 
 اطلاعات بیشتر را در [مستندات رسمی nginx](https://nginx.org/en/docs/)، در این مسائل [#2837](https://github.com/vuejs/vitepress/discussions/2837)، [#3235](https://github.com/vuejs/vitepress/issues/3235) و همچنین در این [پست وبلاگ](https://blog.mehdi.cc/articles/vitepress-cleanurls-on-nginx-environment#readings) از Mehdi Merah پیدا کنید.
+
+### EdgeOne
+
+EdgeOne Pages اکنون یک [قالب استقرار](https://edgeone.ai/pages/templates/vitepress-template) VitePress ارائه می‌دهد که استقرار پروژه‌های VitePress شما را تنها با یک کلیک ممکن می‌سازد.
+
+برای گزینه‌های استقرار انعطاف‌پذیرتر، لطفاً به [مستندات](https://edgeone.ai/document/173005620251889664?product=edgedeveloperplatform) مراجعه کرده و با ویرایش فایل `edgeone.json`، آنها را پیکربندی کنید.

--- a/docs/ko/guide/deploy.md
+++ b/docs/ko/guide/deploy.md
@@ -105,7 +105,7 @@ Cache-Control: max-age=31536000,immutable
 
 ## 플랫폼 가이드 {#platform-guides}
 
-### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render
+### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render / EdgeOne
 
 새 프로젝트를 설정하고 대시보드를 사용하여 다음 설정을 변경하세요:
 
@@ -336,3 +336,9 @@ try_files는 다른 Vue 애플리케이션처럼 index.html을 기본값으로 �
 :::
 
 추가 정보는 [공식 nginx 문서](https://nginx.org/en/docs/), 이슈 [#2837](https://github.com/vuejs/vitepress/discussions/2837), [#3235](https://github.com/vuejs/vitepress/issues/3235) 및 Mehdi Merah의 [블로그 포스트](https://blog.mehdi.cc/articles/vitepress-cleanurls-on-nginx-environment#readings)에서 확인할 수 있습니다.
+
+### EdgeOne
+
+EdgeOne Pages는 이제 VitePress [배포 템플릿](https://edgeone.ai/pages/templates/vitepress-template)을 제공하여 VitePress 프로젝트를 원클릭으로 배포할 수 있습니다.
+
+더 유연한 배포 옵션을 원하시면 [문서](https://edgeone.ai/document/173005620251889664?product=edgedeveloperplatform)를 참조하시고, `edgeone.json` 파일을 편집하여 구성하십시오.

--- a/docs/pt/guide/deploy.md
+++ b/docs/pt/guide/deploy.md
@@ -105,7 +105,7 @@ Nota: o arquivo `vercel.json` deve ser colocado na raiz do seu **repositório**.
 
 ## Guias de Plataforma {#platform-guides}
 
-### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render
+### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render / EdgeOne
 
 Configure um novo projeto e altere estas configurações usando seu painel:
 
@@ -291,3 +291,9 @@ Consulte [Criar e Implantar um Aplicativo VitePress no Edgio](https://docs.edg.i
 ### Kinsta Static Site Hosting {#kinsta-static-site-hosting}
 
 Você pode implantar seu site VitePress em [Kinsta](https://kinsta.com/static-site-hosting/) seguindo estas [instruções](https://kinsta.com/docs/vitepress-static-site-example/).
+
+### EdgeOne
+
+O EdgeOne Pages agora oferece um [modelo de implantação](https://edgeone.ai/pages/templates/vitepress-template) VitePress, permitindo a implantação com um clique dos seus projetos VitePress.
+
+Para opções de implantação mais flexíveis, consulte a [documentação](https://edgeone.ai/document/173005620251889664?product=edgedeveloperplatform) e configure-as editando o arquivo `edgeone.json`.

--- a/docs/ru/guide/deploy.md
+++ b/docs/ru/guide/deploy.md
@@ -105,7 +105,7 @@ Cache-Control: max-age=31536000,immutable
 
 ## Руководства по платформам {#platform-guides}
 
-### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render {#netlify-vercel-cloudflare-pages-aws-amplify-render}
+### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render /EdgeOne {#netlify-vercel-cloudflare-pages-aws-amplify-render-edgeone} / 
 
 Создайте новый проект и измените эти настройки с помощью панели управления:
 
@@ -337,3 +337,9 @@ server {
 :::
 
 Дополнительную информацию можно найти в официальной документации [Nginx](https://nginx.org/ru/docs/), а также в следующих обсуждениях: [#2837](https://github.com/vuejs/vitepress/discussions/2837), [#3235](https://github.com/vuejs/vitepress/issues/3235), а также в [блоге Mehdi Merah](https://blog.mehdi.cc/articles/vitepress-cleanurls-on-nginx-environment#readings).
+
+### EdgeOne
+
+EdgeOne Pages теперь предлагает [шаблон развертывания](https://edgeone.ai/pages/templates/vitepress-template) VitePress, позволяющий развертывать ваши проекты VitePress одним кликом.
+
+Для более гибких вариантов развертывания, пожалуйста, обратитесь к [документации](https://edgeone.ai/document/173005620251889664?product=edgedeveloperplatform) и настройте их, отредактировав файл `edgeone.json`.

--- a/docs/zh/guide/deploy.md
+++ b/docs/zh/guide/deploy.md
@@ -105,7 +105,7 @@ Cache-Control: max-age=31536000,immutable
 
 ## 各平台部署指南 {#platform-guides}
 
-### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render
+### Netlify / Vercel / Cloudflare Pages / AWS Amplify / Render / EdgeOne
 
 使用仪表板创建新项目并更改这些设置：
 
@@ -337,3 +337,9 @@ try_files 解析不能像其他 Vue 应用那样默认为 index.html。这会导
 :::
 
 更多信息请参见 [nginx 官方文档](https://nginx.org/en/docs/)、这些 GitHub Issue [#2837](https://github.com/vuejs/vitepress/discussions/2837)、[#3235](https://github.com/vuejs/vitepress/issues/3235)以及 Mehdi Merah 发表的[博客](https://blog.mehdi.cc/articles/vitepress-cleanurls-on-nginx-environment#readings)。
+
+### EdgeOne
+
+EdgeOne Pages 现已上线 VitePress [部署模板](https://console.cloud.tencent.com/edgeone/pages/new?template=vitepress-template&from=within)，可以一键部署 VitePress 项目。
+
+若在部署中需要更灵活的方案，请查阅[说明文档](https://edgeone.cloud.tencent.com/pages/document/173003746437443584)，并通过编辑 `edgeone.json` 文件来灵活配置。


### PR DESCRIPTION
### Description

docs: Document EdgeOne Pages one-click VitePress deployment template

Recently, I developed a one-click deployment [template](https://edgeone.ai/pages/templates/vitepress-template) for VitePress on EdgeOne Pages. In this PR, I'm adding template usage information to the deployment documentation.

I hope this template will provide a more convenient and efficient deployment solution for VitePress developers and users.

In the EdgeOne Pages deployment instructions, the link to the Chinese documentation leverages EdgeOne's global acceleration deployment, which will be very fast for users in China after domain registration and ICP filing.
