### PR TITLE
docs(github): fix relative link in contributing.md

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -19,7 +19,7 @@ Hi! We're really excited that you are interested in contributing to VitePress. B
 
 - It's OK to have multiple small commits as you work on the PR - GitHub can automatically squash them before merging.
 
-- Commit messages must follow the [commit message convention](./commit-convention.md) so that changelogs can be automatically generated.
+- Commit messages must follow the [commit message convention](/.github/commit-convention.md) so that changelogs can be automatically generated.
 
 ## Development Setup
 


### PR DESCRIPTION
Change the link to the commit convention document to use an absolute repository path (`/.github/...`) instead of a relative path (`./...`).

GitHub's Contributing overview tab incorrectly resolves relative links. Updating the path ensures the link to the commit convention works correctly both in the standard repository file view and on the Contributing overview tab.

Reference: https://github.com/orgs/community/discussions/200300