### PR TITLE
fix(build): respect cleanUrls in content loader render

### DIFF
--- a/__tests__/unit/node/contentLoader.test.ts
+++ b/__tests__/unit/node/contentLoader.test.ts
@@ -1,0 +1,51 @@
+import { resolveConfig } from 'node/config'
+import { createContentLoader } from 'node/contentLoader'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+describe('node/contentLoader', () => {
+  let root: string | undefined
+
+  afterEach(async () => {
+    if (root) {
+      await rm(root, { recursive: true, force: true })
+      root = undefined
+    }
+    delete (global as any).VITEPRESS_CONFIG
+  })
+
+  async function setup(cleanUrls: boolean) {
+    root = await mkdtemp(path.join(tmpdir(), 'vitepress-content-loader-'))
+    await writeFile(
+      path.join(root, 'index.md'),
+      '# Home\n\n[link](./other.md)\n'
+    )
+    await writeFile(path.join(root, 'other.md'), '# Other\n')
+
+    const siteConfig = await resolveConfig(root, 'build', 'production')
+    siteConfig.cleanUrls = cleanUrls
+    ;(global as any).VITEPRESS_CONFIG = siteConfig
+  }
+
+  test('rendered internal links get .html when cleanUrls is false', async () => {
+    await setup(false)
+
+    const data = await createContentLoader('index.md', {
+      render: true
+    }).load()
+
+    expect(data[0].html).toContain('href="./other.html"')
+  })
+
+  test('rendered internal links are clean when cleanUrls is true', async () => {
+    await setup(true)
+
+    const data = await createContentLoader('index.md', {
+      render: true
+    }).load()
+
+    expect(data[0].html).toContain('href="./other"')
+    expect(data[0].html).not.toContain('./other.html')
+  })
+})

--- a/src/node/contentLoader.ts
+++ b/src/node/contentLoader.ts
@@ -8,7 +8,7 @@ import {
   createMarkdownRenderer,
   mergeMarkdownLocales
 } from './markdown/markdown'
-import type { Awaitable } from './shared'
+import type { Awaitable, MarkdownEnv } from './shared'
 import { glob, normalizeGlob, type GlobOptions } from './utils/glob'
 
 export interface ContentOptions<T = ContentData[]> {
@@ -131,15 +131,29 @@ export function createContentLoader<T = ContentData[]>(
               : { excerpt: renderExcerpt as any } // gray-matter types are wrong
           )
 
+          const relativePath = normalizePath(path.relative(config.srcDir, file))
+
           const url =
             '/' +
-            normalizePath(path.relative(config.srcDir, file))
+            relativePath
               .replace(/(^|\/)index\.md$/, '$1')
               .replace(/\.md$/, config.cleanUrls ? '' : '.html')
 
-          const html = options.render ? await md.renderAsync(src) : undefined
+          // pass a markdown env so plugins (e.g. the internal link plugin)
+          // resolve links, `cleanUrls` and paths the same way as during a
+          // normal page render instead of falling back to defaults
+          const env: MarkdownEnv = {
+            path: file,
+            relativePath,
+            cleanUrls: !!config.cleanUrls,
+            realPath: file
+          }
+
+          const html = options.render
+            ? await md.renderAsync(src, env)
+            : undefined
           const renderedExcerpt = renderExcerpt
-            ? excerpt && (await md.renderAsync(excerpt))
+            ? excerpt && (await md.renderAsync(excerpt, env))
             : undefined
 
           const data: ContentData = {


### PR DESCRIPTION
### Description

`createContentLoader` calls `md.renderAsync()` without a `MarkdownEnv`, so the internal link plugin falls back to defaults: `env.cleanUrls` is `undefined`, and internal links inside the `render` / `excerpt` HTML always get a `.html` suffix even when `cleanUrls` is enabled. `env.path` / `env.relativePath` are also missing, which breaks markdown-it plugins that read them.

This builds the same env used during a normal page render (matching `markdownToVue.ts`) and forwards it to both the `render` and `excerpt` calls. Non-`cleanUrls` sites are unaffected — they already produced `.html` links and continue to. Added a unit test covering both `cleanUrls` states (the `cleanUrls: true` case fails without the fix).

As discussed in the issue, scope is intentionally limited to passing `env`; it does not add the per-loader `md.use` reconfiguration from #4349.

### Linked Issues

fixes #4331 (also addresses the env request in #4349)
