### PR TITLE
fix(theme): pass target and rel to prev/next page links

### DIFF
--- a/__tests__/unit/client/theme-default/support/sidebar.test.ts
+++ b/__tests__/unit/client/theme-default/support/sidebar.test.ts
@@ -1,4 +1,8 @@
-import { getSidebar, hasActiveLink } from 'client/theme-default/support/sidebar'
+import {
+  getFlatSideBarLinks,
+  getSidebar,
+  hasActiveLink
+} from 'client/theme-default/support/sidebar'
 
 describe('client/theme-default/support/sidebar', () => {
   describe('getSidebar', () => {
@@ -132,6 +136,43 @@ describe('client/theme-default/support/sidebar', () => {
             { text: 'Root', link: '/en/root' },
             { text: 'External', link: 'https://example.com/' }
           ]
+        }
+      ])
+    })
+  })
+
+  describe('getFlatSideBarLinks', () => {
+    test('flattens nested items and preserves link metadata', () => {
+      const sidebar = [
+        {
+          text: 'Group',
+          items: [
+            { text: 'Intro', link: '/intro' },
+            {
+              text: 'External',
+              link: 'https://example.com/',
+              target: '_self',
+              rel: 'noopener',
+              docFooterText: 'Go external'
+            }
+          ]
+        }
+      ]
+
+      expect(getFlatSideBarLinks(sidebar)).toStrictEqual([
+        {
+          text: 'Intro',
+          link: '/intro',
+          docFooterText: undefined,
+          rel: undefined,
+          target: undefined
+        },
+        {
+          text: 'External',
+          link: 'https://example.com/',
+          docFooterText: 'Go external',
+          rel: 'noopener',
+          target: '_self'
         }
       ])
     })

--- a/src/client/theme-default/components/VPDocFooter.vue
+++ b/src/client/theme-default/components/VPDocFooter.vue
@@ -53,6 +53,8 @@ const showFooter = computed(
           v-if="control.prev?.link"
           class="pager-link prev"
           :href="control.prev.link"
+          :target="control.prev.target"
+          :rel="control.prev.rel"
         >
           <span
             class="desc"
@@ -66,6 +68,8 @@ const showFooter = computed(
           v-if="control.next?.link"
           class="pager-link next"
           :href="control.next.link"
+          :target="control.next.target"
+          :rel="control.next.rel"
         >
           <span
             class="desc"

--- a/src/client/theme-default/composables/prev-next.ts
+++ b/src/client/theme-default/composables/prev-next.ts
@@ -40,7 +40,15 @@ export function usePrevNext() {
             link:
               (typeof frontmatter.value.prev === 'object'
                 ? frontmatter.value.prev.link
-                : undefined) ?? candidates[index - 1]?.link
+                : undefined) ?? candidates[index - 1]?.link,
+            target:
+              (typeof frontmatter.value.prev === 'object'
+                ? frontmatter.value.prev.target
+                : undefined) ?? candidates[index - 1]?.target,
+            rel:
+              (typeof frontmatter.value.prev === 'object'
+                ? frontmatter.value.prev.rel
+                : undefined) ?? candidates[index - 1]?.rel
           },
       next: hideNext
         ? undefined
@@ -56,11 +64,19 @@ export function usePrevNext() {
             link:
               (typeof frontmatter.value.next === 'object'
                 ? frontmatter.value.next.link
-                : undefined) ?? candidates[index + 1]?.link
+                : undefined) ?? candidates[index + 1]?.link,
+            target:
+              (typeof frontmatter.value.next === 'object'
+                ? frontmatter.value.next.target
+                : undefined) ?? candidates[index + 1]?.target,
+            rel:
+              (typeof frontmatter.value.next === 'object'
+                ? frontmatter.value.next.rel
+                : undefined) ?? candidates[index + 1]?.rel
           }
     } as {
-      prev?: { text?: string; link?: string }
-      next?: { text?: string; link?: string }
+      prev?: { text?: string; link?: string; target?: string; rel?: string }
+      next?: { text?: string; link?: string; target?: string; rel?: string }
     }
   })
 }

--- a/src/client/theme-default/support/sidebar.ts
+++ b/src/client/theme-default/support/sidebar.ts
@@ -6,6 +6,8 @@ export interface SidebarLink {
   text: string
   link: string
   docFooterText?: string
+  rel?: string
+  target?: string
 }
 
 type SidebarItem = DefaultTheme.SidebarItem
@@ -75,7 +77,9 @@ export function getFlatSideBarLinks(sidebar: SidebarItem[]): SidebarLink[] {
         links.push({
           text: item.text,
           link: item.link,
-          docFooterText: item.docFooterText
+          docFooterText: item.docFooterText,
+          rel: item.rel,
+          target: item.target
         })
       }
 


### PR DESCRIPTION
### Description

Sidebar items accept `target`/`rel` and `VPSidebarItem` renders them, but the prev/next page buttons in the doc footer drop them: `getFlatSideBarLinks` didn't copy `target`/`rel`, `usePrevNext` only returned `text`/`link`, and `VPDocFooter` passed only `:href` to `VPLink`. So a sidebar item with `target: '_self'` opens as `_self` in the sidebar but not in the pager.

This carries `target`/`rel` from the sidebar item through the flat links and the prev/next composable, and forwards them to `VPLink` in the footer. Frontmatter `prev`/`next` object overrides may also supply `target`/`rel`. When undefined, `VPLink` keeps its existing defaults, so normal links are unaffected. Added a unit test for `getFlatSideBarLinks` preserving link metadata (`target`/`rel`/`docFooterText`).

fixes #5112

### Reproduction

Config:
```ts
sidebar: [{ items: [
  { text: 'Introduction', link: '/' },
  { text: 'test', link: '/test', target: '_self' },
]}]
```

Open a page whose next link is `test`. Before: the "Next page" button has no `target`. After: it renders `target="_self"` (and `rel` likewise), matching the sidebar link.

### Validation

- `vitest run -r __tests__/unit`: 111 passed, including the new test
- `vue-tsc --noEmit -p src/client`: clean
- Prettier: clean
