### PR TITLE
fix(theme): use nav height css var for curtain top in sidebar

### DIFF
--- a/src/client/theme-default/components/VPSidebar.vue
+++ b/src/client/theme-default/components/VPSidebar.vue
@@ -119,7 +119,7 @@ watch(
 @media (min-width: 960px) {
   .curtain {
     position: sticky;
-    top: -64px;
+    top: calc(var(--vp-nav-height) * -1);
     left: 0;
     z-index: 1;
     margin-top: calc(var(--vp-nav-height) * -1);


### PR DESCRIPTION
### Description

Fixes curtain not covering sidebar if it's too long and --vp-nav-height is set to anything besides 64px

Before:
![before-1](https://github.com/user-attachments/assets/b6c71d39-fa2d-4020-872c-fe1b9613aedb)
![before-2](https://github.com/user-attachments/assets/dd23e1cf-7f14-4d01-8d7c-9253d720feb7)


After:
![after](https://github.com/user-attachments/assets/08e9662c-570a-4f75-b60b-66411c00bb18)


<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
