### PR TITLE
Fix/prev next layout

### DIFF
--- a/src/client/theme-default/components/VPDocFooter.vue
+++ b/src/client/theme-default/components/VPDocFooter.vue
@@ -120,13 +120,8 @@ const showFooter = computed(
   padding-top: 24px;
   display: grid;
   grid-row-gap: 8px;
-}
-
-@media (min-width: 640px) {
-  .prev-next {
-    grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: 16px;
-  }
+  grid-template-columns: repeat(2, 1fr);
+  grid-column-gap: 16px;
 }
 
 .pager-link {


### PR DESCRIPTION
### Description

This PR refactors the footer CSS to ensure the "Previous page" and "Next page" navigation links remain side-by-side on narrower viewports. 

Currently, the two-column grid layout for `.prev-next` relies on a `@media (min-width: 640px)` query, causing the links to unnecessarily stack vertically on mobile screens, which consumes excess vertical space and looks bulky. This PR removes that media query and applies the two-column grid unconditionally, matching the layout expectation described in the issue.

### Linked Issues

Resolves #5208

### Additional Context

Tested against mobile viewports down to 320px width to ensure the side-by-side buttons do not overflow or overlap the container boundaries.

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.