### PR TITLE
feat(theme): add before-theme-switch hook for custom logic before the…

### DIFF
--- a/src/client/theme-default/components/VPSwitchAppearance.vue
+++ b/src/client/theme-default/components/VPSwitchAppearance.vue
@@ -5,6 +5,24 @@ import VPSwitch from './VPSwitch.vue'
 
 const { isDark, theme } = useData()
 
+const handleClick = async () => {
+  try {
+    const result = await beforeThemeSwitch()
+    if (result !== false) {
+      toggleAppearance()
+    }
+  } catch (e) {
+    console.error('[VitePress] Error in before-appearance-switch hook:', e)
+  }
+}
+
+type BeforeSwitchHook = () => boolean | Promise<boolean> | void
+
+const beforeThemeSwitch = inject<BeforeSwitchHook>(
+  'before-appearance-switch',
+  () => true
+)
+
 const toggleAppearance = inject('toggle-appearance', () => {
   isDark.value = !isDark.value
 })
@@ -19,12 +37,7 @@ watchPostEffect(() => {
 </script>
 
 <template>
-  <VPSwitch
-    :title="switchTitle"
-    class="VPSwitchAppearance"
-    :aria-checked="isDark"
-    @click="toggleAppearance"
-  >
+  <VPSwitch :title="switchTitle" class="VPSwitchAppearance" :aria-checked="isDark" @click="handleClick">
     <span class="vpi-sun sun" />
     <span class="vpi-moon moon" />
   </VPSwitch>


### PR DESCRIPTION
### Description
This PR introduces a new injection hook `before-appearance-switch` in the theme context.
It allows theme developers to define custom logic (synchronous or asynchronous) that will be executed **before switching between dark and light appearance**.
If the injected function returns `false`, the theme switch will be canceled.
Typical use-cases include custom animations, confirmation dialogs, or delaying the switch for UI synchronization.

For example, if I want to implement a background image switch animation after I click the button—which uses CSS that depends on the presence of `class="dark"`—the class is toggled immediately, so the transition does not have a chance to animate. The browser applies the new class and final styles in the same rendering frame, which causes the background to switch instantly without any smooth animation.

With this new `before-appearance-switch` hook, I can delay the actual theme class change until my custom animation or transition has completed. For instance, I can trigger an animation, wait for it to finish (using a Promise or timeout), and then toggle the `.dark` class, ensuring that the background image transition is smooth and visually appealing.

**Example usage:**

```js
app.provide('before-appearance-switch', async () => {
  // Start animation (e.g. fade out old background)
  document.body.classList.add('theme-switching');
  await new Promise(resolve => setTimeout(resolve, 500)); // Wait for animation to finish
  document.body.classList.remove('theme-switching');
  return true; // Proceed with the appearance switch
});
```

**Why is this needed?**
Because toggling the `.dark` class immediately does not allow transitions/animations that depend on the class change to play smoothly. This hook gives developers precise control over **when** the class is toggled, so they can coordinate it with custom UI effects.

**Hook Usage example:**

```js
// In enhanceApp:
app.provide('before-appearance-switch', async () => {
  // e.g. play animation or wait for an async operation
  await new Promise(resolve => setTimeout(resolve, 800))
  return true
})
```

In your theme component:

```js
const beforeThemeSwitch = inject('before-appearance-switch', () => true)

const handleClick = async () => {
  const result = await beforeThemeSwitch()
  if (result !== false) {
    toggleAppearance()
  }
}
```

This change is fully backward compatible:
If `before-appearance-switch` is not provided, the theme switch works as before.

---

### Linked Issues

<!-- e.g. fixes #123 -->
_No related issues found._

---

### Additional Context

- The hook supports both synchronous and asynchronous functions.
- If the injected function throws an error, the appearance switch will be aborted.
- This feature enables more flexible UI/UX and advanced customization for theme switching.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.