### PR TITLE
fix(build): normalize rewrite drive letters

### DIFF
--- a/__tests__/unit/node/markdownToVue.test.ts
+++ b/__tests__/unit/node/markdownToVue.test.ts
@@ -66,4 +66,37 @@ describe('node/markdownToVue', () => {
       line: 8
     })
   })
+
+  test('applies rewrites with mismatched Windows drive letter case', async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'vitepress-rewrite-'))
+
+    const file = path.join(root, 'index.md')
+    await writeFile(file, '# Home\n')
+
+    const siteConfig = await resolveConfig(root, 'build', 'production')
+    siteConfig.srcDir = 'c:/site/docs'
+    siteConfig.pages = ['en/index.md']
+    siteConfig.rewrites = {
+      map: { 'en/index.md': 'index.md' },
+      inv: { 'index.md': 'en/index.md' }
+    }
+    ;(siteConfig as any).__dirty = true
+
+    const render = await createMarkdownToVueRenderFn(
+      siteConfig.srcDir,
+      { cache: false },
+      '/',
+      false,
+      false,
+      siteConfig
+    )
+
+    const result = await render(
+      '# Home\n',
+      'C:/site/docs/en/index.md',
+      'public'
+    )
+
+    expect(result.pageData.relativePath).toBe('index.md')
+  })
 })

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -47,6 +47,10 @@ let __dynamicRoutes = new Map<string, [string, string]>()
 let __rewrites = new Map<string, string>()
 let __ts: number
 
+function normalizeDriveLetter(file: string) {
+  return file.replace(/^[a-z]:/i, (drive) => drive.toLowerCase())
+}
+
 function getResolutionCache(siteConfig: SiteConfig) {
   // @ts-expect-error internal
   if (siteConfig.__dirty) {
@@ -61,8 +65,8 @@ function getResolutionCache(siteConfig: SiteConfig) {
 
     __rewrites = new Map(
       Object.entries(siteConfig.rewrites.map).map(([key, value]) => [
-        slash(path.join(siteConfig.srcDir, key)),
-        slash(path.join(siteConfig.srcDir, value!))
+        normalizeDriveLetter(slash(path.join(siteConfig.srcDir, key))),
+        normalizeDriveLetter(slash(path.join(siteConfig.srcDir, value!)))
       ])
     )
 
@@ -110,7 +114,7 @@ export async function createMarkdownToVueRenderFn(
       getPageDataTransformer(dynamicRoute?.[1]!)
     ].filter((fn) => fn != null)
 
-    file = rewrites.get(file) || file
+    file = rewrites.get(normalizeDriveLetter(file)) || file
     const relativePath = slash(path.relative(srcDir, file))
 
     const cacheKey = JSON.stringify({ src, ts, relativePath })


### PR DESCRIPTION
## Summary

- Normalize only the Windows drive-letter prefix for rewrite map keys and lookups.
- Keep rewritten paths stable when Vite reports an uppercase drive from a lowercase cwd.
- Add a renderer unit test for the mismatched-drive case.

## Related issue

Closes #4984

## Tests

- `pnpm exec vitest run -r __tests__/unit node/markdownToVue.test.ts -t 'applies rewrites with mismatched Windows drive letter case'`
- `pnpm exec vitest run -r __tests__/unit node/markdownToVue.test.ts`
- `pnpm check`