### PR TITLE
[codex] fix: normalize navbar search keycaps

### DIFF
--- a/src/client/theme-default/components/VPNavBarSearchButton.vue
+++ b/src/client/theme-default/components/VPNavBarSearchButton.vue
@@ -34,8 +34,15 @@ defineProps<{
 }
 
 kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 12px;
   font-family: inherit;
   font-weight: 500;
+  line-height: 1;
+  text-align: center;
+  vertical-align: middle;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- normalize the navbar search shortcut keycaps so each key gets a consistent inline box model
- center the key labels vertically and horizontally to reduce Safari rendering drift at lower zoom levels

## Why
Issue #2885 reports that the `⌘K` shortcut badge in the navbar search box renders unevenly on Safari on macOS. The local search modal already gives each keycap explicit box styling, while the navbar button only relied on font settings.

## Validation
- inspected the existing search keycap styles in the local search modal and aligned the navbar keycaps with the same layout approach
- kept the change scoped to the navbar search button styles only

Closes #2885
