### PR TITLE
fix: prevent DocSearch SVG clipping in WebKit

### DIFF
--- a/src/client/theme-default/styles/docsearch.css
+++ b/src/client/theme-default/styles/docsearch.css
@@ -41,6 +41,10 @@
   --docsearch-modal-shadow: none;
 }
 
+:is(.DocSearch-Container, .DocSearch-Sidepanel) svg {
+  overflow: visible;
+}
+
 .DocSearch-AskAiScreen-RelatedSources-Item-Link {
   padding: 8px 12px 8px 10px;
 }


### PR DESCRIPTION
### Description

Set DocSearch modal and sidepanel inline SVGs to render with visible overflow.
This fixes WebKit clipping on DocSearch icons and the Algolia logo without changing VitePress local-search mask icons.

### Linked Issues

Closes #5225

### Additional Context

Validation:
- `rm -rf dist && pnpm check`
- `pnpm docs:build && pnpm docs:lunaria:build`