### PR TITLE
docs: add defineRoutes example to dynamic routes guide

### DIFF
--- a/docs/en/guide/routing.md
+++ b/docs/en/guide/routing.md
@@ -260,6 +260,30 @@ The generated HTML pages will be:
    └─ bar.html
 ```
 
+### Type-safe loader with `defineRoutes`
+
+If you are using TypeScript, you can wrap the loader with `defineRoutes` from `vitepress` to get type hints for route hooks such as `paths`, `watch`, and `transformPageData`:
+
+```ts
+// packages/[pkg].paths.ts
+import { defineRoutes } from 'vitepress'
+
+export default defineRoutes({
+  watch: ['../data/**/*.json'],
+  async paths() {
+    return [
+      { params: { pkg: 'foo' } },
+      { params: { pkg: 'bar' } }
+    ]
+  },
+  async transformPageData(pageData) {
+    pageData.title = `${pageData.title} · Packages`
+  }
+})
+```
+
+`defineRoutes` is optional, but recommended when authoring `.paths.ts` files.
+
 ### Multiple Params
 
 A dynamic route can contain multiple params:


### PR DESCRIPTION
Closes #5000

## Summary
- Add a new section in the Dynamic Routes guide to document `defineRoutes` usage for `.paths.ts` files
- Provide a type-safe example that includes `paths`, `watch`, and `transformPageData`
- Clarify that `defineRoutes` is optional but recommended for TypeScript loaders

## Validation
- `pnpm exec prettier docs/en/guide/routing.md --check`
- `pnpm build`
- `pnpm docs:build:only`
