### PR TITLE
fix: preserve external sidebar links with base

### DIFF
--- a/__tests__/unit/client/theme-default/support/sidebar.test.ts
+++ b/__tests__/unit/client/theme-default/support/sidebar.test.ts
@@ -103,6 +103,38 @@ describe('client/theme-default/support/sidebar', () => {
         )
       })
     })
+
+    test('applies base only to internal links', () => {
+      expect(
+        getSidebar(
+          {
+            '/en/': {
+              base: '/en/',
+              items: [
+                {
+                  text: 'Guide',
+                  items: [
+                    { text: 'Intro', link: 'intro' },
+                    { text: 'Root', link: '/root' },
+                    { text: 'External', link: 'https://example.com/' }
+                  ]
+                }
+              ]
+            }
+          },
+          '/en/intro'
+        )
+      ).toStrictEqual([
+        {
+          text: 'Guide',
+          items: [
+            { text: 'Intro', link: '/en/intro' },
+            { text: 'Root', link: '/en/root' },
+            { text: 'External', link: 'https://example.com/' }
+          ]
+        }
+      ])
+    })
   })
 
   describe('hasActiveLink', () => {

--- a/src/client/theme-default/support/sidebar.ts
+++ b/src/client/theme-default/support/sidebar.ts
@@ -1,5 +1,5 @@
 import type { DefaultTheme } from 'vitepress/theme'
-import { isActive } from '../../shared'
+import { isActive, isExternal } from '../../shared'
 import { ensureStartingSlash } from './utils'
 
 export interface SidebarLink {
@@ -112,7 +112,7 @@ function addBase(items: SidebarItem[], _base?: string): SidebarItem[] {
   return [...items].map((_item) => {
     const item = { ..._item }
     const base = item.base || _base
-    if (base && item.link)
+    if (base && item.link && !isExternal(item.link))
       item.link = base + item.link.replace(/^\//, base.endsWith('/') ? '' : '/')
     if (item.items) item.items = addBase(item.items, base)
     return item


### PR DESCRIPTION
### Description

Sidebar `base` handling now skips external links while resolving nested sidebar items. Internal links still receive the configured base, and URLs such as `https://...` keep their original href.

Added unit coverage for object-form sidebar configs that mix relative, root-relative, and external links under the same `base`.

### Linked Issues

Closes #4365

### Additional Context

Validation:
- `pnpm vitest run -r __tests__/unit __tests__/unit/client/theme-default/support/sidebar.test.ts`
- `pnpm check`
- `pnpm docs:build`
- `pnpm docs:lunaria:build`