### PR TITLE
feat: add source param to the deadlink check fn

### DIFF
--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -189,7 +189,7 @@ export async function createMarkdownToVueRenderFn(
           return ignore.test(url)
         }
         if (typeof ignore === 'function') {
-          return ignore(url)
+          return ignore(url, fileOrig)
         }
         return false
       })

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -195,7 +195,8 @@ export async function createMarkdownToVueRenderFn(
       })
     }
 
-    if (links) {
+    const { ignoreDeadLinks = true } = siteConfig
+    if (links && ignoreDeadLinks !== true) {
       const dir = path.dirname(file)
       for (let url of links) {
         const { pathname } = new URL(url, 'http://a.com')

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -195,8 +195,7 @@ export async function createMarkdownToVueRenderFn(
       })
     }
 
-    const { ignoreDeadLinks = true } = siteConfig
-    if (links && ignoreDeadLinks !== true) {
+    if (links && siteConfig?.ignoreDeadLinks !== true) {
       const dir = path.dirname(file)
       for (let url of links) {
         const { pathname } = new URL(url, 'http://a.com')

--- a/src/node/siteConfig.ts
+++ b/src/node/siteConfig.ts
@@ -114,7 +114,7 @@ export interface UserConfig<ThemeConfig = any>
   ignoreDeadLinks?:
     | boolean
     | 'localhostLinks'
-    | (string | RegExp | ((link: string) => boolean))[]
+    | (string | RegExp | ((link: string, source: string) => boolean))[]
 
   /**
    * Don't force `.html` on URLs.


### PR DESCRIPTION
### Description

This change allows skipping the deadlink check based on the source file in addition to the destination link.

It also optimizes the flow when the deadlink check is deactivated and skips the check loop which should improve the performance a bit.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
