### PR TITLE
chore: move all pnpm settings to `pnpm-workspace.yaml`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shell-emulator=true
-auto-install-peers=false

--- a/package.json
+++ b/package.json
@@ -208,16 +208,5 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@10.13.1",
-  "pnpm": {
-    "overrides": {
-      "ora>string-width": "^5",
-      "vite": "npm:rolldown-vite@latest"
-    },
-    "patchedDependencies": {
-      "@types/mdurl@2.0.0": "patches/@types__mdurl@2.0.0.patch",
-      "markdown-it-anchor@9.2.0": "patches/markdown-it-anchor@9.2.0.patch"
-    },
-    "neverBuiltDependencies": []
-  }
+  "packageManager": "pnpm@10.13.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
 packages:
   - docs
   - __tests__/*
+
+autoInstallPeers: false
+neverBuiltDependencies: []
+overrides:
+  "ora>string-width": "^5"
+  "vite": "npm:rolldown-vite@latest"
+patchedDependencies:
+  "@types/mdurl@2.0.0": "patches/@types__mdurl@2.0.0.patch"
+  "markdown-it-anchor@9.2.0": "patches/markdown-it-anchor@9.2.0.patch"
+
+shellEmulator: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,13 +2,18 @@ packages:
   - docs
   - __tests__/*
 
-autoInstallPeers: false
-neverBuiltDependencies: []
-overrides:
-  'ora>string-width': '^5'
-  'vite': 'npm:rolldown-vite@latest'
-patchedDependencies:
-  '@types/mdurl@2.0.0': 'patches/@types__mdurl@2.0.0.patch'
-  'markdown-it-anchor@9.2.0': 'patches/markdown-it-anchor@9.2.0.patch'
+onlyBuiltDependencies:
+  - esbuild
+  - playwright-chromium
+  - simple-git-hooks
 
+overrides:
+  ora>string-width: ^5
+  vite: npm:rolldown-vite@latest
+
+patchedDependencies:
+  '@types/mdurl@2.0.0': patches/@types__mdurl@2.0.0.patch
+  markdown-it-anchor@9.2.0: patches/markdown-it-anchor@9.2.0.patch
+
+autoInstallPeers: false
 shellEmulator: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,10 +5,10 @@ packages:
 autoInstallPeers: false
 neverBuiltDependencies: []
 overrides:
-  "ora>string-width": "^5"
-  "vite": "npm:rolldown-vite@latest"
+  'ora>string-width': '^5'
+  'vite': 'npm:rolldown-vite@latest'
 patchedDependencies:
-  "@types/mdurl@2.0.0": "patches/@types__mdurl@2.0.0.patch"
-  "markdown-it-anchor@9.2.0": "patches/markdown-it-anchor@9.2.0.patch"
+  '@types/mdurl@2.0.0': 'patches/@types__mdurl@2.0.0.patch'
+  'markdown-it-anchor@9.2.0': 'patches/markdown-it-anchor@9.2.0.patch'
 
 shellEmulator: true


### PR DESCRIPTION
### Description
To ease management and avoid conflicts with npm, pnpm supports moving all configurations to the pnpm-workspace.yaml file. For more [github.com/orgs/pnpm/discussions/9037](https://github.com/orgs/pnpm/discussions/9037)
<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
