### PR TITLE
fix: remove font-synthesis style

### DIFF
--- a/src/client/theme-default/styles/base.css
+++ b/src/client/theme-default/styles/base.css
@@ -40,7 +40,6 @@
     font-weight: 400;
     color: var(--vp-c-text-1);
     background-color: var(--vp-c-bg);
-    font-synthesis: style;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
### Description

https://github.com/vuejs/vitepress/issues/4971#issuecomment-3375777457

It seems to still render the same for me on my laptop and phone in Chinese docs, but I haven't tested with an Android. But like the comment suggested, it should be harmless to remove the style altogether.

### Linked Issues

fixes #4971

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
