### PR TITLE
Revert "fix: prevent DocSearch SVG clipping in WebKit"

### DIFF
--- a/src/client/theme-default/styles/docsearch.css
+++ b/src/client/theme-default/styles/docsearch.css
@@ -41,10 +41,6 @@
   --docsearch-modal-shadow: none;
 }
 
-:is(.DocSearch-Container, .DocSearch-Sidepanel) svg {
-  overflow: visible;
-}
-
 .DocSearch-AskAiScreen-RelatedSources-Item-Link {
   padding: 8px 12px 8px 10px;
 }


### PR DESCRIPTION
Reverts #5240

closes #5301
closes #5300

x-ref: #5225

<img width="958" height="512" alt="image" src="https://github.com/user-attachments/assets/186896ee-c616-4a15-930c-b6dd388cb99e" />
