### PR TITLE
fix: hmr of style blocks in dynamic routes

### DIFF
--- a/__tests__/e2e/dynamic-routes/[id].md
+++ b/__tests__/e2e/dynamic-routes/[id].md
@@ -1,11 +1,3 @@
 <!-- @content -->
 
 <pre class="params">{{ $params }}</pre>
-
-<style scoped>
-pre {
-  /* try changing this, saving once won't update the color,
-  saving twice will change the color to the first saved color */
-  color: lime;
-}
-</style>

--- a/src/node/plugins/dynamicRoutesPlugin.ts
+++ b/src/node/plugins/dynamicRoutesPlugin.ts
@@ -131,6 +131,7 @@ export const dynamicRoutesPlugin = async (
 ): Promise<Plugin> => {
   return {
     name: 'vitepress:dynamic-routes',
+    enforce: 'pre',
 
     resolveId(id) {
       if (!id.endsWith('.md')) return


### PR DESCRIPTION
Might trigger unnecessary style updates even when style is not updated. But I can't find any better way to do this without having to manually extract and compare the blocks.