### PR TITLE
[codex] fix: preserve target in doc footer pager

### DIFF
--- a/src/client/theme-default/components/VPDocFooter.vue
+++ b/src/client/theme-default/components/VPDocFooter.vue
@@ -53,6 +53,7 @@ const showFooter = computed(
           v-if="control.prev?.link"
           class="pager-link prev"
           :href="control.prev.link"
+          :target="control.prev.target"
         >
           <span
             class="desc"
@@ -66,6 +67,7 @@ const showFooter = computed(
           v-if="control.next?.link"
           class="pager-link next"
           :href="control.next.link"
+          :target="control.next.target"
         >
           <span
             class="desc"

--- a/src/client/theme-default/composables/prev-next.ts
+++ b/src/client/theme-default/composables/prev-next.ts
@@ -40,7 +40,11 @@ export function usePrevNext() {
             link:
               (typeof frontmatter.value.prev === 'object'
                 ? frontmatter.value.prev.link
-                : undefined) ?? candidates[index - 1]?.link
+                : undefined) ?? candidates[index - 1]?.link,
+            target:
+              (typeof frontmatter.value.prev === 'object'
+                ? frontmatter.value.prev.target
+                : undefined) ?? candidates[index - 1]?.target
           },
       next: hideNext
         ? undefined
@@ -56,11 +60,15 @@ export function usePrevNext() {
             link:
               (typeof frontmatter.value.next === 'object'
                 ? frontmatter.value.next.link
-                : undefined) ?? candidates[index + 1]?.link
+                : undefined) ?? candidates[index + 1]?.link,
+            target:
+              (typeof frontmatter.value.next === 'object'
+                ? frontmatter.value.next.target
+                : undefined) ?? candidates[index + 1]?.target
           }
     } as {
-      prev?: { text?: string; link?: string }
-      next?: { text?: string; link?: string }
+      prev?: { text?: string; link?: string; target?: string }
+      next?: { text?: string; link?: string; target?: string }
     }
   })
 }

--- a/src/client/theme-default/support/sidebar.ts
+++ b/src/client/theme-default/support/sidebar.ts
@@ -6,6 +6,7 @@ export interface SidebarLink {
   text: string
   link: string
   docFooterText?: string
+  target?: string
 }
 
 type SidebarItem = DefaultTheme.SidebarItem
@@ -75,7 +76,8 @@ export function getFlatSideBarLinks(sidebar: SidebarItem[]): SidebarLink[] {
         links.push({
           text: item.text,
           link: item.link,
-          docFooterText: item.docFooterText
+          docFooterText: item.docFooterText,
+          target: item.target
         })
       }
 


### PR DESCRIPTION
## Summary
- preserve `target` when flattening sidebar links for the doc footer pager
- pass the preserved `target` through the previous/next footer links
- keep frontmatter overrides able to supply their own `target` as well

## Why
Issue #5112 reports that a sidebar item can define `target="_self"`, but the generated next page button loses that attribute. This happens because the footer pager only forwarded `text` and `link` from sidebar items.

## Validation
- inspected the sidebar flattening and footer pager path to confirm `target` was being dropped before rendering
- kept the change scoped to the existing prev/next link plumbing

Closes #5112
