### PR TITLE
fix(theme): keep external link icon inline

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -560,26 +560,30 @@
 
 /* prettier-ignore */
 :is(.vp-external-link-icon, .vp-doc a[href*='://'], .vp-doc a[target='_blank']):not(:is(.no-icon, svg a, :has(img, svg)))::after {
-  display: inline-block;
-  margin-top: -1px;
+  display: inline;
   margin-left: 4px;
-  width: 11px;
-  height: 11px;
+  padding-left: 11px;
   background: currentColor;
   color: var(--vp-c-text-3);
   flex-shrink: 0;
   --icon: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' %3E%3Cpath d='M0 0h24v24H0V0z' fill='none' /%3E%3Cpath d='M9 5v2h6.59L4 18.59 5.41 20 17 8.41V15h2V5H9z' /%3E%3C/svg%3E");
   -webkit-mask-image: var(--icon);
   mask-image: var(--icon);
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: 11px 11px;
+  mask-size: 11px 11px;
   /*rtl:raw:transform: scaleX(-1);*/
 }
 
 .vp-external-link-icon::after {
-  content: '';
+  content: '\2060';
 }
 
 /* prettier-ignore */
 .external-link-icon-enabled :is(.vp-doc a[href*='://'], .vp-doc a[target='_blank']):not(:is(.no-icon, svg a, :has(img, svg)))::after {
-  content: '';
+  content: '\2060';
   color: currentColor;
 }


### PR DESCRIPTION
## Summary
- Keeps the external-link icon attached to the final inline text fragment so it no longer wraps onto its own line in narrow markdown content.
- Uses a zero-width word joiner inside the icon pseudo-element with explicit mask sizing, preserving normal wrapping earlier in multi-word links.

Fixes #3061

## Testing
- `pnpm format:fail`
- `pnpm build`
- `pnpm test:unit`
- `pnpm docs:build`
- `pnpm check`
- Live docs browser check with a narrow `.external-link-icon-enabled .vp-doc` fixture