### PR TITLE
test: wait for filtered local search results

### DIFF
--- a/__tests__/e2e/local-search/local-search.test.ts
+++ b/__tests__/e2e/local-search/local-search.test.ts
@@ -9,9 +9,18 @@ describe('local search', () => {
     const input = await page.waitForSelector('input#localsearch-input')
     await input.type('local')
 
-    await page.waitForSelector('ul#localsearch-list', { state: 'visible' })
-
     const searchResults = page.locator('#localsearch-list')
+    await page.waitForFunction(() => {
+      const options = [
+        ...document.querySelectorAll('#localsearch-list li[role=option]')
+      ]
+
+      return (
+        options.length === 1 &&
+        options[0].textContent?.includes('Local search included')
+      )
+    })
+
     expect(await searchResults.locator('li[role=option]').count()).toBe(1)
 
     expect(


### PR DESCRIPTION
## Summary

- Wait for the filtered local-search option before asserting the result count.
- Avoid reading the initially visible full result list while the typed query is still settling.

## Context

A Windows e2e run on #5243 failed with `expected 16 to be 1` in this test; this keeps the assertion tied to the final filtered result.

## Tests

- `pnpm -F=tests-e2e test local-search/local-search.test.ts`
- `VITE_TEST_BUILD=1 pnpm -F=tests-e2e test local-search/local-search.test.ts`
- `pnpm check`