### PR TITLE
fix(markdown): handle frontmatter in heading includes

### DIFF
--- a/__tests__/unit/node/utils/fixtures/include-frontmatter/importing.md
+++ b/__tests__/unit/node/utils/fixtures/include-frontmatter/importing.md
@@ -1,0 +1,1 @@
+<!--@include: ./source.md#target-section-->

--- a/__tests__/unit/node/utils/fixtures/include-frontmatter/source-no-frontmatter.md
+++ b/__tests__/unit/node/utils/fixtures/include-frontmatter/source-no-frontmatter.md
@@ -1,0 +1,15 @@
+# Source Page
+
+Intro text before the target heading.
+
+## Target Section
+
+This line should be included.
+
+### Nested Heading
+
+Nested content should also be included if it belongs to Target Section.
+
+## Other Section
+
+This line should NOT be included.

--- a/__tests__/unit/node/utils/fixtures/include-frontmatter/source.md
+++ b/__tests__/unit/node/utils/fixtures/include-frontmatter/source.md
@@ -1,0 +1,19 @@
+---
+description: This page has frontmatter description
+---
+
+# Source Page
+
+Intro text before the target heading.
+
+## Target Section
+
+This line should be included.
+
+### Nested Heading
+
+Nested content should also be included if it belongs to Target Section.
+
+## Other Section
+
+This line should NOT be included.

--- a/__tests__/unit/node/utils/processIncludes.test.ts
+++ b/__tests__/unit/node/utils/processIncludes.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { processIncludes } from '../../../../src/node/utils/processIncludes'
+import { createMarkdownRenderer } from '../../../../src/node/markdown/markdown'
+import path from 'node:path'
+
+describe('processIncludes', () => {
+  it('should handle heading includes with frontmatter', async () => {
+    const srcDir = path.resolve(__dirname, 'fixtures/include-frontmatter')
+    const filePath = path.join(srcDir, 'importing.md')
+    const src = `<!--@include: ./source.md#target-section-->`
+
+    const md = await createMarkdownRenderer(srcDir)
+    const includes: string[] = []
+    const result = processIncludes(md, srcDir, src, filePath, includes, false)
+
+    // The result should contain the target section content
+    expect(result).toContain('This line should be included.')
+    expect(result).toContain(
+      'Nested content should also be included if it belongs to Target Section.'
+    )
+
+    // The result should NOT contain frontmatter
+    expect(result).not.toContain(
+      'description: This page has frontmatter description'
+    )
+    expect(result).not.toContain('This page has frontmatter description')
+
+    // The result should NOT contain content from other sections
+    expect(result).not.toContain('Intro text before the target heading.')
+    expect(result).not.toContain('This line should NOT be included.')
+    expect(result).not.toContain('## Other Section')
+
+    // The result should NOT contain the frontmatter description as content
+    expect(result).not.toMatch(/This page has frontmatter description/)
+  })
+
+  it('should handle heading includes without frontmatter', async () => {
+    const srcDir = path.resolve(__dirname, 'fixtures/include-frontmatter')
+    const filePath = path.join(srcDir, 'importing.md')
+    const src = `<!--@include: ./source-no-frontmatter.md#target-section-->`
+
+    const md = await createMarkdownRenderer(srcDir)
+    const includes: string[] = []
+    const result = processIncludes(md, srcDir, src, filePath, includes, false)
+
+    // The result should contain the target section content
+    expect(result).toContain('This line should be included.')
+    expect(result).toContain(
+      'Nested content should also be included if it belongs to Target Section.'
+    )
+
+    // The result should NOT contain content from other sections
+    expect(result).not.toContain('Intro text before the target heading.')
+    expect(result).not.toContain('This line should NOT be included.')
+  })
+
+  it('should handle full file include with frontmatter', async () => {
+    const srcDir = path.resolve(__dirname, 'fixtures/include-frontmatter')
+    const filePath = path.join(srcDir, 'importing.md')
+    const src = `<!--@include: ./source.md-->`
+
+    const md = await createMarkdownRenderer(srcDir)
+    const includes: string[] = []
+    const result = processIncludes(md, srcDir, src, filePath, includes, false)
+
+    // Full file include should strip frontmatter
+    expect(result).not.toContain(
+      'description: This page has frontmatter description'
+    )
+
+    // But should contain the main content
+    expect(result).toContain('# Source Page')
+    expect(result).toContain('Intro text before the target heading.')
+    expect(result).toContain('## Target Section')
+  })
+})

