### PR TITLE
fix: avoid mobile copy button overlap

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -306,6 +306,10 @@
   .vp-doc li div[class*='language-'] {
     border-radius: 8px 0 0 8px;
   }
+
+  .vp-doc [class*='language-'] code {
+    padding-right: 64px;
+  }
 }
 
 .vp-doc div[class*='language-'] + div[class*='language-'],


### PR DESCRIPTION
Fixes #5120.

## Summary
- reserve extra inline space for code content on narrow screens
- keep the copy button from sitting directly over selectable code text on mobile