### PR TITLE
fix: report duplicate markdown attrs with source line

### DIFF
--- a/__tests__/unit/node/markdownToVue.test.ts
+++ b/__tests__/unit/node/markdownToVue.test.ts
@@ -67,6 +67,28 @@ describe('node/markdownToVue', () => {
     })
   })
 
+  test('reports source line for duplicate markdown attributes', async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'vitepress-markdown-attrs-'))
+
+    const file = path.join(root, 'index.md')
+    const src = '# Home\n\n{% asset_img example.png "Some Picture" %}\n'
+    await writeFile(file, src)
+
+    const siteConfig = await resolveConfig(root, 'build', 'production')
+    const render = await createMarkdownToVueRenderFn(
+      siteConfig.srcDir,
+      { cache: false },
+      '/',
+      false,
+      false,
+      siteConfig
+    )
+
+    await expect(render(src, file, 'public')).rejects.toThrow(
+      `${file}:3: Duplicate attribute "%"`
+    )
+  })
+
   test('selects included heading sections after frontmatter', async () => {
     root = await mkdtemp(path.join(tmpdir(), 'vitepress-include-'))
 

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -37,6 +37,7 @@ import { linkPlugin } from './plugins/link'
 import { preWrapperPlugin } from './plugins/preWrapper'
 import { restoreEntities } from './plugins/restoreEntities'
 import { snippetPlugin } from './plugins/snippet'
+import { validateAttrsPlugin } from './plugins/validateAttrs'
 
 export type { Header } from '../shared'
 
@@ -308,6 +309,7 @@ export async function createMarkdownRenderer(
   // third party plugins
   if (!options.attrs?.disable) {
     attrsPlugin(md, options.attrs)
+    validateAttrsPlugin(md)
   }
   emojiPlugin(md, options.emoji)
 

--- a/src/node/markdown/plugins/validateAttrs.ts
+++ b/src/node/markdown/plugins/validateAttrs.ts
@@ -1,0 +1,47 @@
+import type { MarkdownItAsync } from 'markdown-it-async'
+import type StateCore from 'markdown-it/lib/rules_core/state_core.mjs'
+import type Token from 'markdown-it/lib/token.mjs'
+import type { MarkdownEnv } from '../../shared'
+
+export function validateAttrsPlugin(md: MarkdownItAsync): void {
+  md.core.ruler.after(
+    'curly_attributes',
+    'vitepress_validate_attrs',
+    (state) => {
+      for (const token of state.tokens) {
+        validateTokenAttrs(state, token)
+      }
+    }
+  )
+}
+
+function validateTokenAttrs(
+  state: StateCore,
+  token: Token,
+  locationToken = token
+): void {
+  if (token.attrs) {
+    const seen = new Set<string>()
+
+    for (const [name] of token.attrs) {
+      if (seen.has(name)) {
+        throw new Error(
+          `${formatLocation(state, locationToken)}: Duplicate attribute "${name}" from markdown-it-attrs. Check the attribute block or wrap it in code.`
+        )
+      }
+      seen.add(name)
+    }
+  }
+
+  for (const child of token.children || []) {
+    validateTokenAttrs(state, child, token)
+  }
+}
+
+function formatLocation(state: StateCore, token: Token): string {
+  const env = state.env as MarkdownEnv | undefined
+  const file = env?.realPath || env?.path || env?.relativePath || 'Markdown'
+  const line = token.map?.[0]
+
+  return line == null ? file : `${file}:${line + 1}`
+}


### PR DESCRIPTION
### Description

This adds a small validation pass after markdown-it-attrs so duplicate attributes fail during markdown rendering with the source file and line. It catches cases such as `{% asset_img ... %}` before the generated Vue SFC reaches the compiler.

### Linked Issues

fixes #3401

### Additional Context

`pnpm check`