### PR TITLE
feat: declare Content and ClientOnly components as GlobalComponents

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,6 +11,10 @@ export type { EnhanceAppContext, Theme } from './app/theme'
 // shared types
 export type { HeadConfig, Header, PageData, SiteData } from '../../types/shared'
 
+// components
+import { ClientOnly } from './app/components/ClientOnly'
+import { Content } from './app/components/Content'
+
 // composables
 export { dataSymbol, useData } from './app/data'
 export { useRoute, useRouter } from './app/router'
@@ -26,4 +30,11 @@ export {
 } from './app/utils'
 
 // components
-export { Content } from './app/components/Content'
+export { ClientOnly, Content }
+
+declare module 'vue' {
+  interface GlobalComponents {
+    ClientOnly: typeof ClientOnly
+    Content: typeof Content
+  }
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR exports ClientOnly component and declares Content and ClientOnly components as GlobalComponents in the  `vue` module augmentation at client/index.ts.

### Linked Issues

<!-- e.g. fixes #123 -->
supersedes #5154

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
WebStorm not resolving Content nor ClientOnly, we'll need to add webtypes json file, will go to another PR.

VSCode will suggest both, but WebStorm  don't (or any JetBrains IDE) at vue templates.

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
