### PR TITLE
Allow overflow-x with horizontal scrolling in VPNav

### DIFF
--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -52,7 +52,6 @@ watchEffect(() => {
 @media (min-width: 960px) {
   .VPNav {
     position: fixed;
-    overflow-x: scroll;
   }
 }
 </style>

--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -52,6 +52,7 @@ watchEffect(() => {
 @media (min-width: 960px) {
   .VPNav {
     position: fixed;
+    overflow-x: scroll;
   }
 }
 </style>

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -183,7 +183,8 @@ watchPostEffect(() => {
 }
 
 .content-body {
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
   justify-content: flex-end;
   align-items: center;
   height: var(--vp-nav-height);

--- a/src/client/theme-default/components/VPNavBarMenu.vue
+++ b/src/client/theme-default/components/VPNavBarMenu.vue
@@ -35,6 +35,7 @@ const { theme } = useData()
 @media (min-width: 768px) {
   .VPNavBarMenu {
     display: flex;
+    overflow-x: auto;
   }
 }
 </style>


### PR DESCRIPTION
### Description

This PR fixes the issue of a truncated navigation bar when the content of the navbar is too wide for the viewport but the viewport width is more than 960px which is hard-coded in the media query.

### Linked Issues

Downstream issues

- https://github.com/LuxDL/DocumenterVitepress.jl/issues/61
- https://github.com/LuxDL/DocumenterVitepress.jl/issues/118 

### Additional Context

I am not a CSS expert so this may not be the cleanest fix.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
