### PR TITLE
fix: ensure `clipboard.writeText` is awaited

### DIFF
--- a/src/client/app/composables/copyCode.ts
+++ b/src/client/app/composables/copyCode.ts
@@ -49,7 +49,6 @@ export function useCopyCode() {
 async function copyToClipboard(text: string) {
   try {
     await navigator.clipboard.writeText(text)
-    return
   } catch {
     const element = document.createElement('textarea')
     const previouslyFocusedElement = document.activeElement


### PR DESCRIPTION
### Description

Per [writeText](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText), it should be awaited.

### Linked Issues

N/A

### Additional Context

N/A
