### PR TITLE
fix: add `rel="me"` to social links by default

### DIFF
--- a/src/client/theme-default/components/VPSocialLink.vue
+++ b/src/client/theme-default/components/VPSocialLink.vue
@@ -45,7 +45,7 @@ if (import.meta.env.SSR) {
     :href="link"
     :aria-label="ariaLabel ?? (typeof icon === 'string' ? icon : '')"
     target="_blank"
-    rel="noopener"
+    rel="me noopener"
     v-html="svg"
   ></a>
 </template>


### PR DESCRIPTION
### Description

This is a standard and many sites do this automatically. For example, GitHub adds this automatically for all your social links.

Mastodon also requires a `rel="me"` to be present to consider the link as verified.

* https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/me
* https://joinmastodon.org/verification

/preview