### PR TITLE
fix(theme): fix getSidebar's buggy logic when supporting subtree-lift…

### DIFF
--- a/src/client/theme-default/support/sidebar.ts
+++ b/src/client/theme-default/support/sidebar.ts
@@ -27,11 +27,18 @@ export function getSidebar(
 
   const dir = Object.keys(_sidebar)
     .sort((a, b) => {
+      // longer dir link has higher priority
       return b.split('/').length - a.split('/').length
     })
     .find((dir) => {
+      const dirWithStartingSlash = ensureStartingSlash(dir)
       // make sure the multi sidebar key starts with slash too
-      return path.startsWith(ensureStartingSlash(dir))
+      if (path.startsWith(dirWithStartingSlash)) {
+        // "/" match everything and it has lowest priority
+        if (dirWithStartingSlash === '/') return true
+        const remains = path.replace(dirWithStartingSlash, '')
+        if (remains.startsWith('/') || remains === '') return true
+      }
     })
 
   const sidebar = dir ? _sidebar[dir] : []


### PR DESCRIPTION
fix(theme): fix getSidebar's buggy logic when supporting subtree-lift…

close #4841

### Description

This PR resolves when sidebar config object owns a uplifting subtree node (by duplication), `getSidebar` will match the obviously wrong dir links, for example described in issue #4841, `/api-examples.md` will be matched to `/a`.

Not only when there is subtree lifting will the bug reproduce, and I'm also afraid when doing matching of `/api-b/a.md`, it will be matched to `/api/`, and I also proved this guess, the sidebar object is, [can also see my repo's newest commit](https://github.com/chlsczx/vp-template/tree/vp-bug-fix-get-sidebar):

```json
"sidebar": {
    "/api": [
      {
        "text": "jdjd",
        "link": "/api/jdjd.md",
        ".sort_base": "jdjd.md"
      }
    ],
    "/api-aaa": [
      {
        "text": "a copy",
        "link": "/api-aaa/a-copy",
        "collapsed": true,
        "items": [
          {
            "text": "Runtime API Examples",
            "link": "/api-aaa/a-copy/api-examples.md",
            ".sort_base": "api-examples.md"
          },
          {
            "text": "Markdown Extension Examples",
            "link": "/api-aaa/a-copy/markdown-examples.md",
            ".sort_base": "markdown-examples.md"
          }
        ],
        ".sort_base": "a-copy"
      },
      {
        "text": "📂 b-copy",
        "collapsed": true,
        "items": [
          {
            "text": "Markdown Extension Examples",
            "link": "/api-aaa/b-copy/markdown-examples.md",
            ".sort_base": "markdown-examples.md"
          },
          {
            "text": "Runtime API Examples",
            "link": "/api-aaa/b-copy/z_api-examples.md",
            ".sort_base": "z_api-examples.md"
          }
        ],
        ".sort_base": "b-copy"
      }
    ],
    "/": [
      {
        "text": "Runtime API Examples",
        "link": "/api-examples.md",
        ".sort_base": "api-examples.md"
      },
      {
        "text": "Markdown Extension Examples",
        "link": "/markdown-examples.md",
        ".sort_base": "markdown-examples.md"
      },
      {
        "text": "📂 api",
        "collapsed": true,
        "items": [
          {
            "text": "jdjd",
            "link": "/api/jdjd.md",
            ".sort_base": "jdjd.md"
          }
        ],
        ".sort_base": "api"
      },
      {
        "text": "a",
        "link": "/api-aaa",
        "collapsed": true,
        "items": [
          {
            "text": "a copy",
            "link": "/api-aaa/a-copy",
            "collapsed": true,
            "items": [
              {
                "text": "Runtime API Examples",
                "link": "/api-aaa/a-copy/api-examples.md",
                ".sort_base": "api-examples.md"
              },
              {
                "text": "Markdown Extension Examples",
                "link": "/api-aaa/a-copy/markdown-examples.md",
                ".sort_base": "markdown-examples.md"
              }
            ],
            ".sort_base": "a-copy"
          },
          {
            "text": "📂 b-copy",
            "collapsed": true,
            "items": [
              {
                "text": "Markdown Extension Examples",
                "link": "/api-aaa/b-copy/markdown-examples.md",
                ".sort_base": "markdown-examples.md"
              },
              {
                "text": "Runtime API Examples",
                "link": "/api-aaa/b-copy/z_api-examples.md",
                ".sort_base": "z_api-examples.md"
              }
            ],
            ".sort_base": "b-copy"
          }
        ],
        ".sort_base": "api-aaa"
      }
    ]
  }
```

And my PR also fixed this problem.

### Linked Issues

fixes  #4841

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
