### PR TITLE
fix(markdown): pass container option to gitHubAlertsPlugin

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -258,7 +258,7 @@ export async function createMarkdownRenderer(
   }
 
   if (options.gfmAlerts !== false) {
-    md.use(gitHubAlertsPlugin)
+    md.use(gitHubAlertsPlugin, options.container)
   }
 
   // third party plugins


### PR DESCRIPTION
### Description

[GitHub-flavored Alerts](https://vitepress.dev/guide/markdown#github-flavored-alerts)  
Cannot set global custom titles by configuring markdown.container.

```ts
// config.ts
export default defineConfig({
  // ...
  markdown: {
    container: {
      infoLabel: '相关信息',
      noteLabel: '注',
      tipLabel: '提示',
      warningLabel: '注意',
      dangerLabel: '危险',
      detailsLabel: '详情',
      importantLabel: '重要',
      cautionLabel: '警告'
    }
  }
  // ...
})
```