### PR TITLE
fix(cli): gate ora spinner behind tty check

### DIFF
--- a/src/node/utils/task.ts
+++ b/src/node/utils/task.ts
@@ -1,10 +1,11 @@
+import process from 'node:process'
 import ora from 'ora'
 
 export const okMark = '\x1b[32m✓\x1b[0m'
 export const failMark = '\x1b[31m✗\x1b[0m'
 
 export async function task(taskName: string, task: () => Promise<void>) {
-  const spinner = ora({ discardStdin: false })
+  const spinner = ora({ discardStdin: false, isEnabled: !!process.stdin.isTTY })
   spinner.start(taskName + '...')
 
   try {


### PR DESCRIPTION
### Description

This PR gates the `ora` spinner behind a TTY check so VitePress behaves correctly in non-interactive environments (e.g., Nix builds).

Without this, the spinner remains enabled in non‑TTY contexts and suppress/overwrite error output, making build failures appear to "hang" indefinitely.

#### Why this is needed

- Animated terminal UIs assume an interactive TTY. In non‑TTY contexts, `ora`'s frame updates and cursor control can interfere with output and error reporting. This actually hides build errors and looks like a hang
- This change preserves the same behavior for interactive terminals, and prints clear, non-interactive output in non‑TTY environments

#### Minimal public reproduction (Nix + GitHub Actions)

- Repo: [ora-nix-issue-demo](https://github.com/nicolas-goudry/ora-nix-issue-demo)
- It uses a tiny script that rejects a promise after a short delay
- Two modes:
  - Problematic: spinner force enabled in a non‑TTY, error is hidden, looks like a hang
  - Fixed: spinner gated by TTY, error shows reliably
- Includes both a Nix expression and a GitHub Actions workflow to reproduce in non-interactive contexts

#### Impact

- No breaking changes for interactive use
- In non‑TTY environments, errors are visible and builds no longer appear to hang

### Linked Issues

N/A

### Additional Context

N/A