### PR TITLE
fix: preserve Agent Studio DocSearch options

### DIFF
--- a/__tests__/unit/client/theme-default/support/docsearch.test.ts
+++ b/__tests__/unit/client/theme-default/support/docsearch.test.ts
@@ -1,5 +1,6 @@
 import {
   buildAskAiConfig,
+  buildSidePanelProps,
   hasAskAi,
   hasKeywordSearch,
   mergeLangFacetFilters,
@@ -191,6 +192,61 @@ describe('client/theme-default/support/docsearch', () => {
         'en'
       )
       expect(result.searchParameters?.facetFilters).toEqual(['lang:en'])
+    })
+  })
+
+  describe('buildSidePanelProps', () => {
+    test('passes resolved Ask AI options to the side panel', () => {
+      const result = buildSidePanelProps(
+        {
+          assistantId: 'assistant123',
+          agentStudio: true,
+          searchParameters: {
+            index: {
+              facetFilters: ['lang:en']
+            }
+          },
+          suggestedQuestions: true,
+          useStagingEnv: true,
+          sidePanel: {
+            button: {
+              variant: 'inline'
+            },
+            panel: {
+              width: 420,
+              suggestedQuestions: true
+            }
+          }
+        } as any,
+        {
+          appId: 'app',
+          apiKey: 'key',
+          indexName: 'index'
+        } as any
+      )
+
+      expect(result).toEqual({
+        container: '#vp-docsearch-sidepanel',
+        appId: 'app',
+        apiKey: 'key',
+        indexName: 'index',
+        assistantId: 'assistant123',
+        agentStudio: true,
+        searchParameters: {
+          index: {
+            facetFilters: ['lang:en']
+          }
+        },
+        suggestedQuestions: true,
+        useStagingEnv: true,
+        button: {
+          variant: 'inline'
+        },
+        panel: {
+          width: 420,
+          suggestedQuestions: true
+        }
+      })
     })
   })
 })

--- a/__tests__/unit/client/theme-default/support/docsearch.test.ts
+++ b/__tests__/unit/client/theme-default/support/docsearch.test.ts
@@ -193,6 +193,56 @@ describe('client/theme-default/support/docsearch', () => {
       )
       expect(result.searchParameters?.facetFilters).toEqual(['lang:en'])
     })
