### PR TITLE
fix: prevent hidden copy button from blocking code text selection

### DIFF
--- a/src/client/theme-default/styles/components/vp-doc.css
+++ b/src/client/theme-default/styles/components/vp-doc.css
@@ -455,6 +455,7 @@
   height: 40px;
   background-color: var(--vp-code-copy-code-bg);
   opacity: 0;
+  pointer-events: none;
   cursor: pointer;
   background-image: var(--vp-icon-copy);
   background-position: 50%;
@@ -469,6 +470,7 @@
 .vp-doc [class*='language-']:hover > button.copy,
 .vp-doc [class*='language-'] > button.copy:focus {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .vp-doc [class*='language-'] > button.copy:hover,


### PR DESCRIPTION
### Description
Addresses the text selection bug in mobile code blocks caused by the hidden copy button intercepting pointer events. 

The `.copy` button currently relies solely on `opacity: 0` for its hidden state. This leaves it within the interaction layer, implicitly blocking touch and selection events on the underlying code block content (particularly in the top-right corner). 

This PR introduces `pointer-events: none` to the base `.copy` button class and restores it to `auto` on `:hover` and `:focus`. This allows selection events to natively bypass the hidden button while retaining expected behavior on hover/focus, successfully resolving the overlap without introducing layout or margin side-effects.

#Linked Issues
Fixes #5120 
