### PR TITLE
Add force-light appearance

### DIFF
--- a/docs/en/reference/site-config.md
+++ b/docs/en/reference/site-config.md
@@ -489,7 +489,7 @@ When set to `true`, the production app will be built in [MPA Mode](../guide/mpa-
 
 ### appearance
 
-- Type: `boolean | 'dark' | 'force-dark' | 'force-auto' | import('@vueuse/core').UseDarkOptions`
+- Type: `boolean | 'dark' | 'force-dark' | 'force-light' | 'force-auto' | import('@vueuse/core').UseDarkOptions`
 - Default: `true`
 
 Whether to enable dark mode (by adding the `.dark` class to the `<html>` element).
@@ -498,6 +498,7 @@ Whether to enable dark mode (by adding the `.dark` class to the `<html>` element
 - If the option is set to `dark`, the theme will be dark by default, unless the user manually toggles it.
 - If the option is set to `false`, users will not be able to toggle the theme.
 - If the option is set to `'force-dark'`, the theme will always be dark and users will not be able to toggle it.
+- If the option is set to `'force-light'`, the theme will always be light and users will not be able to toggle it.
 - If the option is set to `'force-auto'`, the theme will always be determined by the user's preferred color scheme and users will not be able to toggle it.
 
 This option injects an inline script that restores users settings from local storage using the `vitepress-theme-appearance` key. This ensures the `.dark` class is applied before the page is rendered to avoid flickering.

--- a/src/client/app/data.ts
+++ b/src/client/app/data.ts
@@ -70,15 +70,17 @@ export function initData(route: Route): VitePressData {
   const isDark =
     appearance === 'force-dark'
       ? ref(true)
-      : appearance === 'force-auto'
-        ? usePreferredDark()
-        : appearance
-          ? useDark({
-              storageKey: APPEARANCE_KEY,
-              initialValue: () => (appearance === 'dark' ? 'dark' : 'auto'),
-              ...(typeof appearance === 'object' ? appearance : {})
-            })
-          : ref(false)
+      : appearance === 'force-light'
+        ? ref(false)
+        : appearance === 'force-auto'
+          ? usePreferredDark()
+          : appearance
+            ? useDark({
+                storageKey: APPEARANCE_KEY,
+                initialValue: () => (appearance === 'dark' ? 'dark' : 'auto'),
+                ...(typeof appearance === 'object' ? appearance : {})
+              })
+            : ref(false)
 
   const hashRef = ref(inBrowser ? location.hash : '')
 

--- a/src/client/theme-default/components/VPNavBarAppearance.vue
+++ b/src/client/theme-default/components/VPNavBarAppearance.vue
@@ -10,6 +10,7 @@ const { site } = useData()
     v-if="
       site.appearance &&
       site.appearance !== 'force-dark' &&
+      site.appearance !== 'force-light' &&
       site.appearance !== 'force-auto'
     "
     class="VPNavBarAppearance"

--- a/src/client/theme-default/components/VPNavBarExtra.vue
+++ b/src/client/theme-default/components/VPNavBarExtra.vue
@@ -45,6 +45,7 @@ const hasExtraContent = computed(
       v-if="
         site.appearance &&
         site.appearance !== 'force-dark' &&
+        site.appearance !== 'force-light' &&
         site.appearance !== 'force-auto'
       "
       class="group"

--- a/src/client/theme-default/components/VPNavScreenAppearance.vue
+++ b/src/client/theme-default/components/VPNavScreenAppearance.vue
@@ -10,6 +10,7 @@ const { site, theme } = useData()
     v-if="
       site.appearance &&
       site.appearance !== 'force-dark' &&
+      site.appearance !== 'force-light' &&
       site.appearance !== 'force-auto'
     "
     class="VPNavScreenAppearance"

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -363,17 +363,19 @@ function resolveSiteDataHead(userConfig?: UserConfig): HeadConfig[] {
       { id: 'check-dark-mode' },
       fallbackPreference === 'force-dark'
         ? `document.documentElement.classList.add('dark')`
-        : fallbackPreference === 'force-auto'
-          ? `;(() => {
-               if (window.matchMedia('(prefers-color-scheme: dark)').matches)
-                 document.documentElement.classList.add('dark')
-             })()`
-          : `;(() => {
-               const preference = localStorage.getItem('${APPEARANCE_KEY}') || '${fallbackPreference}'
-               const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-               if (!preference || preference === 'auto' ? prefersDark : preference === 'dark')
-                 document.documentElement.classList.add('dark')
-             })()`
+        : fallbackPreference === 'force-light'
+          ? ``
+          : fallbackPreference === 'force-auto'
+            ? `;(() => {
+                 if (window.matchMedia('(prefers-color-scheme: dark)').matches)
+                   document.documentElement.classList.add('dark')
+               })()`
+            : `;(() => {
+                 const preference = localStorage.getItem('${APPEARANCE_KEY}') || '${fallbackPreference}'
+                 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+                 if (!preference || preference === 'auto' ? prefersDark : preference === 'dark')
+                   document.documentElement.classList.add('dark')
+               })()`
     ])
   }
 

--- a/src/node/siteConfig.ts
+++ b/src/node/siteConfig.ts
@@ -63,6 +63,7 @@ export interface UserConfig<
     | boolean
     | 'dark'
     | 'force-dark'
+    | 'force-light'
     | 'force-auto'
     | (Omit<UseDarkOptions, 'initialValue'> & { initialValue?: 'dark' })
   lastUpdated?: boolean

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -133,6 +133,7 @@ export interface SiteData<ThemeConfig = any> {
     | boolean
     | 'dark'
     | 'force-dark'
+    | 'force-light'
     | 'force-auto'
     | (Omit<UseDarkOptions, 'initialValue'> & { initialValue?: 'dark' })
   themeConfig: ThemeConfig


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

Add `force-light` mode for supporting light mode only.

### Linked Issues

<!-- e.g. fixes #123 -->

#4471

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

My design system supports light theme, but the color palette that I'm using supports both light and dark theme. \
So with `auto` appearance, it breaks my color palette.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.