### PR TITLE
fix(build): apply `base` to links with download attribute

### DIFF
--- a/src/node/markdown/plugins/link.ts
+++ b/src/node/markdown/plugins/link.ts
@@ -30,8 +30,6 @@ export const linkPlugin = (
     const hrefIndex = token.attrIndex('href')
     if (
       hrefIndex >= 0 &&
-      token.attrIndex('target') < 0 &&
-      token.attrIndex('download') < 0 &&
       token.attrGet('class') !== 'header-anchor' // header anchors are already normalized
     ) {
       const hrefAttr = token.attrs![hrefIndex]
@@ -54,6 +52,9 @@ export const linkPlugin = (
           !url.startsWith('#') &&
           // skip mail/custom protocol links
           protocol.startsWith('http') &&
+          // skip links with target/download attribute as they are meant to be opened/downloaded as-is
+          token.attrIndex('target') < 0 &&
+          token.attrIndex('download') < 0 &&
           // skip links to files (other than html/md)
           treatAsHtml(pathname)
         ) {


### PR DESCRIPTION
### Description

Fixes #4230 where links with the `download` attribute completely ignored the `base` config.

The issue traces back to #3947 (commit `e24899a`). That fix added an early check that skipped *all* link processing when `target` or `download` was present. That stopped `.html` suffixes on download links (good) but also skipped applying the `base` URL (bad).

This PR moves the check so we only skip the `.html` suffix part, not the whole thing. Now download links get the `base` applied while still avoiding the `.html` treatment.

### Linked Issues

Fixes #4230  
Related: #3947

### Additional Context

Moved the `target` / `download` check into the `treatAsHtml` block. Tested locally with a `base` set—download links now resolve correctly.

cc @brc-dd 
