### PR TITLE
feat: Add support for `format` option in Carbon options

### DIFF
--- a/docs/en/reference/default-theme-carbon-ads.md
+++ b/docs/en/reference/default-theme-carbon-ads.md
@@ -11,7 +11,8 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
@@ -19,8 +20,10 @@ export default {
 
 These values are used to call carbon CDN script as shown below.
 
+The `format` option supports `classic`, `responsive`, and `cover`.
+
 ```js
-`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}&format=${format}`
 ```
 
 To learn more about Carbon Ads configuration, please visit [Carbon Ads website](https://www.carbonads.net/).

--- a/docs/en/reference/default-theme-config.md
+++ b/docs/en/reference/default-theme-config.md
@@ -368,6 +368,7 @@ export default {
     carbonAds: {
       code: 'your-carbon-code',
       placement: 'your-carbon-placement'
+      format: 'classic'
     }
   }
 }
@@ -377,6 +378,7 @@ export default {
 export interface CarbonAdsOptions {
   code: string
   placement: string
+  format?: 'classic' | 'responsive' | 'cover'
 }
 ```
 

--- a/docs/es/reference/default-theme-carbon-ads.md
+++ b/docs/es/reference/default-theme-carbon-ads.md
@@ -11,7 +11,8 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'tu-código-carbon',
-      placement: 'tu-vinculación-carbon'
+      placement: 'tu-vinculación-carbon',
+      format: 'classic'
     }
   }
 }
@@ -19,8 +20,10 @@ export default {
 
 Estos valores se utilizan para llamar al script en CDN de carbon como se muestra a continuación.
 
+La opción `format` admite `classic`, `responsive` y `cover`.
+
 ```js
-`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}&format=${format}`
 ```
 
 Para obtener más información de la configuración de Carbono Ads, por favor visite [Site Carbon Ads](https://www.carbonads.net/).

--- a/docs/es/reference/default-theme-config.md
+++ b/docs/es/reference/default-theme-config.md
@@ -353,16 +353,20 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'su-código-carbon',
-      placement: 'su-colocación-carbon'
+      placement: 'su-colocación-carbon',
+      format: 'classic'
     }
   }
 }
 ```
 
+La opción `format` admite `classic`, `responsive` y `cover`.
+
 ```ts
 export interface CarbonAdsOptions {
   code: string
   placement: string
+  format?: 'classic' | 'responsive' | 'cover'
 }
 ```
 

--- a/docs/fa/reference/default-theme-carbon-ads.md
+++ b/docs/fa/reference/default-theme-carbon-ads.md
@@ -11,7 +11,8 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
@@ -19,8 +20,10 @@ export default {
 
 این مقادیر برای فراخوانی اسکریپت CDN Carbon به شکل زیر استفاده می‌شوند.
 
+گزینه `format` از مقادیر `classic`، `responsive` و `cover` پشتیبانی می‌کند.
+
 ```js
-`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}&format=${format}`
 ```
 
 برای یادگیری بیشتر درباره پیکربندی تبلیغات Carbon، لطفاً به [وب‌سایت Carbon Ads](https://www.carbonads.net/) مراجعه کنید.

--- a/docs/fa/reference/default-theme-config.md
+++ b/docs/fa/reference/default-theme-config.md
@@ -382,16 +382,20 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
 ```
 
+گزینه `format` از مقادیر `classic`، `responsive` و `cover` پشتیبانی می‌کند.
+
 ```ts
 export interface CarbonAdsOptions {
   code: string
   placement: string
+  format?: 'classic' | 'responsive' | 'cover'
 }
 ```
 

--- a/docs/ja/reference/default-theme-carbon-ads.md
+++ b/docs/ja/reference/default-theme-carbon-ads.md
@@ -11,7 +11,8 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
@@ -19,8 +20,10 @@ export default {
 
 これらの値は、次のように Carbon の CDN スクリプトを呼び出すために使用されます。
 
+`format` オプションには `classic`、`responsive`、`cover` を指定できます。
+
 ```js
-`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}&format=${format}`
 ```
 
 Carbon Ads の設定について詳しくは、[Carbon Ads のウェブサイト](https://www.carbonads.net/)を参照してください。

--- a/docs/ja/reference/default-theme-config.md
+++ b/docs/ja/reference/default-theme-config.md
@@ -367,16 +367,20 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
 ```
 
+`format` オプションには `classic`、`responsive`、`cover` を指定できます。
+
 ```ts
 export interface CarbonAdsOptions {
   code: string
   placement: string
+  format?: 'classic' | 'responsive' | 'cover'
 }
 ```
 

--- a/docs/ko/reference/default-theme-carbon-ads.md
+++ b/docs/ko/reference/default-theme-carbon-ads.md
@@ -11,7 +11,8 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
@@ -19,8 +20,10 @@ export default {
 
 이 값들은 아래와 같이 카본 CDN 스크립트를 호출하는 데 사용됩니다.
 
+`format` 옵션에는 `classic`, `responsive`, `cover`를 사용할 수 있습니다.
+
 ```js
-`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}&format=${format}`
 ```
 
 카본 광고 구성에 대해 더 알고 싶다면 [카본 광고 웹사이트](https://www.carbonads.net/)를 방문하세요.

--- a/docs/ko/reference/default-theme-config.md
+++ b/docs/ko/reference/default-theme-config.md
@@ -366,16 +366,20 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
 ```
 
+`format` 옵션에는 `classic`, `responsive`, `cover`를 사용할 수 있습니다.
+
 ```ts
 export interface CarbonAdsOptions {
   code: string
   placement: string
+  format?: 'classic' | 'responsive' | 'cover'
 }
 ```
 

--- a/docs/pt/reference/default-theme-carbon-ads.md
+++ b/docs/pt/reference/default-theme-carbon-ads.md
@@ -11,7 +11,8 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'seu-código-carbon',
-      placement: 'sua-veiculação-carbon'
+      placement: 'sua-veiculação-carbon',
+      format: 'classic'
     }
   }
 }
@@ -19,8 +20,10 @@ export default {
 
 Esses valores são usados para chamar o sript em CDN do carbon como mostrado abaixo.
 
+A opção `format` aceita `classic`, `responsive` e `cover`.
+
 ```js
-`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}&format=${format}`
 ```
 
 Para aprender mais sobre a configuração Carbon Ads, por favor visite [Site Carbon Ads](https://www.carbonads.net/).

--- a/docs/pt/reference/default-theme-config.md
+++ b/docs/pt/reference/default-theme-config.md
@@ -353,16 +353,20 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'seu-código-carbon',
-      placement: 'sua-veiculação-carbon'
+      placement: 'sua-veiculação-carbon',
+      format: 'classic'
     }
   }
 }
 ```
 
+A opção `format` aceita `classic`, `responsive` e `cover`.
+
 ```ts
 export interface CarbonAdsOptions {
   code: string
   placement: string
+  format?: 'classic' | 'responsive' | 'cover'
 }
 ```
 

--- a/docs/ru/reference/default-theme-carbon-ads.md
+++ b/docs/ru/reference/default-theme-carbon-ads.md
@@ -11,7 +11,8 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'код-рекламы',
-      placement: 'место-размещения-рекламы'
+      placement: 'место-размещения-рекламы',
+      format: 'classic'
     }
   }
 }
