### PR TITLE
docs(markdown): add installation guidance for markdown-it-mathjax3@^4…

### DIFF
--- a/docs/en/guide/markdown.md
+++ b/docs/en/guide/markdown.md
@@ -949,7 +949,7 @@ and include it like this:
 This is currently opt-in. To enable it, you need to install `markdown-it-mathjax3` and set `markdown.math` to `true` in your config file:
 
 ```sh
-npm add -D markdown-it-mathjax3
+npm add -D markdown-it-mathjax3^4
 ```
 
 ```ts [.vitepress/config.ts]

--- a/docs/es/guide/markdown.md
+++ b/docs/es/guide/markdown.md
@@ -844,7 +844,7 @@ Observe que esto no genera errores si el archivo no está presente. Por lo tanto
 Esto es actualmente opcional. Para activarlo, necesita instalar `markdown-it-mathjax3` y definir `markdown.math` como `true` en su archivo de configuración:
 
 ```sh
-npm add -D markdown-it-mathjax3
+npm add -D markdown-it-mathjax3^4
 ```
 
 ```ts [.vitepress/config.ts]

--- a/docs/fa/guide/markdown.md
+++ b/docs/fa/guide/markdown.md
@@ -833,7 +833,7 @@ export default config
 در حال حاضر این گزینه اختیاری است. برای فعال‌سازی آن، باید `markdown-it-mathjax3` را نصب کرده و `markdown.math` را در فایل پیکربندی خود به `true` تنظیم کنید:
 
 ```sh
-npm add -D markdown-it-mathjax3
+npm add -D markdown-it-mathjax3^4
 ```
 
 ```ts [.vitepress/config.ts]

--- a/docs/ja/guide/markdown.md
+++ b/docs/ja/guide/markdown.md
@@ -954,7 +954,7 @@ VS Code のリージョンの代わりに、ヘッダーアンカーを使って
 この機能はオプトインです。利用するには `markdown-it-mathjax3` をインストールし、設定ファイルで `markdown.math` を `true` に設定します。
 
  ```sh
- npm add -D markdown-it-mathjax3
+ npm add -D markdown-it-mathjax3^4
  ```
 
  ```ts [.vitepress/config.ts]

--- a/docs/ko/guide/markdown.md
+++ b/docs/ko/guide/markdown.md
@@ -880,7 +880,7 @@ Can be created using `.foorc.json`.
 선택 사항입니다. 활성화하려면 `markdown-it-mathjax3`를 설치하고 설정 파일에서 `markdown.math`를 `true`로 설정해야 합니다:
 
 ```sh
-npm add -D markdown-it-mathjax3
+npm add -D markdown-it-mathjax3^4
 ```
 
 ```ts [.vitepress/config.ts]

--- a/docs/pt/guide/markdown.md
+++ b/docs/pt/guide/markdown.md
@@ -843,7 +843,7 @@ Observe que isso não gera erros se o arquivo não estiver presente. Portanto, a
 Isso é atualmente opcional. Para ativá-lo, você precisa instalar `markdown-it-mathjax3` e definir `markdown.math` como `true` no seu arquivo de configuração:
 
 ```sh
-npm add -D markdown-it-mathjax3
+npm add -D markdown-it-mathjax3^4
 ```
 
 ```ts [.vitepress/config.ts]

--- a/docs/ru/guide/markdown.md
+++ b/docs/ru/guide/markdown.md
@@ -951,7 +951,7 @@ export default config
 В настоящее время эта фича предоставляется по желанию. Чтобы включить её, вам нужно установить `markdown-it-mathjax3` и установить значение `true` для опции `markdown.math` в вашем файле конфигурации:
 
 ```sh
-npm add -D markdown-it-mathjax3
+npm add -D markdown-it-mathjax3^4
 ```
 
 ```ts [.vitepress/config.ts]

--- a/docs/zh/guide/markdown.md
+++ b/docs/zh/guide/markdown.md
@@ -843,7 +843,7 @@ Can be created using `.foorc.json`.
 现在这是可选的。要启用它，需要安装 `markdown-it-mathjax3`，在配置文件中设置`markdown.math` 为 `true`：
 
 ```sh
-npm add -D markdown-it-mathjax3
+npm add -D markdown-it-mathjax3^4
 ```
 
 ```ts [.vitepress/config.ts]


### PR DESCRIPTION
… to enable math

### Description

The latest version of markdown-it-mathjax3 is already 5. However, installing it according to the default instructions in the documentation will trigger an error.
Meanwhile, there is an error message in the code indicating that version 4.x should be installed.

<img width="2294" height="404" alt="image" src="https://github.com/user-attachments/assets/b24eab60-8500-4f00-9e28-34fa6a4d0f47" />

https://github.com/vuejs/vitepress/blob/3f888218fc510776194619a260c69ab1f7b52eb7/src/node/markdown/markdown.ts#L383-L386

<img width="792" height="459" alt="image" src="https://github.com/user-attachments/assets/4708792d-904a-4511-8c80-407758a80db4" />


### Additional Context

only modify md guide

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
