### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -37,6 +37,10 @@ $ yarn add -D vitepress@next vue
 $ bun add -D vitepress@next
 ```
 
+```sh [deno]
+$ deno add -D vitepress@next
+```
+
 :::
 
 ::: tip NOTE


### PR DESCRIPTION
### Description

👋 Bartek from the Deno team here.

The install instructions list npm, pnpm, yarn, and bun, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno add -D vitepress@next
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install vitepress`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

### Linked Issues

_None._

### Additional Context

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
