### PR TITLE
feat: support social link target option

### DIFF
--- a/__tests__/e2e/.vitepress/config.ts
+++ b/__tests__/e2e/.vitepress/config.ts
@@ -162,6 +162,14 @@ export default defineConfig({
   themeConfig: {
     nav,
     sidebar,
+    socialLinks: [
+      {
+        icon: 'github',
+        link: '/home',
+        ariaLabel: 'Home social link',
+        target: '_self'
+      }
+    ],
     search: {
       provider: 'local',
       options: {

--- a/__tests__/e2e/home.test.ts
+++ b/__tests__/e2e/home.test.ts
@@ -32,4 +32,13 @@ describe('render correct content', async () => {
     const outlineLinksCount = await outlineLinksLocator.count()
     expect(outlineLinksCount).toEqual(4)
   })
+
+  test('social link target override', async () => {
+    const socialLink = page.locator(
+      '.VPNavBarSocialLinks a[aria-label="Home social link"]'
+    )
+
+    expect(await socialLink.getAttribute('href')).toBe('/home')
+    expect(await socialLink.getAttribute('target')).toBe('_self')
+  })
 })

--- a/docs/en/reference/default-theme-config.md
+++ b/docs/en/reference/default-theme-config.md
@@ -253,6 +253,7 @@ export default {
       // You can add any icon from simple-icons (https://simpleicons.org/):
       { icon: 'github', link: 'https://github.com/vuejs/vitepress' },
       { icon: 'twitter', link: '...' },
+      { icon: 'discord', link: '/community', target: '_self' },
       // You can also add custom icons by passing SVG as string:
       {
         icon: {
@@ -272,6 +273,7 @@ interface SocialLink {
   icon: string | { svg: string }
   link: string
   ariaLabel?: string
+  target?: string
 }
 ```
 

--- a/src/client/theme-default/components/VPSocialLink.vue
+++ b/src/client/theme-default/components/VPSocialLink.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   icon: DefaultTheme.SocialLinkIcon
   link: string
   ariaLabel?: string
+  target?: string
   me: boolean
 }>()
 
@@ -45,7 +46,7 @@ if (import.meta.env.SSR) {
     class="VPSocialLink no-icon"
     :href="link"
     :aria-label="ariaLabel ?? (typeof icon === 'string' ? icon : '')"
-    target="_blank"
+    :target="target ?? '_blank'"
     :rel="me ? 'me noopener' : 'noopener'"
     v-html="svg"
   ></a>

--- a/src/client/theme-default/components/VPSocialLinks.vue
+++ b/src/client/theme-default/components/VPSocialLinks.vue
@@ -13,11 +13,12 @@ withDefaults(defineProps<{
 <template>
   <div class="VPSocialLinks">
     <VPSocialLink
-      v-for="{ link, icon, ariaLabel } in links"
+      v-for="{ link, icon, ariaLabel, target } in links"
       :key="link"
       :icon
       :link
       :ariaLabel
+      :target
       :me
     />
   </div>

--- a/types/default-theme.d.ts
+++ b/types/default-theme.d.ts
@@ -318,6 +318,7 @@ export namespace DefaultTheme {
     icon: SocialLinkIcon
     link: string
     ariaLabel?: string
+    target?: string
   }
 
   export type SocialLinkIcon = string | { svg: string }


### PR DESCRIPTION
### Description

Adds `target` to default-theme social links and passes it through to the rendered social anchor. Existing social links still default to `_blank`.

The e2e fixture covers an internal navbar social link that opts into `_self`, and the docs show the new option in `SocialLink`.

### Linked Issues

Closes #5214

### Additional Context

Validation:
- `pnpm -F=tests-e2e test home.test.ts`
- `pnpm check`
- `pnpm docs:build`
- `pnpm docs:lunaria:build`