### PR TITLE
docs: fix last-updated doc description

### DIFF
--- a/docs/zh/reference/default-theme-last-updated.md
+++ b/docs/zh/reference/default-theme-last-updated.md
@@ -1,6 +1,6 @@
 # 最后更新于 {#last-updated}
 
-最近一条内容的更新时间会显示在页面右下角。要启用它，请将 `lastUpdated` 选项添加到配置中。
+最近一条内容的更新时间默认显示在页面左下角，如果[editLink](./default-theme-edit-link) 为true，则会显示在页面右下角。要启用它，请将 `lastUpdated` 选项添加到配置中。
 
 ::: tip
 VitePress 通过每个文件最近一次 Git 提交的时间戳显示"最后更新"时间，因此你必须提交 markdown 文件才能看到最后更新时间。
@@ -17,7 +17,7 @@ VitePress 通过每个文件最近一次 Git 提交的时间戳显示"最后更�
 ```
 
 其他 CI/CD 平台也有类似设置。
-
+  
 若上述选项不可用，可在 `package.json` 中的 `docs:build` 命令后手动添加获取操作：
 
 ```json


### PR DESCRIPTION
### Description

The description of the 'last updated' feature is inaccurate and can be misleading. When editLink is enabled, the default behavior should be that it appears on the left side.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
