### PR TITLE
perf: make a single git call for timestamps instead of calling it for each file

### DIFF
--- a/src/node/build/generateSitemap.ts
+++ b/src/node/build/generateSitemap.ts
@@ -9,6 +9,7 @@ import {
   type NewsItem
 } from 'sitemap'
 import type { SiteConfig } from '../config'
+import { slash } from '../shared'
 import { getGitTimestamp } from '../utils/getGitTimestamp'
 import { task } from '../utils/task'
 
@@ -29,7 +30,7 @@ export async function generateSitemap(siteConfig: SiteConfig) {
     if (data.lastUpdated === false) return undefined
     if (data.lastUpdated instanceof Date) return +data.lastUpdated
 
-    return (await getGitTimestamp(file)) || undefined
+    return (await getGitTimestamp(slash(file))) || undefined
   }
 
   await task('generating sitemap', async () => {

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -31,6 +31,7 @@ import { staticDataPlugin } from './plugins/staticDataPlugin'
 import { webFontsPlugin } from './plugins/webFontsPlugin'
 import { slash, type PageDataPayload } from './shared'
 import { deserializeFunctions, serializeFunctions } from './utils/fnSerialize'
+import { cacheAllGitTimestamps } from './utils/getGitTimestamp'
 
 declare module 'vite' {
   interface UserConfig {
@@ -113,6 +114,8 @@ export async function createVitePressPlugin(
 
     async configResolved(resolvedConfig) {
       config = resolvedConfig
+      // pre-resolve git timestamps
+      if (lastUpdated) await cacheAllGitTimestamps(srcDir)
       markdownToVue = await createMarkdownToVueRenderFn(
         srcDir,
         markdown,

--- a/src/node/utils/getGitTimestamp.ts
+++ b/src/node/utils/getGitTimestamp.ts
@@ -1,29 +1,117 @@
-import { spawn } from 'cross-spawn'
-import fs from 'fs-extra'
-import { basename, dirname } from 'node:path'
+import { spawn, sync } from 'cross-spawn'
+import fs from 'node:fs'
+import path from 'node:path'
+import { slash } from '../shared'
 
-const cache = new Map<string, number>()
+let cache = new Map<string, number>()
 
-export function getGitTimestamp(file: string) {
+const RS = 0x1e
+const NUL = 0x00
+
+export async function cacheAllGitTimestamps(
+  root: string,
+  pathspec: string[] = ['*.md']
+): Promise<void> {
+  const cp = sync('git', ['rev-parse', '--show-toplevel'], { cwd: root })
+  if (cp.error) throw cp.error
+  const gitRoot = cp.stdout.toString('utf8').trim()
+
+  const args = [
+    'log',
+    '--pretty=format:%x1e%at%x00', // RS + epoch + NUL
+    '--name-only',
+    '-z',
+    '--',
+    ...pathspec
+  ]
+
+  return new Promise((resolve, reject) => {
+    const out = new Map<string, number>()
+    const child = spawn('git', args, { cwd: root })
+
+    let buf = Buffer.alloc(0)
+    child.stdout.on('data', (chunk: Buffer<ArrayBuffer>) => {
+      buf = buf.length ? Buffer.concat([buf, chunk]) : chunk
+
+      let scanFrom = 0
+      let ts = 0
+
+      while (true) {
+        if (ts === 0) {
+          const rs = buf.indexOf(RS, scanFrom)
+          if (rs === -1) break
+          scanFrom = rs + 1
+
+          const nul = buf.indexOf(NUL, scanFrom)
+          if (nul === -1) break
+          scanFrom = nul + 2 // skip LF after NUL
+
+          const tsSec = buf.toString('utf8', rs + 1, nul)
+          ts = Number.parseInt(tsSec, 10) * 1000
+        }
+
+        let nextNul
+        while (true) {
+          nextNul = buf.indexOf(NUL, scanFrom)
+          if (nextNul === -1) break
+
+          // double NUL, move to next record
+          if (nextNul === scanFrom) {
+            scanFrom += 1
+            ts = 0
+            break
+          }
+
+          const file = buf.toString('utf8', scanFrom, nextNul)
+          if (file && !out.has(file)) out.set(file, ts)
+          scanFrom = nextNul + 1
+        }
+
+        if (nextNul === -1) break
+      }
+
+      if (scanFrom > 0) buf = buf.subarray(scanFrom)
+    })
+
+    child.on('close', async () => {
+      cache.clear()
+
+      for (const [file, ts] of out) {
+        const abs = path.resolve(gitRoot, file)
+        if (fs.existsSync(abs)) cache.set(slash(abs), ts)
+      }
+
+      out.clear()
+      resolve()
+    })
+
+    child.on('error', reject)
+  })
+}
+
+export async function getGitTimestamp(file: string): Promise<number> {
   const cached = cache.get(file)
+  // most likely will never be stale except for recently added files in dev
   if (cached) return cached
 
   if (!fs.existsSync(file)) return 0
 
-  return new Promise<number>((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const child = spawn(
       'git',
-      ['log', '-1', '--pretty="%ai"', basename(file)],
-      { cwd: dirname(file) }
+      ['log', '-1', '--pretty=%at', path.basename(file)],
+      { cwd: path.dirname(file) }
     )
 
     let output = ''
     child.stdout.on('data', (d) => (output += String(d)))
 
     child.on('close', () => {
-      const timestamp = +new Date(output)
-      cache.set(file, timestamp)
-      resolve(timestamp)
+      const ts = Number.parseInt(output.trim(), 10) * 1000
+      if (!(ts > 0)) return resolve(0)
+
+      cache.set(file, ts)
+      resolve(ts)
     })
 
     child.on('error', reject)

--- a/src/node/utils/getGitTimestamp.ts
+++ b/src/node/utils/getGitTimestamp.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { slash } from '../shared'
 
-let cache = new Map<string, number>()
+const cache = new Map<string, number>()
 
 const RS = 0x1e
 const NUL = 0x00

--- a/src/node/utils/getGitTimestamp.ts
+++ b/src/node/utils/getGitTimestamp.ts
@@ -1,8 +1,10 @@
 import { spawn, sync } from 'cross-spawn'
+import _debug from 'debug'
 import fs from 'node:fs'
 import path from 'node:path'
 import { slash } from '../shared'
 
+const debug = _debug('vitepress:git')
 const cache = new Map<string, number>()
 
 const RS = 0x1e
@@ -91,8 +93,10 @@ export async function cacheAllGitTimestamps(
 
 export async function getGitTimestamp(file: string): Promise<number> {
   const cached = cache.get(file)
-  // most likely will never be stale except for recently added files in dev
   if (cached) return cached
+
+  // most likely will never happen except for recently added files in dev
+  debug(`[cache miss] ${file}`)
 
   if (!fs.existsSync(file)) return 0
 


### PR DESCRIPTION
--- Autogenerated ---

This pull request optimizes how git timestamps are retrieved and cached for markdown files, improving both performance and reliability of the sitemap generation process. The main changes include introducing a new bulk caching function for git timestamps, updating related imports, and ensuring consistent path handling.

**Git Timestamp Caching Improvements:**

* Added a new function `cacheAllGitTimestamps` in `src/node/utils/getGitTimestamp.ts` to efficiently pre-fetch and cache git timestamps for all markdown files in a repository using a single git command. This reduces the number of individual git calls during site generation.
* Updated the `getGitTimestamp` function to use the cached values and improved its logic for parsing git output and handling file paths.

**Integration with Build and Plugin System:**

* In `src/node/plugin.ts`, imported `cacheAllGitTimestamps` and invoked it in the VitePress plugin setup to pre-resolve timestamps for all markdown files when the `lastUpdated` feature is enabled. [[1]](diffhunk://#diff-41c1809ae4af577adcfce070c7132e24b3052578da47fd715f38d09a0a70fca5R34) [[2]](diffhunk://#diff-41c1809ae4af577adcfce070c7132e24b3052578da47fd715f38d09a0a70fca5R117-R118)

**Path Handling Consistency:**

* Ensured that file paths are normalized using the `slash` utility when retrieving git timestamps, both in `src/node/build/generateSitemap.ts` and `src/node/utils/getGitTimestamp.ts`, to prevent mismatches and improve cross-platform compatibility. [[1]](diffhunk://#diff-51e4e028f0b25eaabd115961aca42a6bd2df5fdf72942c436a618c01903948a0R12) [[2]](diffhunk://#diff-51e4e028f0b25eaabd115961aca42a6bd2df5fdf72942c436a618c01903948a0L32-R33) [[3]](diffhunk://#diff-aa73813325ccfad406e08d79f1c54332fc6fdc7e06c92f435ae8dec6729be7c7L1-R114)