### PR TITLE
docs: clarify page headers config

### DIFF
--- a/docs/en/reference/runtime-api.md
+++ b/docs/en/reference/runtime-api.md
@@ -62,6 +62,8 @@ interface PageData {
 }
 ```
 
+`page.headers` is populated only when [`markdown.headers`](./site-config#markdown) is enabled. Without that option, it remains an empty array. The default theme outline reads rendered headings from the page content, so it can still appear when `page.headers` is empty.
+
 **Example:**
 
 ```vue

--- a/docs/en/reference/site-config.md
+++ b/docs/en/reference/site-config.md
@@ -561,6 +561,8 @@ export default {
 
 Check the [type declaration and jsdocs](https://github.com/vuejs/vitepress/blob/main/src/node/markdown/markdown.ts) for all the options available.
 
+Set `markdown.headers` to `true` or pass [`@mdit-vue/plugin-headers`](https://github.com/mdit-vue/mdit-vue/tree/main/packages/plugin-headers) options to collect headings into [`useData().page.headers`](./runtime-api#usedata). This option is disabled by default.
+
 ### vite
 
 - Type: `import('vite').UserConfig`


### PR DESCRIPTION
## Summary
- Documents that `useData().page.headers` is populated only when `markdown.headers` is enabled.
- Adds the matching `markdown.headers` pointer in the site config reference.

Fixes #3208

## Testing
- `pnpm format:fail`
- `pnpm docs:build`
- `pnpm check`