### PR TITLE
chore(scripts): replace execa with node:child_process in release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "conventional-changelog-angular": "^8.3.1",
     "cross-spawn": "^7.0.6",
     "esbuild": "^0.27.7",
-    "execa": "^9.6.1",
     "fs-extra": "^11.3.4",
     "get-port": "^7.2.0",
     "gray-matter": "^4.0.3",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -2,9 +2,9 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
+import { execFileSync } from 'node:child_process'
 import c from 'picocolors'
 import prompts from 'prompts'
-import { execa } from 'execa'
 import semver from 'semver'
 
 const { version: currentVersion } = createRequire(import.meta.url)(
@@ -19,7 +19,7 @@ const tags = ['latest', 'next']
 const dir = fileURLToPath(new URL('.', import.meta.url))
 const inc = (i) => _inc(currentVersion, i)
 const run = (bin, args, opts = {}) =>
-  execa(bin, args, { stdio: 'inherit', ...opts })
+ execFileSync(bin, args, { stdio: 'inherit', ...opts })
 const step = (msg) => console.log(c.cyan(msg))
 
 async function main() {


### PR DESCRIPTION
closes #5183

Replace `execa` with Node.js built-in `execFileSync` from `node:child_process`
in `scripts/release.js` and remove `execa` from devDependencies.

All commands in the release script run sequentially with `stdio: 'inherit'`,
so `execFileSync` is a drop-in replacement with identical behavior.