### PR TITLE
docs: add `home-hero-actions-before-actions` slot to layout slots

### DIFF
--- a/docs/en/guide/extending-default-theme.md
+++ b/docs/en/guide/extending-default-theme.md
@@ -190,6 +190,7 @@ Full list of slots available in the default theme layout:
   - `home-hero-info-before`
   - `home-hero-info`
   - `home-hero-info-after`
+  - `home-hero-actions-before-actions`
   - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`

--- a/docs/es/guide/extending-default-theme.md
+++ b/docs/es/guide/extending-default-theme.md
@@ -189,6 +189,8 @@ Lista completa de _slots_ disponibles en el layout del tema por defecto:
   - `home-hero-before`
   - `home-hero-info-before`
   - `home-hero-info`
+  - `home-hero-info-after`
+  - `home-hero-actions-before-actions`
   - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`

--- a/docs/fa/guide/extending-default-theme.md
+++ b/docs/fa/guide/extending-default-theme.md
@@ -191,6 +191,7 @@ export default {
   - `home-hero-info-before`
   - `home-hero-info`
   - `home-hero-info-after`
+  - `home-hero-actions-before-actions`
   - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`

--- a/docs/ja/guide/extending-default-theme.md
+++ b/docs/ja/guide/extending-default-theme.md
@@ -192,6 +192,7 @@ export default {
   - `home-hero-info-before`
   - `home-hero-info`
   - `home-hero-info-after`
+  - `home-hero-actions-before-actions`
   - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`

--- a/docs/ko/guide/extending-default-theme.md
+++ b/docs/ko/guide/extending-default-theme.md
@@ -190,6 +190,7 @@ export default {
   - `home-hero-info-before`
   - `home-hero-info`
   - `home-hero-info-after`
+  - `home-hero-actions-before-actions`
   - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`

--- a/docs/pt/guide/extending-default-theme.md
+++ b/docs/pt/guide/extending-default-theme.md
@@ -189,6 +189,8 @@ Lista completa de _slots_ disponíveis no layout do tema padrão:
   - `home-hero-before`
   - `home-hero-info-before`
   - `home-hero-info`
+  - `home-hero-info-after`
+  - `home-hero-actions-before-actions`
   - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`

--- a/docs/ru/guide/extending-default-theme.md
+++ b/docs/ru/guide/extending-default-theme.md
@@ -191,6 +191,7 @@ export default {
   - `home-hero-info-before`
   - `home-hero-info`
   - `home-hero-info-after`
+  - `home-hero-actions-before-actions`
   - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`

--- a/docs/zh/guide/extending-default-theme.md
+++ b/docs/zh/guide/extending-default-theme.md
@@ -189,6 +189,7 @@ export default {
   - `home-hero-info-before`
   - `home-hero-info`
   - `home-hero-info-after`
+  - `home-hero-actions-before-actions`
   - `home-hero-actions-after`
   - `home-hero-image`
   - `home-hero-after`


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This pull request adds the new `home-hero-actions-before-actions` slot to the Layout Slots in all `/guide/extending-default-theme#layout-slots` files.

This PR also includes:
- adding the missing `home-hero-info-header` slot to the Spanish md file
- adding the missing `home-hero-info-header` slot to the Portuguese md file

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
Missing in this PR: https://github.com/vuejs/vitepress/pull/5151

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
