### PR TITLE
fix(docs): correct component name in headers

### DIFF
--- a/docs/es/guide/using-vue.md
+++ b/docs/es/guide/using-vue.md
@@ -128,7 +128,7 @@ Si un componente fuera usado en la mayoría de las páginas, ellos pueden ser re
 Asegurese de que el nombre de un componente personalizado contenga un hífen o esté en PascalCase. Caso contrario, el será tratado como un elemento alineado y envuelto dentro de una tag `<p>`, lo que llevará a una incompatibilidad de hidratación pues `<p>` no permite que elementos de bloque sean colocados dentro de el.
 :::
 
-### Usando Componentes En Headers <ComponenteEnHeader /> {#using-components-in-headers}
+### Usando Componentes En Headers <ComponentInHeader /> {#using-components-in-headers}
 
 Puede usar componentes Vue en los headers, pero observe la diferencia entre las siguientes sintaxis:
 

--- a/docs/pt/guide/using-vue.md
+++ b/docs/pt/guide/using-vue.md
@@ -128,7 +128,7 @@ Se um componente for usado na maioria das páginas, eles podem ser registrados g
 Certifique-se de que o nome de um componente personalizado contenha um hífen ou esteja em PascalCase. Caso contrário, ele será tratado como um elemento alinhado e envolvido dentro de uma tag `<p>`, o que levará a uma incompatibilidade de hidratação pois `<p>` não permite que elementos de bloco sejam colocados dentro dele.
 :::
 
-### Usando Componentes Em Cabeçalhos <ComponenteNoCabeçalho /> {#using-components-in-headers}
+### Usando Componentes Em Cabeçalhos <ComponentInHeader /> {#using-components-in-headers}
 
 Você pode usar componentes Vue nos cabeçalhos, mas observe a diferença entre as seguintes sintaxes:
 


### PR DESCRIPTION
### Description

The component name should not be translated

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
