### PR TITLE
docs: cache VitePress in Pages workflow

### DIFF
--- a/docs/en/guide/deploy.md
+++ b/docs/en/guide/deploy.md
@@ -166,6 +166,13 @@ Don't enable options like _Auto Minify_ for HTML code. It will remove comments f
            with:
              node-version: 24
              cache: npm # or pnpm / yarn
+         - name: Cache VitePress
+           uses: actions/cache@v4
+           with:
+             path: docs/.vitepress/cache
+             key: ${{ runner.os }}-vitepress-${{ hashFiles('docs/**', 'package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'bun.lockb') }}
+             restore-keys: |
+               ${{ runner.os }}-vitepress-
          - name: Setup Pages
            uses: actions/configure-pages@v4
          - name: Install dependencies


### PR DESCRIPTION
## Summary
- Adds an `actions/cache` step for `docs/.vitepress/cache` in the GitHub Pages workflow example.
- Keys the cache from docs files and common lockfiles, with an OS-level restore prefix for reuse across content updates.

Fixes #4372

## Testing
- Workflow YAML block parses with Ruby YAML
- `pnpm format:fail`
- `pnpm docs:build`
- `pnpm check`