### PR TITLE
Feature/arrow key nav

### DIFF
--- a/src/client/theme-default/components/VPDoc.vue
+++ b/src/client/theme-default/components/VPDoc.vue
@@ -1,19 +1,54 @@
 <script setup lang="ts">
-import { useRoute } from 'vitepress'
-import { computed } from 'vue'
+import { useRoute, useRouter } from 'vitepress'
+import { computed, onMounted, onUnmounted } from 'vue'
 import { useData } from '../composables/data'
 import { useLayout } from '../composables/layout'
+import { usePrevNext } from '../composables/prev-next'
 import VPDocAside from './VPDocAside.vue'
 import VPDocFooter from './VPDocFooter.vue'
 
 const { theme } = useData()
 
 const route = useRoute()
+const router = useRouter()
 const { hasSidebar, hasAside, leftAside } = useLayout()
+const control = usePrevNext()
 
 const pageName = computed(() =>
   route.path.replace(/[./]+/g, '_').replace(/_html$/, '')
 )
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return
+  if (e.defaultPrevented) return
+
+  const activeElement = document.activeElement
+  if (activeElement) {
+    const tagName = activeElement.tagName
+    if (
+      tagName === 'INPUT' ||
+      tagName === 'TEXTAREA' ||
+      tagName === 'SELECT' ||
+      (activeElement as HTMLElement).isContentEditable
+    ) {
+      return
+    }
+  }
+
+  if (e.key === 'ArrowLeft' && control.value.prev?.link) {
+    router.go(control.value.prev.link)
+  } else if (e.key === 'ArrowRight' && control.value.next?.link) {
+    router.go(control.value.next.link)
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeydown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', onKeydown)
+})
 </script>
 
 <template>


### PR DESCRIPTION
### Description

This PR introduces keyboard navigation to documentation pages, allowing users to navigate to the previous or next page using the `ArrowLeft` and `ArrowRight` keys. This brings VitePress closer in parity with other documentation tools like `mdbook`, improving accessibility and reading efficiency for power users.

**Technical Details:**
- Added a global `keydown` event listener in `VPDoc.vue`.
- Connected the listener directly to the existing `usePrevNext()` composable to resolve the correct `prev` and `next` routing links.
- Added heuristics to ensure the event listener respects user intent and prevents accidental navigations:
  - Navigation is aborted if the user is holding any modifier keys (`Alt`, `Ctrl`, `Meta`, `Shift`).
  - Navigation is aborted if the user's active focus is within an interactive text element (`INPUT`, `TEXTAREA`, `SELECT`, or elements with `contenteditable`).
  - Navigation is aborted if the event's default action was already prevented by a child component.

### Linked Issues

Resolves #5221 