### PR TITLE
docs: clarify Ask AI suggested questions

### DIFF
--- a/docs/en/reference/default-theme-search.md
+++ b/docs/en/reference/default-theme-search.md
@@ -291,6 +291,12 @@ export default defineConfig({
 })
 ```
 
+Use `askAi.sidePanel.panel.suggestedQuestions` for side panel suggested
+questions. Algolia's standalone Ask AI examples also mention
+`askAi.suggestedQuestions`, but that top-level option is not enough for
+VitePress side panel mode and does not make the integrated keyword-search
+modal display suggested questions on first open.
+
 If you need to disable the keyboard shortcut, use the `keyboardShortcuts` option at the sidepanel root level:
 
 ```ts


### PR DESCRIPTION
### Description

Clarifies where to place `suggestedQuestions` when using the Ask AI side panel. The side panel example already uses `askAi.sidePanel.panel.suggestedQuestions`, so this adds a note that top-level `askAi.suggestedQuestions` from Algolia's standalone examples is not enough for VitePress side panel mode or the integrated keyword-search modal's first-open state.

### Linked Issues

fixes #5223

### Additional Context

Checks:
- `pnpm exec prettier --check docs/en/reference/default-theme-search.md`
- `pnpm run docs:build`
