### PR TITLE
docs(es): use `es` instead `es-CO`

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -128,7 +128,7 @@ export default defineConfig({
     zh: { label: '简体中文', lang: 'zh-Hans', dir: 'ltr' },
     pt: { label: 'Português', lang: 'pt-BR', dir: 'ltr' },
     ru: { label: 'Русский', lang: 'ru-RU', dir: 'ltr' },
-    es: { label: 'Español', lang: 'es-CO', dir: 'ltr' },
+    es: { label: 'Español', lang: 'es', dir: 'ltr' },
     ko: { label: '한국어', lang: 'ko-KR', dir: 'ltr' },
     fa: { label: 'فارسی', lang: 'fa-IR', dir: 'rtl' }
   },

--- a/docs/es/config.ts
+++ b/docs/es/config.ts
@@ -24,7 +24,7 @@ export default defineAdditionalConfig({
 
     footer: {
       message: 'Liberado bajo la licencia MIT',
-      copyright: `Derechos reservados © 2019-PRESENTE Evan You`
+      copyright: 'Derechos reservados © 2019-PRESENTE Evan You'
     },
 
     docFooter: {

--- a/docs/es/config.ts
+++ b/docs/es/config.ts
@@ -24,7 +24,7 @@ export default defineAdditionalConfig({
 
     footer: {
       message: 'Liberado bajo la licencia MIT',
-      copyright: `Derechos reservados © 2019-${new Date().getFullYear()} Evan You`
+      copyright: `Derechos reservados © 2019-PRESENTE Evan You`
     },
 
     docFooter: {

--- a/docs/es/config.ts
+++ b/docs/es/config.ts
@@ -24,7 +24,7 @@ export default defineAdditionalConfig({
 
     footer: {
       message: 'Liberado bajo la licencia MIT',
-      copyright: 'Derechos reservados © 2019-PRESENTE Evan You'
+      copyright: 'Todos los derechos reservados © 2019-PRESENTE Evan You'
     },
 
     docFooter: {

--- a/docs/zh/config.ts
+++ b/docs/zh/config.ts
@@ -24,7 +24,7 @@ export default defineAdditionalConfig({
 
     footer: {
       message: '基于 MIT 许可发布',
-      copyright: `版权所有 © 2019-${new Date().getFullYear()} 尤雨溪`
+      copyright: '版权所有 © 2019-至今 尤雨溪'
     },
 
     docFooter: {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR also changes the footer entry to use `-PRESENT` (translated to spanish) instead using the year.

Maybe we should use this layout in all translations.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
