### PR TITLE
docs: include vue in Bun installation command

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -30,7 +30,7 @@ $ yarn add -D vitepress@next vue
 ```
 
 ```sh [bun]
-$ bun add -D vitepress@next
+$ bun add -D vitepress@next vue
 ```
 
 :::


### PR DESCRIPTION
### Description

This PR updates the Bun installation command to explicitly include `vue`.

VitePress relies on Vue at runtime, and Bun does not automatically install peer dependencies.  
Without installing `vue`, a fresh Bun setup can result in runtime errors.

### Linked Issues

N/A

### Additional Context

This change only affects the documentation and aligns the Bun install command with the actual runtime requirements.