### PR TITLE
fix(theme): skip link jumps to aside instead main content heading/anchor

### DIFF
--- a/src/client/theme-default/components/VPSkipLink.vue
+++ b/src/client/theme-default/components/VPSkipLink.vue
@@ -10,9 +10,11 @@ const backToTop = ref()
 watch(() => route.path, () => backToTop.value.focus())
 
 function focusOnTargetAnchor({ target }: Event) {
-  const el = document.getElementById(
+  const targetEl = document.getElementById(
     decodeURIComponent((target as HTMLAnchorElement).hash).slice(1)
   )
+
+  const el = targetEl?.querySelector<HTMLAnchorElement>('main h1[id][tabindex="-1"]') ?? targetEl
 
   if (el) {
     const removeTabIndex = () => {

--- a/src/client/theme-default/components/VPSkipLink.vue
+++ b/src/client/theme-default/components/VPSkipLink.vue
@@ -17,13 +17,15 @@ function focusOnTargetAnchor({ target }: Event) {
   const el = targetEl?.querySelector<HTMLAnchorElement>('main h1[id][tabindex="-1"]') ?? targetEl
 
   if (el) {
-    const removeTabIndex = () => {
-      el.removeAttribute('tabindex')
-      el.removeEventListener('blur', removeTabIndex)
-    }
+    if (!el.hasAttribute('tabindex')) {
+      const removeTabIndex = () => {
+        el.removeAttribute('tabindex')
+        el.removeEventListener('blur', removeTabIndex)
+      }
 
-    el.setAttribute('tabindex', '-1')
-    el.addEventListener('blur', removeTabIndex)
+      el.setAttribute('tabindex', '-1')
+      el.addEventListener('blur', removeTabIndex)
+    }
     el.focus()
     window.scrollTo(0, 0)
   }
@@ -43,6 +45,7 @@ function focusOnTargetAnchor({ target }: Event) {
 
 <style scoped>
 .VPSkipLink {
+  position: fixed;
   top: 8px;
   left: 8px;
   padding: 8px 16px;


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR just search for the first h1 heading with tabindex inside `#VPContent main` instead just inside `#VPContent`.

This PR also adds `position: fixed` to the skip link anchor, the skip to content anchor scrolls with the content.

~~The result will be similar to clicking on the first aside link if present without changing the route.~~

Since Skip to Content has an anchor to `#VPContent` there is no way to avoid changing the url.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
