### PR TITLE
chore: add `@ts-ignore` to `vite.rolldownVersion` access

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -109,6 +109,7 @@ export async function build(
         clientResult.output.some(
           (chunk) =>
             chunk.type === 'chunk' &&
+            // @ts-ignore only exists for rolldown-vite
             (vite.rolldownVersion || chunk.name === 'theme') && // FIXME: remove when rolldown-vite supports manualChunks
             chunk.moduleIds.some((id) => id.includes('client/theme-default'))
         )


### PR DESCRIPTION
### Description

This PR should fix the ecosystem-ci failure.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/15918578065/job/44900684235#step:7:1304

refs https://github.com/vuejs/vitepress/commit/ed387e89d42a08c15a9f45c9c5e11c6750245490

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
