### PR TITLE
fix: remove stackTraceLimit Infinity for DEBUG

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -13,10 +13,6 @@ import { init } from './init/init'
 import { clearCache } from './markdownToVue'
 import { bindShortcuts } from './shortcuts'
 
-if (process.env.DEBUG) {
-  Error.stackTraceLimit = Infinity
-}
-
 const argv: any = minimist(process.argv.slice(2))
 
 Object.keys(argv).forEach((key) => {


### PR DESCRIPTION
### Description

This was added since https://github.com/vuejs/vitepress/commit/4dac35fc9ec3eecb4371befa619626ee4db1ba58 for a temporary fix for shiki twoslash, but the workaround since then has been removed, except this part which I don't know if it's intentional.

I think it's best to not auto set this to Infinity though if DEBUG was set, and leave users to control this as needed.

### Linked Issues

n/a

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
