### PR TITLE
feat: add `web-types.json` for JetBrains IDE support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dev:node": "DEV=true pnpm build:node -w",
     "dev:shared": "node scripts/copyShared",
     "dev:watch": "node scripts/watchAndCopy",
-    "build": "pnpm build:prepare && pnpm build:client && pnpm build:node",
+    "build": "pnpm build:prepare && pnpm build:client && pnpm build:node && node scripts/webTypes.js",
     "build:prepare": "pnpm clean && node scripts/copyShared",
     "build:client": "vue-tsc --noEmit -p src/client && tsc -p src/client && node scripts/copyClient",
     "build:node": "tsc -p src/node --noEmit && rollup --config rollup.config.ts --configPlugin esbuild",
@@ -209,5 +209,6 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@10.32.1"
+  "packageManager": "pnpm@10.32.1",
+  "web-types": "./dist/web-types.json"
 }

--- a/scripts/webTypes.js
+++ b/scripts/webTypes.js
@@ -1,0 +1,67 @@
+import { createRequire } from 'node:module'
+import { writeFile } from 'node:fs/promises'
+
+const require = createRequire(import.meta.url)
+
+// release script will change the version before running the build script
+const { version } = require('../package.json')
+
+await writeFile(
+  './dist/web-types.json',
+  JSON.stringify(
+    {
+      // $schema: 'https://json.schemastore.org/web-types',
+      $schema:
+        'https://raw.githubusercontent.com/JetBrains/web-types/master/schema/web-types.json',
+      framework: 'vue',
+      name: 'vitepress',
+      version: version,
+      'js-types-syntax': 'typescript',
+      'description-markup': 'markdown',
+      'framework-config': {
+        'enable-when': {
+          'node-packages': ['vue'],
+          'file-extensions': ['vue'],
+          'ide-libraries': ['vue']
+        }
+      },
+      contributions: {
+        html: {
+          'vue-components': [
+            {
+              name: 'ClientOnly',
+              description:
+                'ClientOnly component renders its default slot only at client side.',
+              'doc-url':
+                'https://vitepress.dev/reference/runtime-api#clientonly',
+              slots: [
+                {
+                  name: 'default',
+                  description: 'Content to render once client app is mounted'
+                }
+              ]
+            },
+            {
+              name: 'Content',
+              description:
+                'The Content component displays the rendered markdown contents. Useful when creating your own theme.',
+              'doc-url': 'https://vitepress.dev/reference/runtime-api#content',
+              props: [
+                {
+                  name: 'as',
+                  description:
+                    'An HTML tag name, a Component name or Component class reference.',
+                  type: ['string', 'object'],
+                  default: '"div"'
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    null,
+    2
+  ),
+  'utf8'
+)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR includes a new script to generate the `dist/web-types.json` to allow JetBrains IDE integration (IntelliJ, WebStorm...).

Right now only includes global components (ClientOnly and Content), later we can modify the script to add support for the default theme components (including slots, slots props, directives if any, etc..).

**NOTE**: won't work here in the monorepo (not sure yet why), I have created a local repo and installing the local tgz from this PR, check screenshots bellow.

<details>
<summary>Some WebStorm screenshots</summary>

<img width="680" height="397" alt="Content component" src="https://github.com/user-attachments/assets/ac998acc-41a9-4bcc-9d18-4140a5031558" />

<img width="1376" height="405" alt="ClientOnly component" src="https://github.com/user-attachments/assets/e8264f47-e6fd-45be-a031-624f26825b77" />

<img width="1434" height="670" alt="Content as prop" src="https://github.com/user-attachments/assets/29c656cb-863d-411b-b568-24709ccd952a" />


</details>

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
