### PR TITLE
fix(VPHero): injection of layoutInfoInjectionKey not handled properly causes failure

### DIFF
--- a/src/client/theme-default/components/VPHero.vue
+++ b/src/client/theme-default/components/VPHero.vue
@@ -24,7 +24,7 @@ defineProps<{
 const { heroImageSlotExists } = inject(
   layoutInfoInjectionKey,
   { heroImageSlotExists: computed(() => false) }
-);
+)
 </script>
 
 <template>


### PR DESCRIPTION
### Description

in `src/client/theme-default/Layout.vue` we have `provide(layoutInfoInjectionKey, { heroImageSlotExists })`, but I am using a custom layout that uses `src/client/theme-default/components/VPHomeHero.vue` and it is not providing that key causing

`TypeError: Cannot destructure property 'heroImageSlotExists' of 'inject(...)' as it is undefined.`

The fix consists in assigning a default value of `false` to the injection.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
