### PR TITLE
docs: add missing Chinese translation for extending-default-theme.md

### DIFF
--- a/docs/zh/guide/extending-default-theme.md
+++ b/docs/zh/guide/extending-default-theme.md
@@ -289,7 +289,7 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
 </style>
 ```
 
-Result (**warning!**: flashing colors, sudden movements, bright lights):
+结果（**注意！**：画面闪烁、快速闪现、强光刺激）:
 
 <details>
 <summary>Demo</summary>


### PR DESCRIPTION
Added translation for an alert note.

Original text: Result (**warning!**: flashing colors, sudden movements, bright lights):

Translation: 结果（**注意！**：画面闪烁、快速闪现、强光刺激）:

### Description

Added a missing translation in the docs.

### Additional Context

This is my first PR in this project, and I’m not quite sure if there are certain translation standards that I need to follow. I’m not sure if translating “warning” into Chinese as “警告” is appropriate.

Thank you all for tolerating my less-than-perfect English.