### PR TITLE
docs: add guide for CJK emphasis compatibility in markdown

### DIFF
--- a/docs/en/guide/markdown.md
+++ b/docs/en/guide/markdown.md
@@ -1036,4 +1036,23 @@ export default defineConfig({
 })
 ```
 
+### CJK Emphasis Compatibility
+
+CommonMark's default emphasis (bold/italic) delimiter flanking rules are optimized for space-delimited languages. In CJK (Chinese, Japanese, Korean) layouts where spaces are not typically used, formatting like `**「bold」**` or `**（bold）**` (with adjacent CJK punctuation) may fail to render correctly.
+
+To resolve this, use CJK-friendly plugins such as [`markdown-it-cjk-friendly`](https://github.com/tats-u/markdown-cjk-friendly):
+
+```js
+// .vitepress/config.js
+import markdownItCjkFriendly from 'markdown-it-cjk-friendly'
+
+export default {
+  markdown: {
+    config: (md) => {
+      md.use(markdownItCjkFriendly)
+    }
+  }
+}
+```
+
 See full list of configurable properties in [Config Reference: App Config](../reference/site-config#markdown).

--- a/docs/ja/guide/markdown.md
+++ b/docs/ja/guide/markdown.md
@@ -1036,6 +1036,24 @@ export default defineConfig({
     }
   }
 })
+
+### CJK 強調構文の互換性 (太字/斜体)
+
+CommonMark 仕様における強調 (太字/斜体) のデリミタ判定規則は、スペースで区切られる英語などの言語向けに最適化されています。スペースを使用しない日本語、中国語、韓国語 (CJK) などのレイアウトでは、太字や斜体が CJK の句読点（例えば `**「太字」**` や `**（太字）**`）と隣接している場合、デフォルトでは正しくレンダリングされず、記号のまま表示されます。
+
+この問題を解決するには、[`markdown-it-cjk-friendly`](https://github.com/tats-u/markdown-cjk-friendly) などの CJK フレンドリーなプラグインを使用します:
+
+```js
+// .vitepress/config.js
+import markdownItCjkFriendly from 'markdown-it-cjk-friendly'
+
+export default {
+  markdown: {
+    config: (md) => {
+      md.use(markdownItCjkFriendly)
+    }
+  }
+}
 ```
 
 設定可能なプロパティの完全な一覧は、[設定リファレンス: アプリ設定](../reference/site-config#markdown) を参照してください。

--- a/docs/ko/guide/markdown.md
+++ b/docs/ko/guide/markdown.md
@@ -967,4 +967,23 @@ export default defineConfig({
 })
 ```
 
+### CJK 강조 구문 호환성 (굵게/기울임)
+
+CommonMark 사양에서 강조 (굵게/기울임) 구분자 판정 규칙은 공백으로 구분되는 영어 등의 언어에 최적화되어 있습니다. 공백을 사용하지 않는 한국어, 중국어, 일본어 (CJK) 레이아웃에서는 CJK 문장 부호(예: `**「굵게」**` 또는 `**（굵게）**`)와 인접한 경우, 기본적으로 올바르게 렌더링되지 않고 기호 그대로 표시됩니다.
+
+이 문제를 해결하려면 [`markdown-it-cjk-friendly`](https://github.com/tats-u/markdown-cjk-friendly) 와 같은 CJK 친화적인 플러그인을 사용할 수 있습니다:
+
+```js
+// .vitepress/config.js
+import markdownItCjkFriendly from 'markdown-it-cjk-friendly'
+
+export default {
+  markdown: {
+    config: (md) => {
+      md.use(markdownItCjkFriendly)
+    }
+  }
+}
+```
+
 구성 가능한 프로퍼티의 전체 목록은 [레퍼런스: 앱 구성](../reference/site-config#markdown)에서 확인하세요.

--- a/docs/zh/guide/markdown.md
+++ b/docs/zh/guide/markdown.md
@@ -928,4 +928,23 @@ export default defineConfig({
 })
 ```
 
+### CJK 强调语法兼容性 (粗体/斜体)
+
+CommonMark 规范中关于强调 (粗体/斜体) 定界符的判定规则，主要是为英文等以空格分隔单词的语言所设计。在中日韩 (CJK) 等不使用空格分隔的排版中，当粗体或斜体紧邻 CJK 标点符号时（例如 `**「粗体」**` 或 `**（粗体）**`），默认会解析失败并直接显示原始符号。
+
+若要解决此问题，可以使用 CJK 友好的 markdown-it 插件，例如 [`markdown-it-cjk-friendly`](https://github.com/tats-u/markdown-cjk-friendly)：
+
+```js
+// .vitepress/config.js
+import markdownItCjkFriendly from 'markdown-it-cjk-friendly'
+
+export default {
+  markdown: {
+    config: (md) => {
+      md.use(markdownItCjkFriendly)
+    }
+  }
+}
+```
+
 请查看[配置参考：站点配置](../reference/site-config#markdown)来获取完整的可配置属性列表。


### PR DESCRIPTION
### Description

This PR adds a guide section under "Advanced Configuration" to explain CJK (Chinese, Japanese, Korean) emphasis compatibility issues and how to resolve them.

In CJK layouts where spaces are not typically used, bold or italic delimiters adjacent to CJK punctuation (e.g., `**「bold」**` or `**（bold）**`) fail to render as `<strong>` or `<em>` by default due to CommonMark's flanking delimiter rules. This section provides CJK developers a clear guide on how to register CJK-friendly plugins like `markdown-it-cjk-friendly`.

### Linked Issues

None. (Direct documentation improvement)

### Additional Context

Since this issue frequently affects CJK developers writing technical docs in VitePress without space padding, documenting this edge case in "Advanced Configuration" will help them find the solution easily without opening duplicate issues. 

The translations for English, Chinese (Simplified), Japanese, and Korean documents have been fully prepared and aligned with the original file style.