### PR TITLE
doc: incorrect path for Overriding Internal Components example

### DIFF
--- a/docs/en/guide/extending-default-theme.md
+++ b/docs/en/guide/extending-default-theme.md
@@ -319,7 +319,7 @@ export default defineConfig({
         {
           find: /^.*\/VPNavBar\.vue$/,
           replacement: fileURLToPath(
-            new URL('./components/CustomNavBar.vue', import.meta.url)
+            new URL('./theme/components/CustomNavBar.vue', import.meta.url)
           )
         }
       ]


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

The [Overriding Internal Components
](https://vitepress.dev/guide/extending-default-theme#overriding-internal-components) section of the doc is showing a replacement path that is not compatible with the template project where the `components` directory is a child of the `theme` directory, this directory being part of the template project make it very likely that a first time user puts their override components here more than anywhere else.

Using the provided path as is and putting the override components in the generated components directory will lead to a hard to track down error as vite with print the original path in the reported error (here trying to remap the `VPNavBarExtra` component):
```shell
9:33:57 PM [vitepress] Pre-transform error: Failed to resolve import "./VPNavBarExtra.vue" from "../../node_modules/vitepress/dist/client/theme-default/components/VPNavBar.vue". Does the file exist?
9:33:57 PM [vitepress] Internal server error: Failed to resolve import "./VPNavBarExtra.vue" from "../../node_modules/vitepress/dist/client/theme-default/components/VPNavBar.vue". Does the file exist?
  Plugin: vite:import-analysis
  File: /home/ragnar/dev/xoram/node_modules/vitepress/dist/client/theme-default/components/VPNavBar.vue:7:26
  5  |  import { useSidebar } from "../composables/sidebar";
  6  |  import VPNavBarAppearance from "./VPNavBarAppearance.vue";
  7  |  import VPNavBarExtra from "./VPNavBarExtra.vue";
     |                             ^
  8  |  import VPNavBarHamburger from "./VPNavBarHamburger.vue";
  9  |  import VPNavBarMenu from "./VPNavBarMenu.vue";
      at TransformPluginContext._formatError (file:///home/ragnar/dev/xoram/node_modules/vitepress/node_modules/vite/dist/node/chunks/dep-DbT5NFX0.js:49258:41)
      at TransformPluginContext.error (file:///home/ragnar/dev/xoram/node_modules/vitepress/node_modules/vite/dist/node/chunks/dep-DbT5NFX0.js:49253:16)
      at normalizeUrl (file:///home/ragnar/dev/xoram/node_modules/vitepress/node_modules/vite/dist/node/chunks/dep-DbT5NFX0.js:64241:23)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async file:///home/ragnar/dev/xoram/node_modules/vitepress/node_modules/vite/dist/node/chunks/dep-DbT5NFX0.js:64373:39
      at async Promise.all (index 6)
      at async TransformPluginContext.transform (file:///home/ragnar/dev/xoram/node_modules/vitepress/node_modules/vite/dist/node/chunks/dep-DbT5NFX0.js:64300:7)
      at async PluginContainer.transform (file:///home/ragnar/dev/xoram/node_modules/vitepress/node_modules/vite/dist/node/chunks/dep-DbT5NFX0.js:49099:18)
      at async loadAndTransform (file:///home/ragnar/dev/xoram/node_modules/vitepress/node_modules/vite/dist/node/chunks/dep-DbT5NFX0.js:51938:27)
      at async viteTransformMiddleware (file:///home/ragnar/dev/xoram/node_modules/vitepress/node_modules/vite/dist/node/chunks/dep-DbT5NFX0.js:62055:24)
```

### Linked Issues

https://github.com/vuejs/vitepress/discussions/4235

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

This PR only impacts documentation and has been done through github's only UI, I am not aware of any test suite that might be impacted but I can check theme / update them if required.
