### PR TITLE
Fix `Error: MiniSearch: duplicate ID` upon server restart

### DIFF
--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -134,6 +134,7 @@ export async function localSearchPlugin(
       if (!section || !(section.text || section.titles)) break
       const { anchor, text, titles } = section
       const id = anchor ? [fileId, anchor].join('#') : fileId
+      index.has(id) && index.discard(id)
       index.add({
         id,
         text,


### PR DESCRIPTION
Fix #4642; Fix #4688.

```
xx:xx:xx [vitepress] vite.config.ts changed, restarting server...
.../minisearch/7.2.0/.../node_modules/minisearch/dist/es/index.js:...
            throw new Error(`MiniSearch: duplicate ID ${id}`);
                  ^

Error: MiniSearch: duplicate ID ...
    at MiniSearch.add (.../minisearch/7.2.0/.../node_modules/minisearch/dist/es/index.js:...)
    at indexFile (.../vitepress/2.0.0-alpha.17/.../node_modules/vitepress/dist/node/chunk-CpMTk0EA.js:...)
    at async scanForBuild (.../vitepress/2.0.0-alpha.17/.../node_modules/vitepress/dist/node/chunk-CpMTk0EA.js:...)

Node.js v24.18.0
ELIFECYCLE Command failed with exit code 1.
```

Ref: #4251, #4282.
