### PR TITLE
fix: lower wide layout breakpoint to 1200px

### DIFF
--- a/src/client/theme-default/components/VPBackdrop.vue
+++ b/src/client/theme-default/components/VPBackdrop.vue
@@ -33,7 +33,7 @@ defineProps<{
   transition-duration: .25s;
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .VPBackdrop {
     display: none;
   }

--- a/src/client/theme-default/components/VPDoc.vue
+++ b/src/client/theme-default/components/VPDoc.vue
@@ -90,7 +90,7 @@ const pageName = computed(() =>
   }
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .VPDoc .container {
     display: flex;
     justify-content: center;
@@ -176,7 +176,7 @@ const pageName = computed(() =>
   }
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .content {
     order: 1;
     margin: 0;

--- a/src/client/theme-default/components/VPLocalNav.vue
+++ b/src/client/theme-default/components/VPLocalNav.vue
@@ -92,7 +92,7 @@ const classes = computed(() => {
   }
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .VPLocalNav {
     display: none;
   }

--- a/src/client/theme-default/components/VPNavBarAppearance.vue
+++ b/src/client/theme-default/components/VPNavBarAppearance.vue
@@ -23,7 +23,7 @@ const { site } = useData()
   display: none;
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .VPNavBarAppearance {
     display: flex;
     align-items: center;

--- a/src/client/theme-default/components/VPNavBarExtra.vue
+++ b/src/client/theme-default/components/VPNavBarExtra.vue
@@ -73,7 +73,7 @@ const hasExtraContent = computed(
   }
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .VPNavBarExtra {
     display: none;
   }

--- a/src/client/theme-default/components/VPNavBarSocialLinks.vue
+++ b/src/client/theme-default/components/VPNavBarSocialLinks.vue
@@ -18,7 +18,7 @@ const { theme } = useData()
   display: none;
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .VPNavBarSocialLinks {
     display: flex;
     align-items: center;

--- a/src/client/theme-default/components/VPNavBarTranslations.vue
+++ b/src/client/theme-default/components/VPNavBarTranslations.vue
@@ -30,7 +30,7 @@ const { localeLinks, currentLang } = useLangs({ correspondingLink: true })
   display: none;
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .VPNavBarTranslations {
     display: flex;
     align-items: center;

--- a/src/client/theme-default/components/VPSkipLink.vue
+++ b/src/client/theme-default/components/VPSkipLink.vue
@@ -40,7 +40,7 @@ watch(() => route.path, () => backToTop.value.focus())
   clip-path: none;
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1200px) {
   .VPSkipLink {
     top: 14px;
     left: 16px;

--- a/src/client/theme-default/composables/aside.ts
+++ b/src/client/theme-default/composables/aside.ts
@@ -5,14 +5,14 @@ import { useLayout } from './layout'
 export function useAside() {
   const { hasSidebar } = useLayout()
   const is960 = useMediaQuery('(min-width: 960px)')
-  const is1280 = useMediaQuery('(min-width: 1280px)')
+  const is1200 = useMediaQuery('(min-width: 1200px)')
 
   const isAsideEnabled = computed(() => {
-    if (!is1280.value && !is960.value) {
+    if (!is1200.value && !is960.value) {
       return false
     }
 
-    return hasSidebar.value ? is1280.value : is960.value
+    return hasSidebar.value ? is1200.value : is960.value
   })
 
   return {


### PR DESCRIPTION
## Issue
- https://github.com/vuejs/vitepress/issues/5069

## Summary
- shift default theme wide-layout breakpoint from 1280px to 1200px (aside/nav/local nav/backdrop)

## Motivation
- keep 1200px wide screens from prematurely hiding doc layout and navigation elements

## Validation
- pnpm dev:shared
- pnpm test:unit