### PR TITLE
fix(theme-default): stabilize horizontal layout across pages with/without vertical scrollbar

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -22,6 +22,7 @@ html {
   line-height: 1.4;
   font-size: 16px;
   -webkit-text-size-adjust: 100%;
+  overflow-y: scroll;
 }
 
 html.dark {


### PR DESCRIPTION
## Summary

On browsers using classic (space-occupying) vertical scrollbars, navigating
between a page that triggers the scrollbar and one that does not causes the
top nav, content area, and local nav to shift horizontally by ~15 px at
viewport widths >= 1440 px. Reproduces on default Chrome/Edge on Linux/Windows.

## Root cause

The desktop layout in `VPNavBar.vue`, `VPContent.vue`, and `VPLocalNav.vue`
uses `100vw` to compute a centering offset inside an `@media (min-width:
1440px)` block. `100vw` is constant across scroll states (always includes
the scrollbar gutter per spec), but the container these paddings apply to
has `width: 100%` and therefore tracks `html.clientWidth`, which shrinks by
the scrollbar width when the scrollbar appears.

## Fix

Set `overflow-y: scroll` on `html` so the scrollbar gutter is always
reserved, making `html.clientWidth` constant and the layout pixel-stable
across navigations.

### Why not `scrollbar-gutter: stable`

Tested first; produced no effect on the wobble in the reporter's browser,
suggesting incomplete propagation of the property to viewport-relative
measurements. `overflow-y: scroll` is the universal, lowest-friction fix.

## Verified on

vitepress 1.6.4 (the CSS construct is unchanged on `main` as of this PR).

## Compatibility

- Overlay-scrollbar browsers (macOS Safari, mobile Chrome): no visual change.
- Classic-scrollbar browsers: a thin inactive scrollbar track appears on
  short pages; layout is now stable.
- Pure CSS, no JS or markup change.
