### PR TITLE
feat(theme): disable whitespace wrapping for VPBadge

### DIFF
--- a/src/client/theme-default/components/VPBadge.vue
+++ b/src/client/theme-default/components/VPBadge.vue
@@ -24,6 +24,7 @@ withDefaults(defineProps<Props>(), {
   line-height: 22px;
   font-size: 12px;
   font-weight: 500;
+  white-space: nowrap;
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
### Description

This PR will disable whitespace wrapping in VPBadge elements. Since they are generally meant for usage with a small amount of text it makes sense to set that as the default.

### Linked Issues

Fixes #4764

### Additional Context

In contrast to the proposed solution in the linked issue I have decided to add the style to the component itself instead of applying it via CSS. Also I did not use the `!important` rule to still allow for simple override.
