### PR TITLE
docs: add vitepress-plugin-typesense npm link to Reference > Default theme > Search

### DIFF
--- a/docs/en/reference/default-theme-search.md
+++ b/docs/en/reference/default-theme-search.md
@@ -29,6 +29,7 @@ Alternatively, you can use [Algolia DocSearch](#algolia-search) or some communit
 - <https://www.npmjs.com/package/vitepress-plugin-search>
 - <https://www.npmjs.com/package/vitepress-plugin-pagefind>
 - <https://www.npmjs.com/package/@orama/plugin-vitepress>
+- <https://www.npmjs.com/package/vitepress-plugin-typesense>
 
 ### i18n {#local-search-i18n}
 


### PR DESCRIPTION
### Description
This PR adds the [Vitepress Plugin Typesense](https://vitepress-plugin.typesense.org/) npm link to Reference > Default theme > Search.

The plugin lets you use Typesense as the backend for the search interface in VitePress, similar to Algolia DocSearch.
