### PR TITLE
feat: use `minify` function exposed from Vite for Vite 8+

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -30,8 +30,11 @@ export async function build(
 ) {
   const start = Date.now()
 
-  // @ts-ignore only exists for rolldown-vite
-  if (vite.rolldownVersion) {
+  if (
+    !vite.version.startsWith('8.') &&
+    // @ts-ignore only exists for rolldown-vite
+    vite.rolldownVersion
+  ) {
     try {
       await import('oxc-minify')
     } catch {

--- a/src/node/build/render.ts
+++ b/src/node/build/render.ts
@@ -265,8 +265,12 @@ function renderAttrs(attrs: Record<string, string>): string {
 }
 
 async function minifyScript(code: string, filename: string): Promise<string> {
-  // @ts-ignore use oxc-minify when rolldown-vite is used
-  if (vite.rolldownVersion) {
+  if (vite.version.startsWith('8.')) {
+    // @ts-ignore minify is available in vite 8
+    const minify = vite.minify
+    return (await minify(filename, code)).code.trim()
+    // @ts-ignore use oxc-minify when rolldown-vite is used
+  } else if (vite.rolldownVersion) {
     const oxcMinify = await import('oxc-minify')
     return (await oxcMinify.minify(filename, code)).code.trim()
   }


### PR DESCRIPTION
### Description

Vite 8+ exposes `minify` function so you don't need to install oxc-minify separately.

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
