### PR TITLE
fix: git log parsing when there are empty commits in history

### DIFF
--- a/src/node/utils/getGitTimestamp.ts
+++ b/src/node/utils/getGitTimestamp.ts
@@ -94,7 +94,7 @@ class GitLogParser extends Transform {
       ts: Number.parseInt(ts, 10) * 1000,
       files: this.#files.slice()
     }
-    if (rec.files.length > 0) this.push(rec)
+    if (rec.ts > 0 && rec.files.length > 0) this.push(rec)
 
     this.#tsBytes.length = 0
     this.#fileBytes.length = 0


### PR DESCRIPTION
x-ref: https://github.com/vuejs/vitepress/issues/4954#issuecomment-3342963178