### PR TITLE
fix: align badges in h1 and h2

### DIFF
--- a/src/client/theme-default/components/VPBadge.vue
+++ b/src/client/theme-default/components/VPBadge.vue
@@ -39,15 +39,14 @@ withDefaults(defineProps<Props>(), {
   display: none;
 }
 
-.vp-doc h1 > .VPBadge {
-  margin-top: 4px;
-  vertical-align: top;
+.vp-doc h1 > .VPBadge,
+.vp-doc h2 > .VPBadge {
+  margin: 0 0 0 2px;
+  vertical-align: middle;
 }
 
 .vp-doc h2 > .VPBadge {
-  margin-top: 3px;
   padding: 0 8px;
-  vertical-align: top;
 }
 
 .vp-doc h3 > .VPBadge {


### PR DESCRIPTION
## Issue
- https://github.com/vuejs/vitepress/issues/5063

## Summary
- align h1/h2 badges to the text baseline and remove the top offset

## Motivation
- fix heading badge vertical alignment regression reported in the default theme

## Validation
- pnpm dev:shared
- pnpm test:unit