@@ -19,8 +20,10 @@ export default {
 
 Эти значения используются для вызова сценария Carbon CDN, как показано ниже:
 
+Параметр `format` поддерживает значения `classic`, `responsive` и `cover`.
+
 ```js
-;`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}&format=${format}`
 ```
 
 Чтобы узнать больше о настройке Carbon Ads, посетите [веб-сайт Carbon Ads](https://www.carbonads.net/).

--- a/docs/ru/reference/default-theme-config.md
+++ b/docs/ru/reference/default-theme-config.md
@@ -367,16 +367,20 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'код-рекламы',
-      placement: 'место-размещения-рекламы'
+      placement: 'место-размещения-рекламы',
+      format: 'classic'
     }
   }
 }
 ```
 
+Параметр `format` поддерживает значения `classic`, `responsive` и `cover`.
+
 ```ts
 export interface CarbonAdsOptions {
   code: string
   placement: string
+  format?: 'classic' | 'responsive' | 'cover'
 }
 ```
 

--- a/docs/zh/reference/default-theme-carbon-ads.md
+++ b/docs/zh/reference/default-theme-carbon-ads.md
@@ -11,7 +11,8 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
@@ -19,8 +20,10 @@ export default {
 
 这些值用于调用 carbon CDN 脚本，如下所示。
 
+`format` 选项支持 `classic`、`responsive` 和 `cover`。
+
 ```js
-`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}`
+`//cdn.carbonads.com/carbon.js?serve=${code}&placement=${placement}&format=${format}`
 ```
 
 要了解有关 Carbon Ads 配置的更多信息，请访问 [Carbon Ads 站点](https://www.carbonads.net/)。

--- a/docs/zh/reference/default-theme-config.md
+++ b/docs/zh/reference/default-theme-config.md
@@ -353,16 +353,20 @@ export default {
   themeConfig: {
     carbonAds: {
       code: 'your-carbon-code',
-      placement: 'your-carbon-placement'
+      placement: 'your-carbon-placement',
+      format: 'classic'
     }
   }
 }
 ```
 
+`format` 选项支持 `classic`、`responsive` 和 `cover`。
+
 ```ts
 export interface CarbonAdsOptions {
   code: string
   placement: string
+  format?: 'classic' | 'responsive' | 'cover'
 }
 ```
 

--- a/src/client/theme-default/components/VPCarbonAds.vue
+++ b/src/client/theme-default/components/VPCarbonAds.vue
@@ -22,7 +22,7 @@ function init() {
     const params = new URLSearchParams({
       serve: carbonOptions.code,
       placement: carbonOptions.placement,
-      format: carbonOptions.format || 'classic',
+      format: carbonOptions?.format || 'classic',
     })
     const s = document.createElement('script')
     s.id = '_carbonads_js'

--- a/src/client/theme-default/components/VPCarbonAds.vue
+++ b/src/client/theme-default/components/VPCarbonAds.vue
@@ -19,9 +19,14 @@ let isInitialized = false
 function init() {
   if (!isInitialized) {
     isInitialized = true
+    const params = new URLSearchParams({
+      serve: carbonOptions.code,
+      placement: carbonOptions.placement,
+      format: carbonOptions.format || 'classic',
+    })
     const s = document.createElement('script')
     s.id = '_carbonads_js'
-    s.src = `//cdn.carbonads.com/carbon.js?serve=${carbonOptions.code}&placement=${carbonOptions.placement}`
+    s.src = `//cdn.carbonads.com/carbon.js?${params.toString()}`
     s.async = true
     container.value.appendChild(s)
   }

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -410,6 +410,7 @@ export namespace DefaultTheme {
   export interface CarbonAdsOptions {
     code: string
     placement: string
+    format?: 'classic' | 'responsive' | 'cover'
   }
 
   // last updated --------------------------------------------------------------


### PR DESCRIPTION
### Description

Adding support for the `format` option in carbon ads options.

### Additional Context

By default, carbon ads are served with the classic format. But the newer formats, `responsive` or `cover`, are preferred by Carbon since they have more interactions, attracting more attention.
---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