+
+    test('preserves Agent Studio search parameters by index', () => {
+      const result = buildAskAiConfig(
+        {
+          assistantId: 'assistant123',
+          agentStudio: true,
+          searchParameters: {
+            index: {
+              distinct: false
+            }
+          }
+        } as any,
+        {
+          appId: 'app',
+          apiKey: 'key',
+          indexName: 'index',
+          searchParameters: {
+            facetFilters: ['tag:docs']
+          }
+        } as any,
+        'en'
+      )
+
+      expect(result.searchParameters).toEqual({
+        index: {
+          distinct: false
+        }
+      })
+      expect(result.searchParameters).not.toHaveProperty('facetFilters')
+    })
+
+    test('does not add legacy facet filters to Agent Studio config', () => {
+      const result = buildAskAiConfig(
+        {
+          assistantId: 'assistant123',
+          agentStudio: true
+        } as any,
+        {
+          appId: 'app',
+          apiKey: 'key',
+          indexName: 'index',
+          searchParameters: {
+            facetFilters: ['tag:docs']
+          }
+        } as any,
+        'en'
+      )
+
+      expect(result.searchParameters).toBeUndefined()
+    })
   })
 
   describe('buildSidePanelProps', () => {

--- a/src/client/theme-default/components/VPAlgoliaSearchBox.vue
+++ b/src/client/theme-default/components/VPAlgoliaSearchBox.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import type { DocSearchInstance, DocSearchProps } from '@docsearch/js'
-import type { SidepanelInstance, SidepanelProps } from '@docsearch/sidepanel-js'
+import type { SidepanelInstance } from '@docsearch/sidepanel-js'
 import { inBrowser, useRouter } from 'vitepress'
 import type { DefaultTheme } from 'vitepress/theme'
 import { nextTick, onUnmounted, watch } from 'vue'
 import type { DocSearchAskAi } from '../../../../types/docsearch'
 import { useData } from '../composables/data'
-import { resolveMode, validateCredentials } from '../support/docsearch'
+import {
+  buildSidePanelProps,
+  resolveMode,
+  validateCredentials
+} from '../support/docsearch'
 
 import '../styles/docsearch.css'
 
@@ -105,12 +109,7 @@ async function initialize(userOptions: DefaultTheme.AlgoliaSearchOptions) {
     if (currentInitialize !== initializeCount) return
 
     sidepanelInstance = sidepanel({
-      ...(askAi.sidePanel === true ? {} : askAi.sidePanel),
-      container: '#vp-docsearch-sidepanel',
-      indexName: askAi.indexName ?? userOptions.indexName,
-      appId: askAi.appId ?? userOptions.appId,
-      apiKey: askAi.apiKey ?? userOptions.apiKey,
-      assistantId: askAi.assistantId,
+      ...buildSidePanelProps(askAi, userOptions),
       onOpen: focusInput,
       onClose: onClose.bind(null, 'sidepanel'),
       onReady: () => {
@@ -122,7 +121,7 @@ async function initialize(userOptions: DefaultTheme.AlgoliaSearchOptions) {
       keyboardShortcuts: {
         'Ctrl/Cmd+I': false
       }
-    } as SidepanelProps)
+    })
   }
 
   const options = {

--- a/src/client/theme-default/support/docsearch.ts
+++ b/src/client/theme-default/support/docsearch.ts
@@ -20,6 +20,7 @@ export interface ResolvedMode {
   useSidePanel: boolean
 }
 
+// FIXME: remove when https://github.com/algolia/docsearch/pull/2906 is released
 export type ResolvedSidePanelProps = SidepanelProps & {
   agentStudio?: boolean
   searchParameters?: DocSearchAskAi['searchParameters']
@@ -219,35 +220,16 @@ export function buildSidePanelProps(
   askAi: DocSearchAskAi,
   options: DefaultTheme.AlgoliaSearchOptions
 ): ResolvedSidePanelProps {
-  const sidePanelOptions =
-    askAi.sidePanel && askAi.sidePanel !== true ? askAi.sidePanel : {}
+  const { sidePanel, ...askAiRest } = askAi
 
-  const result: ResolvedSidePanelProps = {
-    ...sidePanelOptions,
+  return {
     container: '#vp-docsearch-sidepanel',
-    indexName: (askAi.indexName ?? options.indexName)!,
-    appId: (askAi.appId ?? options.appId)!,
-    apiKey: (askAi.apiKey ?? options.apiKey)!,
-    assistantId: askAi.assistantId!
-  }
-
-  if (askAi.agentStudio !== undefined) {
-    result.agentStudio = askAi.agentStudio
-  }
-
-  if (askAi.searchParameters !== undefined) {
-    result.searchParameters = askAi.searchParameters
-  }
-
-  if (askAi.suggestedQuestions !== undefined) {
-    result.suggestedQuestions = askAi.suggestedQuestions
-  }
-
-  if (askAi.useStagingEnv !== undefined) {
-    result.useStagingEnv = askAi.useStagingEnv
-  }
-
-  return result
+    indexName: options.indexName,
+    appId: options.appId,
+    apiKey: options.apiKey,
+    ...askAiRest,
+    ...(sidePanel && sidePanel !== true ? sidePanel : {})
+  } as ResolvedSidePanelProps
 }
 
 /**

--- a/src/client/theme-default/support/docsearch.ts
+++ b/src/client/theme-default/support/docsearch.ts
@@ -176,10 +176,8 @@ export function buildAskAiConfig(
     !isAskAiString && askAiProp.searchParameters
       ? { ...askAiProp.searchParameters }
       : undefined
+  const isAgentStudio = !isAskAiString && askAiProp.agentStudio === true
 
-  // If Ask AI defines its own facetFilters, merge lang filtering into those.
-  // Otherwise, reuse the keyword search facetFilters so Ask AI follows the
-  // same language filtering behavior by default.
   const askAiFacetFiltersSource =
     askAiSearchParameters?.facetFilters ??
     options.searchParameters?.facetFilters
@@ -188,10 +186,12 @@ export function buildAskAiConfig(
     lang
   )
 
-  const mergedAskAiSearchParameters = {
-    ...askAiSearchParameters,
-    facetFilters: askAiFacetFilters.length ? askAiFacetFilters : undefined
-  }
+  const mergedAskAiSearchParameters = isAgentStudio
+    ? askAiSearchParameters
+    : {
+        ...askAiSearchParameters,
+        facetFilters: askAiFacetFilters.length ? askAiFacetFilters : undefined
+      }
 
   const result: Record<string, any> = {
     ...(isAskAiString ? {} : askAiProp),
@@ -202,7 +202,10 @@ export function buildAskAiConfig(
   }
 
   // Keep `searchParameters` undefined unless it has at least one key.
-  if (Object.values(mergedAskAiSearchParameters).some((v) => v != null)) {
+  if (
+    mergedAskAiSearchParameters &&
+    Object.values(mergedAskAiSearchParameters).some((v) => v != null)
+  ) {
     result.searchParameters = mergedAskAiSearchParameters
   }
 

--- a/src/client/theme-default/support/docsearch.ts
+++ b/src/client/theme-default/support/docsearch.ts
@@ -1,3 +1,4 @@
+import type { SidepanelProps } from '@docsearch/sidepanel-js'
 import type { DefaultTheme } from 'vitepress/theme'
 import type { DocSearchAskAi } from '../../../../types/docsearch'
 import { isObject } from '../../shared'
@@ -17,6 +18,13 @@ export interface ResolvedMode {
   mode: DocSearchMode
   showKeywordSearch: boolean
   useSidePanel: boolean
+}
+
+export type ResolvedSidePanelProps = SidepanelProps & {
+  agentStudio?: boolean
+  searchParameters?: DocSearchAskAi['searchParameters']
+  suggestedQuestions?: boolean
+  useStagingEnv?: boolean
 }
 
 /**
@@ -196,6 +204,44 @@ export function buildAskAiConfig(
   // Keep `searchParameters` undefined unless it has at least one key.
   if (Object.values(mergedAskAiSearchParameters).some((v) => v != null)) {
     result.searchParameters = mergedAskAiSearchParameters
+  }
+
+  return result
+}
+
+/**
+ * Builds the DocSearch side panel config from the resolved Ask AI options.
+ */
+export function buildSidePanelProps(
+  askAi: DocSearchAskAi,
+  options: DefaultTheme.AlgoliaSearchOptions
+): ResolvedSidePanelProps {
+  const sidePanelOptions =
+    askAi.sidePanel && askAi.sidePanel !== true ? askAi.sidePanel : {}
+
+  const result: ResolvedSidePanelProps = {
+    ...sidePanelOptions,
+    container: '#vp-docsearch-sidepanel',
+    indexName: (askAi.indexName ?? options.indexName)!,
+    appId: (askAi.appId ?? options.appId)!,
+    apiKey: (askAi.apiKey ?? options.apiKey)!,
+    assistantId: askAi.assistantId!
+  }
+
+  if (askAi.agentStudio !== undefined) {
+    result.agentStudio = askAi.agentStudio
+  }
+
+  if (askAi.searchParameters !== undefined) {
+    result.searchParameters = askAi.searchParameters
+  }
+
+  if (askAi.suggestedQuestions !== undefined) {
+    result.suggestedQuestions = askAi.suggestedQuestions
+  }
+
+  if (askAi.useStagingEnv !== undefined) {
+    result.useStagingEnv = askAi.useStagingEnv
   }
 
   return result


### PR DESCRIPTION
### Description

Preserves Agent Studio Ask AI options through VitePress' DocSearch setup.

- passes `agentStudio`, `searchParameters`, `suggestedQuestions`, and `useStagingEnv` into side panel and hybrid modes
- keeps Agent Studio `searchParameters` keyed by index instead of adding legacy top-level `facetFilters`

### Linked Issues

Refs #5168
Refs #5177

### Additional Context

Local checks:
- `pnpm test:unit -- __tests__/unit/client/theme-default/support/docsearch.test.ts`
- `pnpm check`
