### PR TITLE
fix: keep doc footer links side by side

### DIFF
--- a/__tests__/e2e/markdown-extensions/markdown-extensions.test.ts
+++ b/__tests__/e2e/markdown-extensions/markdown-extensions.test.ts
@@ -122,6 +122,36 @@ describe('Table of Contents', () => {
   })
 })
 
+describe('Doc Footer', () => {
+  test('render prev and next links side by side on narrow screens', async () => {
+    await page.setViewportSize({ width: 390, height: 800 })
+    await goto('/markdown-extensions/')
+
+    const nav = page.locator('.VPDocFooter .prev-next')
+    await nav.scrollIntoViewIfNeeded()
+
+    const boxes = await nav.evaluate((element) => {
+      const prev = element
+        .querySelector('.pager-link.prev')
+        ?.getBoundingClientRect()
+      const next = element
+        .querySelector('.pager-link.next')
+        ?.getBoundingClientRect()
+
+      return prev && next
+        ? {
+            prev: { x: prev.x, y: prev.y, width: prev.width },
+            next: { x: next.x, y: next.y }
+          }
+        : null
+    })
+
+    expect(boxes).toBeTruthy()
+    expect(Math.abs(boxes!.prev.y - boxes!.next.y)).toBeLessThan(2)
+    expect(boxes!.next.x).toBeGreaterThan(boxes!.prev.x + boxes!.prev.width)
+  })
+})
+
 describe('Custom Containers', () => {
   enum CustomBlocks {
     Info = 'INFO',

--- a/src/client/theme-default/components/VPDocFooter.vue
+++ b/src/client/theme-default/components/VPDocFooter.vue
@@ -119,14 +119,9 @@ const showFooter = computed(
   border-top: 1px solid var(--vp-c-divider);
   padding-top: 24px;
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-row-gap: 8px;
-}
-
-@media (min-width: 640px) {
-  .prev-next {
-    grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: 16px;
-  }
+  grid-column-gap: 16px;
 }
 
 .pager-link {


### PR DESCRIPTION
### Description

Keeps the default-theme doc footer pager in its two-column layout on narrow screens instead of stacking the previous and next links. The grid uses `minmax(0, 1fr)` so link titles wrap inside each column.

### Linked Issues

Fixes #5208.

### Additional Context

Validated on the e2e markdown extensions page at 390px width; previous and next links render on the same row with a 16px gap.

### Checks

- `pnpm -F=tests-e2e test markdown-extensions/markdown-extensions.test.ts`
- `pnpm check`
- `pnpm docs:build`
- `git diff --check`