### PR TITLE
feat(theme): add Japanese translation for "copied" label

### DIFF
--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -386,7 +386,7 @@
   --vp-code-copy-copied-text-content: '已复制';
 }
 :lang(ja) {
-  --vp-code-copy-copied-text-content: 'コピー済';
+  --vp-code-copy-copied-text-content: 'コピー完了';
 }
 
 /**


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

Translated "Copied" label into Japanese.

<img width="286" height="143" alt="image" src="https://github.com/user-attachments/assets/dc56b74f-fc2a-41c4-adab-50dbbff08725" />
<img width="171" height="74" alt="image" src="https://github.com/user-attachments/assets/3d290e5f-0744-405e-ae36-9bcf4b09d680" />


↑ Shorter

- コピー済
- **コピー完了** (Adopted)
- コピーしました

↓ Longer

"○○済" → Has already done ...
"○○完了" → ... has been completed

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
