### PR TITLE
docs(markdown): update mathjax3 install instructions in markdown guides

### DIFF
--- a/docs/en/guide/markdown.md
+++ b/docs/en/guide/markdown.md
@@ -948,22 +948,9 @@ and include it like this:
 
 This is currently opt-in. To enable it, you need to install `markdown-it-mathjax3` and set `markdown.math` to `true` in your config file:
 
-::: code-group
-
-```sh [npm]
-$ npm add -D markdown-it-mathjax3@^4
+```sh
+npm add -D markdown-it-mathjax3@^4
 ```
-
-```sh [pnpm]
-$ pnpm add -D markdown-it-mathjax3@^4
-```
-
-:::
-
-::: tip NOTE
-Use `markdown-it-mathjax3@^4` instead of the latest version.  
-Newer releases introduce breaking changes that are not compatible with VitePress.
-:::
 
 ```ts [.vitepress/config.ts]
 export default {

--- a/docs/es/guide/markdown.md
+++ b/docs/es/guide/markdown.md
@@ -843,22 +843,9 @@ Observe que esto no genera errores si el archivo no está presente. Por lo tanto
 
 Esto es actualmente opcional. Para activarlo, necesita instalar `markdown-it-mathjax3` y definir `markdown.math` como `true` en su archivo de configuración:
 
-::: code-group
-
-```sh [npm]
-$ npm add -D markdown-it-mathjax3@^4
+```sh
+npm add -D markdown-it-mathjax3@^4
 ```
-
-```sh [pnpm]
-$ pnpm add -D markdown-it-mathjax3@^4
-```
-
-:::
-
-::: tip NOTE
-Use `markdown-it-mathjax3@^4` instead of the latest version.  
-Newer releases introduce breaking changes that are not compatible with VitePress.
-:::
 
 ```ts [.vitepress/config.ts]
 export default {

--- a/docs/fa/guide/markdown.md
+++ b/docs/fa/guide/markdown.md
@@ -832,22 +832,9 @@ export default config
 
 در حال حاضر این گزینه اختیاری است. برای فعال‌سازی آن، باید `markdown-it-mathjax3` را نصب کرده و `markdown.math` را در فایل پیکربندی خود به `true` تنظیم کنید:
 
-::: code-group
-
-```sh [npm]
-$ npm add -D markdown-it-mathjax3@^4
+```sh
+npm add -D markdown-it-mathjax3@^4
 ```
-
-```sh [pnpm]
-$ pnpm add -D markdown-it-mathjax3@^4
-```
-
-:::
-
-::: tip NOTE
-Use `markdown-it-mathjax3@^4` instead of the latest version.  
-Newer releases introduce breaking changes that are not compatible with VitePress.
-:::
 
 ```ts [.vitepress/config.ts]
 export default {

--- a/docs/ja/guide/markdown.md
+++ b/docs/ja/guide/markdown.md
@@ -953,22 +953,9 @@ VS Code のリージョンの代わりに、ヘッダーアンカーを使って
 
 この機能はオプトインです。利用するには `markdown-it-mathjax3` をインストールし、設定ファイルで `markdown.math` を `true` に設定します。
 
-::: code-group
-
-```sh [npm]
-$ npm add -D markdown-it-mathjax3@^4
+```sh
+npm add -D markdown-it-mathjax3@^4
 ```
-
-```sh [pnpm]
-$ pnpm add -D markdown-it-mathjax3@^4
-```
-
-:::
-
-::: tip NOTE
-Use `markdown-it-mathjax3@^4` instead of the latest version.  
-Newer releases introduce breaking changes that are not compatible with VitePress.
-:::
 
  ```ts [.vitepress/config.ts]
  export default {

--- a/docs/ko/guide/markdown.md
+++ b/docs/ko/guide/markdown.md
@@ -879,22 +879,9 @@ Can be created using `.foorc.json`.
 
 선택 사항입니다. 활성화하려면 `markdown-it-mathjax3`를 설치하고 설정 파일에서 `markdown.math`를 `true`로 설정해야 합니다:
 
-::: code-group
-
-```sh [npm]
-$ npm add -D markdown-it-mathjax3@^4
+```sh
+npm add -D markdown-it-mathjax3@^4
 ```
-
-```sh [pnpm]
-$ pnpm add -D markdown-it-mathjax3@^4
-```
-
-:::
-
-::: tip NOTE
-Use `markdown-it-mathjax3@^4` instead of the latest version.  
-Newer releases introduce breaking changes that are not compatible with VitePress.
-:::
 
 ```ts [.vitepress/config.ts]
 export default {

--- a/docs/pt/guide/markdown.md
+++ b/docs/pt/guide/markdown.md
@@ -842,22 +842,9 @@ Observe que isso não gera erros se o arquivo não estiver presente. Portanto, a
 
 Isso é atualmente opcional. Para ativá-lo, você precisa instalar `markdown-it-mathjax3` e definir `markdown.math` como `true` no seu arquivo de configuração:
 
-::: code-group
-
-```sh [npm]
-$ npm add -D markdown-it-mathjax3@^4
+```sh
+npm add -D markdown-it-mathjax3@^4
 ```
-
-```sh [pnpm]
-$ pnpm add -D markdown-it-mathjax3@^4
-```
-
-:::
-
-::: tip NOTE
-Use `markdown-it-mathjax3@^4` instead of the latest version.  
-Newer releases introduce breaking changes that are not compatible with VitePress.
-:::
 
 ```ts [.vitepress/config.ts]
 export default {

--- a/docs/ru/guide/markdown.md
+++ b/docs/ru/guide/markdown.md
@@ -950,22 +950,9 @@ export default config
 
 В настоящее время эта фича предоставляется по желанию. Чтобы включить её, вам нужно установить `markdown-it-mathjax3` и установить значение `true` для опции `markdown.math` в вашем файле конфигурации:
 
-::: code-group
-
-```sh [npm]
-$ npm add -D markdown-it-mathjax3@^4
+```sh
+npm add -D markdown-it-mathjax3@^4
 ```
-
-```sh [pnpm]
-$ pnpm add -D markdown-it-mathjax3@^4
-```
-
-:::
-
-::: tip NOTE
-Use `markdown-it-mathjax3@^4` instead of the latest version.  
-Newer releases introduce breaking changes that are not compatible with VitePress.
-:::
 
 ```ts [.vitepress/config.ts]
 export default {

--- a/docs/zh/guide/markdown.md
+++ b/docs/zh/guide/markdown.md
@@ -842,22 +842,9 @@ Can be created using `.foorc.json`.
 
 现在这是可选的。要启用它，需要安装 `markdown-it-mathjax3`，在配置文件中设置`markdown.math` 为 `true`：
 
-::: code-group
-
-```sh [npm]
-$ npm add -D markdown-it-mathjax3@^4
+```sh
+npm add -D markdown-it-mathjax3@^4
 ```
-
-```sh [pnpm]
-$ pnpm add -D markdown-it-mathjax3@^4
-```
-
-:::
-
-::: tip NOTE
-Use `markdown-it-mathjax3@^4` instead of the latest version.  
-Newer releases introduce breaking changes that are not compatible with VitePress.
-:::
 
 ```ts [.vitepress/config.ts]
 export default {


### PR DESCRIPTION
### Description
When you copy the old command `markdown-it-mathjax3^4`, it fails because the syntax is invalid.
This PR replaces that example with correct code-group install commands for all package managers and adds a note recommending `markdown-it-mathjax3@^4` due to breaking changes in newer versions.
All language versions of the markdown guide have been updated.

### Linked Issues

Not applicable, documentation correction.
