### PR TITLE
fix(search): resolve `$frontmatter` expressions in local search index

### DIFF
--- a/__tests__/e2e/local-search/frontmatter-title.md
+++ b/__tests__/e2e/local-search/frontmatter-title.md
@@ -1,0 +1,7 @@
+---
+title: Frontmatter Title Resolved
+---
+
+# {{ $frontmatter.title }}
+
+This page uses a frontmatter title expression.

--- a/__tests__/e2e/local-search/local-search.test.ts
+++ b/__tests__/e2e/local-search/local-search.test.ts
@@ -28,4 +28,24 @@ describe('local search', () => {
         .count()
     ).toBe(0)
   })
+
+  test('resolve $frontmatter expressions in search results', async () => {
+    await page.locator('.VPNavBarSearchButton').click()
+
+    const input = await page.waitForSelector('input#localsearch-input')
+
+    await input.type('Frontmatter Title Resolved')
+    await page.waitForSelector('ul#localsearch-list', { state: 'visible' })
+
+    const searchResults = page.locator('#localsearch-list')
+
+    expect(
+      await searchResults
+        .filter({ hasText: 'Frontmatter Title Resolved' })
+        .count()
+    ).toBe(1)
+    expect(
+      await searchResults.filter({ hasText: '$frontmatter.title' }).count()
+    ).toBe(0)
+  })
 })

--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -56,12 +56,23 @@ export async function localSearchPlugin(
     const env: MarkdownEnv = { path: file, relativePath, cleanUrls }
     const md_raw = await fs.promises.readFile(file, 'utf-8')
     const md_src = processIncludes(md, srcDir, md_raw, file, [], cleanUrls)
+    let html: string
+
     if (options._render) {
-      return await options._render(md_src, env, md)
+      html = await options._render(md_src, env, md)
     } else {
-      const html = await md.renderAsync(md_src, env)
-      return env.frontmatter?.search === false ? '' : html
+      html = await md.renderAsync(md_src, env)
+
+      if (env.frontmatter?.search === false) {
+        return ''
+      }
     }
+
+    if (env.frontmatter) {
+      html = resolveFrontmatterExpressions(html, env.frontmatter)
+    }
+
+    return html
   }
 
   const indexByLocales = new Map<string, MiniSearch<IndexObject>>()
@@ -247,4 +258,23 @@ function getSearchableText(content: string) {
 
 function clearHtmlTags(str: string) {
   return str.replace(/<[^>]*>/g, '')
+}
+
+function resolveFrontmatterExpressions(
+  html: string,
+  frontmatter: Record<string, any>
+): string {
+  return html.replace(
+    /\{\{\s*\$frontmatter\.(\S+?)\s*\}\}/g,
+    (match, key: string) => {
+      const value = key
+        .split('.')
+        .reduce(
+          (object, key) => (object != null ? object[key] : undefined),
+          frontmatter
+        )
+
+      return value != null ? String(value) : match
+    }
+  )
 }


### PR DESCRIPTION
### Description

This pull request fixes the resolution of `$frontmatter` expressions in the search results. The index itself resolved the expressions properly, but when showing the results entries in the search UI it still showed the raw `$frontmatter` expressions.

### Linked Issues

Fixes https://github.com/vuejs/vitepress/issues/4934

### Additional Context

**Before**

<img width="2334" height="1396" alt="CleanShot 2026-03-23 at 20 12 44@2x" src="https://github.com/user-attachments/assets/c38e3186-34ce-4cf1-bbcf-4ea71f8dae2d" />



**After**

<img width="2334" height="1396" alt="CleanShot 2026-03-23 at 20 12 24@2x" src="https://github.com/user-attachments/assets/1223a2eb-bd5e-40ff-8dd8-e0af7f1bec48" />


---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
