### PR TITLE
chore(devtool): remove `as any`

### DIFF
--- a/src/client/app/devtools.ts
+++ b/src/client/app/devtools.ts
@@ -21,8 +21,7 @@ export const setupDevtools = (
       componentStateTypes: [COMPONENT_STATE_TYPE]
     },
     (api) => {
-      // TODO: remove any
-      api.on.inspectComponent((payload: any) => {
+      api.on.inspectComponent((payload) => {
         payload.instanceData.state.push({
           type: COMPONENT_STATE_TYPE,
           key: 'route',


### PR DESCRIPTION
devtool api has correct type define no longer need `as any`
<img width="530" height="334" alt="image" src="https://github.com/user-attachments/assets/8ed14e86-99e3-4365-82b7-461ce39e1a20" />

