### PR TITLE
feat(theme): allow joining attr to external link

### DIFF
--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -26,7 +26,7 @@ import mditCjkFriendly from 'markdown-it-cjk-friendly'
 import { full as emojiPlugin } from 'markdown-it-emoji'
 import type { BuiltinLanguage, BuiltinTheme, Highlighter } from 'shiki'
 import type { Logger } from 'vite'
-import type { Awaitable } from '../shared'
+import type { Awaitable, ExternalLinkAttrValue } from '../shared'
 import { containerPlugin, type ContainerOptions } from './plugins/containers'
 import { gitHubAlertsPlugin } from './plugins/githubAlerts'
 import { highlight as createHighlighter } from './plugins/highlight'
@@ -62,7 +62,7 @@ export interface MarkdownOptions extends MarkdownItAsyncOptions {
    * Disable cache (experimental)
    */
   cache?: boolean
-  externalLinks?: Record<string, string>
+  externalLinks?: Record<string, string | ExternalLinkAttrValue>
 
   /* ==================== Syntax Highlighting ==================== */
 
@@ -279,7 +279,11 @@ export async function createMarkdownRenderer(
   imagePlugin(md, options.image)
   linkPlugin(
     md,
-    { target: '_blank', rel: 'noreferrer', ...options.externalLinks },
+    {
+      target: '_blank',
+      rel: { value: 'noreferrer', join: true },
+      ...options.externalLinks
+    },
     base,
     slugify
   )

--- a/src/node/markdown/plugins/link.ts
+++ b/src/node/markdown/plugins/link.ts
@@ -8,14 +8,15 @@ import {
   EXTERNAL_URL_RE,
   isExternal,
   treatAsHtml,
-  type MarkdownEnv
+  type MarkdownEnv,
+  type ExternalLinkAttrValue
 } from '../../shared'
 
 const indexRE = /(^|.*\/)index.md(#?.*)$/i
 
 export const linkPlugin = (
   md: MarkdownItAsync,
-  externalAttrs: Record<string, string>,
+  externalAttrs: Record<string, string | ExternalLinkAttrValue>,
   base: string,
   slugify: (str: string) => string
 ) => {
@@ -38,7 +39,15 @@ export const linkPlugin = (
       const url = hrefAttr[1]
       if (isExternal(url)) {
         Object.entries(externalAttrs).forEach(([key, val]) => {
-          token.attrSet(key, val)
+          if (typeof val === 'string') {
+            token.attrSet(key, val)
+          } else {
+            if (val.join) {
+              token.attrJoin(key, val.value)
+            } else {
+              token.attrSet(key, val.value)
+            }
+          }
         })
         // catch localhost links as dead link
         if (url.replace(EXTERNAL_URL_RE, '').startsWith('//localhost:')) {

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -19,7 +19,8 @@ export type {
   SSGContext,
   AdditionalConfig,
   AdditionalConfigDict,
-  AdditionalConfigLoader
+  AdditionalConfigLoader,
+  ExternalLinkAttrValue
 } from '../../types/shared'
 
 export const EXTERNAL_URL_RE = /^(?:[a-z]+:|\/\/)/i

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -232,3 +232,8 @@ export interface MarkdownEnv {
   realPath?: string
   localeIndex?: string
 }
+
+export interface ExternalLinkAttrValue {
+  value: string
+  join?: boolean
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

I tried to add `rel="nofollow"` attribute to an external link and found it doesn't work.

My markdown file is like this:

```md
[LINK](https://external.link){rel=nofollow} // use markdown-it-attrs plugin
```

And this is the final html:

```html
<a href="https://external.link" rel="noreferrer" target="_blank">LINK</a>
```

It's `rel` attribute is an unexpected **noreferrer** but not **nofollow**.

That's because the `linkPlugin` always use `attrSet` and override the old value.

This PR add an option telling the `linkPlugin` to use `attrSet` or to use `attrJoin` for each attr.

```ts
linkPlugin(
  md,
  {
    target: '_blank',
    rel: { value: 'noreferrer', join: true },
    example1: 'will-override',
    example2: { value: 'will-override' },
    example3: { value: 'will-override', join: false },
    example4: { value: 'will-join-in', join: true },
    ...options.externalLinks
  },
  base,
  slugify
)

let externalLinks?: Record<string, string | ExternalLinkAttrValue>

export interface ExternalLinkAttrValue {
  value: string
  join?: boolean
}
```

The final html contains both **nofollow** and **noreferrer**:

```html
<a href="https://external.link" rel="nofollow noreferrer" target="_blank">LINK</a>
```
### Linked Issues

<!-- e.g. fixes #123 -->

None.

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

The markdown-it-attrs plugin is built-in with VitePress.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
