### PR TITLE
fix(theme): NavItem's child incorrectly use RegExp to active

### DIFF
--- a/src/client/theme-default/components/VPMenuLink.vue
+++ b/src/client/theme-default/components/VPMenuLink.vue
@@ -18,6 +18,14 @@ const href = computed(() =>
     : props.item.link
 )
 
+const isActiveLink = computed(() =>
+  isActive(
+    page.value.relativePath,
+    props.item.activeMatch || href.value,
+    !!props.item.activeMatch
+  )
+)
+
 defineOptions({ inheritAttrs: false })
 </script>
 
@@ -25,13 +33,7 @@ defineOptions({ inheritAttrs: false })
   <div class="VPMenuLink">
     <VPLink
       v-bind="$attrs"
-      :class="{
-        active: isActive(
-          page.relativePath,
-          item.activeMatch || href,
-          !!item.activeMatch
-        )
-      }"
+      :class="{ active: isActiveLink }"
       :href
       :target="item.target"
       :rel="props.rel ?? item.rel"

--- a/src/client/theme-default/components/VPNavBarMenuGroup.vue
+++ b/src/client/theme-default/components/VPNavBarMenuGroup.vue
@@ -11,31 +11,36 @@ const props = defineProps<{
 
 const { page } = useData()
 
-const isChildActive = (navItem: DefaultTheme.NavItem) => {
+const isActiveGroup = computed(() => {
+  if (props.item.activeMatch) {
+    return isActive(page.value.relativePath, props.item.activeMatch, true)
+  }
+  return isChildActive(props.item)
+})
+
+function isChildActive(navItem: DefaultTheme.NavItem): boolean {
   if ('component' in navItem) return false
 
   if ('link' in navItem) {
+    const href =
+      typeof navItem.link === 'function'
+        ? navItem.link(page.value)
+        : navItem.link
+
     return isActive(
       page.value.relativePath,
-      navItem.activeMatch ? navItem.activeMatch : (typeof navItem.link === "function" ? navItem.link(page.value) : navItem.link),
+      navItem.activeMatch || href,
       !!navItem.activeMatch
     )
   }
 
   return navItem.items.some(isChildActive)
 }
-
-const childrenActive = computed(() => isChildActive(props.item))
 </script>
 
 <template>
   <VPFlyout
-    :class="{
-      VPNavBarMenuGroup: true,
-      active:
-        isActive(page.relativePath, item.activeMatch, !!item.activeMatch) ||
-        childrenActive
-    }"
+    :class="{ VPNavBarMenuGroup: true, active: isActiveGroup }"
     :button="item.text"
     :items="item.items"
   />

--- a/src/client/theme-default/components/VPNavBarMenuLink.vue
+++ b/src/client/theme-default/components/VPNavBarMenuLink.vue
@@ -16,18 +16,19 @@ const href = computed(() =>
     ? props.item.link(page.value)
     : props.item.link
 )
+
+const isActiveLink = computed(() =>
+  isActive(
+    page.value.relativePath,
+    props.item.activeMatch || href.value,
+    !!props.item.activeMatch
+  )
+)
 </script>
 
 <template>
   <VPLink
-    :class="{
-      VPNavBarMenuLink: true,
-      active: isActive(
-        page.relativePath,
-        item.activeMatch || href,
-        !!item.activeMatch
-      )
-    }"
+    :class="{ VPNavBarMenuLink: true, active: isActiveLink }"
     :href
     :target="item.target"
     :rel="item.rel"


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

Previously,when a NavItem use `activeMatch` as RegExp to active and be highlighted,it always judge its children using the child's `link` (but not `activeMatch`) as RegExp,whatever the child has `activeMatch` or not.

(After commit b1fbece047ca503f2c59553f9e37a0aac4be52c9,a NavItem will be actived when any of its childs is matched.Although the child itself will not be incorrectly actived,the NavItem does.)

**Example**

When you have a nav config like this,the `NavItem2` will be incorrectly actived on Page B,because its link `/nav1/nav2/page` matches RegExp `/nav2/`,which is the `link` of Page C.

```ts
nav: [
  {
    text: "NavItem1",
    activeMatch: "^/nav1/",
    items: [
      { text: "Page A", link: "/nav1/page" },
      { text: "Page B", link: "/nav1/nav2/page" }
    ]
  },

  {
    text: "NavItem2",
    activeMatch: "^/nav2/",
    items: [
      { text: "Page C", link: "/nav2/" } // link to "/nav2/index.html"
    ]
  }
];
```

Sorry for my poor English.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