--- a/__tests__/unit/node/utils/processIncludes.test.ts
+++ b/__tests__/unit/node/utils/processIncludes.test.ts
@@ -23,15 +23,14 @@ describe('processIncludes', () => {
     expect(result).not.toContain(
       'description: This page has frontmatter description'
     )
-    expect(result).not.toContain('This page has frontmatter description')
+
+    // The result should NOT contain the heading itself (start is after heading)
+    expect(result).not.toContain('## Target Section')
 
     // The result should NOT contain content from other sections
     expect(result).not.toContain('Intro text before the target heading.')
     expect(result).not.toContain('This line should NOT be included.')
     expect(result).not.toContain('## Other Section')
-
-    // The result should NOT contain the frontmatter description as content
-    expect(result).not.toMatch(/This page has frontmatter description/)
   })
 
   it('should handle heading includes without frontmatter', async () => {

--- a/src/node/utils/processIncludes.ts
+++ b/src/node/utils/processIncludes.ts
@@ -47,9 +47,18 @@ export function processIncludes(
         // region not found, it might be a header
         // Strip frontmatter before parsing to get correct line numbers
         const { content: contentWithoutFrontmatter } = matter(content)
-        const frontmatterLines =
-          content.split('\n').length -
-          contentWithoutFrontmatter.split('\n').length
+
+        // Calculate frontmatter offset by detecting the closing --- line
+        let frontmatterLines = 0
+        if (content.startsWith('---')) {
+          const lines = content.split('\n')
+          for (let i = 1; i < lines.length; i++) {
+            if (lines[i].trim() === '---') {
+              frontmatterLines = i + 1
+              break
+            }
+          }
+        }
 
         const tokens = md
           .parse(contentWithoutFrontmatter, {
@@ -64,17 +73,13 @@ export function processIncludes(
         const token = tokens[idx]
         if (token) {
           // Adjust line numbers to account for stripped frontmatter
-          start = token.map![0] + frontmatterLines
+          start = token.map![1] + frontmatterLines
           const level = parseInt(token.tag.slice(1))
           for (let i = idx + 1; i < tokens.length; i++) {
             if (parseInt(tokens[i].tag.slice(1)) <= level) {
               end = tokens[i].map![0] + frontmatterLines
               break
             }
-          }
-          // If no end found, include rest of content
-          if (end === undefined) {
-            end = lines.length
           }
         }
       }

--- a/src/node/utils/processIncludes.ts
+++ b/src/node/utils/processIncludes.ts
@@ -45,8 +45,14 @@ export function processIncludes(
 
       if (start === undefined) {
         // region not found, it might be a header
+        // Strip frontmatter before parsing to get correct line numbers
+        const { content: contentWithoutFrontmatter } = matter(content)
+        const frontmatterLines =
+          content.split('\n').length -
+          contentWithoutFrontmatter.split('\n').length
+
         const tokens = md
-          .parse(content, {
+          .parse(contentWithoutFrontmatter, {
             path: includePath,
             relativePath: slash(path.relative(srcDir, includePath)),
             cleanUrls
@@ -57,13 +63,18 @@ export function processIncludes(
         )
         const token = tokens[idx]
         if (token) {
-          start = token.map![1]
+          // Adjust line numbers to account for stripped frontmatter
+          start = token.map![0] + frontmatterLines
           const level = parseInt(token.tag.slice(1))
           for (let i = idx + 1; i < tokens.length; i++) {
             if (parseInt(tokens[i].tag.slice(1)) <= level) {
-              end = tokens[i].map![0]
+              end = tokens[i].map![0] + frontmatterLines
               break
             }
+          }
+          // If no end found, include rest of content
+          if (end === undefined) {
+            end = lines.length
           }
         }
       }


### PR DESCRIPTION
### Description

When using `<!--@include: ...#heading-->` to include a section from a Markdown file with frontmatter, the included content was incorrect because line numbers were misaligned.

The `frontmatterPlugin` strips frontmatter before parsing, so token line numbers are based on content without frontmatter. But the slice operation used those numbers on the original content (with frontmatter), causing an offset.

Fix by explicitly stripping frontmatter before parsing and adjusting line numbers accordingly.

### Linked Issues

fixes #5202

### Additional Context

- Add a regression test for `<!--@include: ...#heading-->` with source frontmatter
- Adjust include processing so heading ranges are resolved correctly when frontmatter is present
- Run `pnpm run test:unit` and `pnpm run format:fail` to verify