### PR TITLE
docs(search): correct Chinese grammar in search interface

### DIFF
--- a/docs/zh/config.ts
+++ b/docs/zh/config.ts
@@ -209,7 +209,7 @@ function searchOptions(): Partial<DefaultTheme.AlgoliaSearchOptions> {
           closeText: '关闭',
           backToSearchText: '返回搜索',
           closeKeyAriaLabel: 'Esc 键',
-          poweredByText: '由…提供支持'
+          poweredByText: '搜索提供'
         },
         errorScreen: {
           titleText: '无法获取结果',
@@ -301,7 +301,7 @@ function searchOptions(): Partial<DefaultTheme.AlgoliaSearchOptions> {
                 '我会搜索你的文档，快速帮你找到设置指南、功能细节和故障排除提示。'
             },
             logo: {
-              poweredByText: '由…提供支持'
+              poweredByText: '搜索提供'
             }
           }
         }


### PR DESCRIPTION
### Description

Correct the Chinese translation of the Algolia search interface by replacing the unnatural wording used for the "Powered by" label.

This updates both the search modal and the Ask AI side panel to use a more natural Chinese translation.

### Additional Context

This PR only updates translation strings and does not change any functionality.
