### PR TITLE
feat: Auto-anchor the sidebar to the active item

### DIFF
--- a/src/client/theme-default/components/VPSidebar.vue
+++ b/src/client/theme-default/components/VPSidebar.vue
@@ -1,11 +1,12 @@
 <script lang="ts" setup>
 import { useScrollLock } from '@vueuse/core'
-import { inBrowser } from 'vitepress'
-import { ref, watch } from 'vue'
+import { inBrowser, useRoute } from 'vitepress'
+import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useLayout } from '../composables/layout'
 import VPSidebarGroup from './VPSidebarGroup.vue'
 
 const { sidebarGroups, hasSidebar } = useLayout()
+const route = useRoute()
 
 const props = defineProps<{
   open: boolean
@@ -35,6 +36,72 @@ watch(
   },
   { deep: true }
 )
+
+const userScrolled = ref(false)
+const isProgrammaticScrolling = ref(false)
+
+const scrollToActiveItem = async (smooth: boolean = true) => {
+  // if SSR || (Mobile && Not open)
+  if (!inBrowser || (window.innerWidth < 960 && !props.open)) return
+
+  await nextTick()
+  const container = navEl.value
+  const activeItem = container?.querySelector('.VPSidebarItem.is-active')
+  if (!container || !activeItem) return
+
+  // set flags
+  isProgrammaticScrolling.value = true
+  userScrolled.value = false
+
+  activeItem.scrollIntoView({
+    behavior: smooth ? 'smooth' : 'instant',
+    block: 'center',
+    inline: 'nearest'
+  })
+
+  // reset flag when scroll ends
+  container.addEventListener('scrollend', () => {
+    isProgrammaticScrolling.value = false
+  }, { once: true })
+}
+
+const onSidebarScroll = () => {
+  // ignore programmatic scrolls
+  if (!isProgrammaticScrolling.value) userScrolled.value = true
+}
+
+const onWindowResize = () => {
+  // scroll only if the user has not scrolled manually
+  if (!userScrolled.value) scrollToActiveItem(false)
+}
+
+// route changes
+watch(() => route.path, () => scrollToActiveItem(true))
+
+// sidebar content changes
+watch(sidebarGroups, () => scrollToActiveItem(false), { deep: true })
+
+// Mobile: when opened
+watch(() => props.open, (newOpen) => {
+  if (newOpen) scrollToActiveItem(false)
+})
+
+// scroll once; attach event listeners
+onMounted(() => {
+  scrollToActiveItem(false)
+  if (inBrowser && navEl.value) {
+    navEl.value.addEventListener('scroll', onSidebarScroll)
+    window.addEventListener('resize', onWindowResize)
+  }
+})
+
+// clean up event listeners
+onBeforeUnmount(() => {
+  if (inBrowser && navEl.value) {
+    navEl.value.removeEventListener('scroll', onSidebarScroll)
+    window.removeEventListener('resize', onWindowResize)
+  }
+})
 </script>
 
 <template>


### PR DESCRIPTION
### Description

1. 让侧边栏可以自动定位到当前页面所对应的链接
2. 在窗口大小变化时，将当前页链接保持在侧边栏可视区域中央
3. 用户手动滚动侧边栏后，没有切换路由、刷新页面、重新打开侧边栏，且侧边栏内容未变化时，禁用自动定位，以提升用户体验
###
1. Enable the sidebar to automatically scroll to the link corresponding to the current page.
2. When the window size changes, keep the current page link centered within the sidebar's visible area.
3. After the user manually scrolls the sidebar, disable auto-positioning (to improve user experience) unless the route changes, the page is refreshed, the sidebar is reopened, or the sidebar content changes.

### Linked Issues

#3426 #4296 #4345 #4579

### Additional Context

注意到2024年已经有人提过类似PR：
Note that similar PRs have already been proposed in 2024:

#3654 #3901

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
