### PR TITLE
feat: use ul and li for lists

### DIFF
--- a/src/client/theme-default/components/VPFeatures.vue
+++ b/src/client/theme-default/components/VPFeatures.vue
@@ -37,8 +37,8 @@ const grid = computed(() => {
 <template>
   <div v-if="features" class="VPFeatures">
     <div class="container">
-      <div class="items">
-        <div
+      <ul class="items">
+        <li
           v-for="feature in features"
           :key="feature.title"
           class="item"
@@ -53,8 +53,8 @@ const grid = computed(() => {
             :rel="feature.rel"
             :target="feature.target"
           />
-        </div>
-      </div>
+        </li>
+      </ul>
     </div>
   </div>
 </template>

--- a/src/client/theme-default/components/VPMenu.vue
+++ b/src/client/theme-default/components/VPMenu.vue
@@ -10,8 +10,8 @@ defineProps<{
 
 <template>
   <div class="VPMenu">
-    <div v-if="items" class="items">
-      <template v-for="item in items" :key="JSON.stringify(item)">
+    <ul v-if="items" class="items">
+      <li v-for="item in items" :key="JSON.stringify(item)">
         <VPMenuLink v-if="'link' in item" :item />
         <component
           v-else-if="'component' in item"
@@ -19,8 +19,8 @@ defineProps<{
           v-bind="item.props"
         />
         <VPMenuGroup v-else :text="item.text" :items="item.items" />
-      </template>
-    </div>
+      </li>
+    </ul>
 
     <slot />
   </div>

--- a/src/client/theme-default/components/VPNavBarExtra.vue
+++ b/src/client/theme-default/components/VPNavBarExtra.vue
@@ -26,13 +26,13 @@ const hasExtraContent = computed(
     class="VPNavBarExtra"
     label="extra navigation"
   >
-    <div
+    <ul
       v-if="localeLinks.length && currentLang.label"
       class="group translations"
     >
-      <p class="trans-title">{{ currentLang.label }}</p>
+      <li class="trans-title">{{ currentLang.label }}</li>
 
-      <template v-for="locale in localeLinks" :key="locale.link">
+      <li v-for="locale in localeLinks" :key="locale.link">
         <VPMenuLink
           :item="locale"
           :external="false"
@@ -42,8 +42,8 @@ const hasExtraContent = computed(
           :dir="locale.dir"
           data-allow-mismatch="attribute"
         />
-      </template>
-    </div>
+      </li>
+    </ul>
 
     <div
       v-if="

--- a/src/client/theme-default/components/VPNavBarMenu.vue
+++ b/src/client/theme-default/components/VPNavBarMenu.vue
@@ -15,15 +15,17 @@ const { theme } = useData()
     <span id="main-nav-aria-label" class="visually-hidden">
       Main Navigation
     </span>
-    <template v-for="item in theme.nav" :key="JSON.stringify(item)">
-      <VPNavBarMenuLink v-if="'link' in item" :item />
-      <component
-        v-else-if="'component' in item"
-        :is="item.component"
-        v-bind="item.props"
-      />
-      <VPNavBarMenuGroup v-else :item />
-    </template>
+    <ul class="list">
+      <li v-for="item in theme.nav" :key="JSON.stringify(item)">
+        <VPNavBarMenuLink v-if="'link' in item" :item />
+        <component
+          v-else-if="'component' in item"
+          :is="item.component"
+          v-bind="item.props"
+        />
+        <VPNavBarMenuGroup v-else :item />
+      </li>
+    </ul>
   </nav>
 </template>
 
@@ -32,9 +34,13 @@ const { theme } = useData()
   display: none;
 }
 
+.list {
+  display: flex;
+}
+
 @media (min-width: 768px) {
   .VPNavBarMenu {
-    display: flex;
+    display: block;
   }
 }
 </style>

--- a/src/client/theme-default/components/VPNavBarTranslations.vue
+++ b/src/client/theme-default/components/VPNavBarTranslations.vue
@@ -17,10 +17,10 @@ const { localeLinks, currentLang } = useLangs({
     icon="vpi-languages"
     :label="theme.langMenuLabel || 'Change language'"
   >
-    <div class="items">
-      <p class="title">{{ currentLang.label }}</p>
+    <ul class="items">
+      <li class="title">{{ currentLang.label }}</li>
 
-      <template v-for="locale in localeLinks" :key="locale.link">
+      <li v-for="locale in localeLinks" :key="locale.link">
         <VPMenuLink
           :item="locale"
           :external="false"
@@ -30,8 +30,8 @@ const { localeLinks, currentLang } = useLangs({
           :dir="locale.dir"
           data-allow-mismatch="attribute"
         />
-      </template>
-    </div>
+      </li>
+    </ul>
   </VPFlyout>
 </template>
 

--- a/src/client/theme-default/components/VPNavScreenMenu.vue
+++ b/src/client/theme-default/components/VPNavScreenMenu.vue
@@ -8,19 +8,21 @@ const { theme } = useData()
 
 <template>
   <nav v-if="theme.nav" class="VPNavScreenMenu">
-    <template v-for="item in theme.nav" :key="JSON.stringify(item)">
-      <VPNavScreenMenuLink v-if="'link' in item" :item />
-      <component
-        v-else-if="'component' in item"
-        :is="item.component"
-        v-bind="item.props"
-        screen-menu
-      />
-      <VPNavScreenMenuGroup
-        v-else
-        :text="item.text || ''"
-        :items="item.items"
-      />
-    </template>
+    <ul>
+      <li v-for="item in theme.nav" :key="JSON.stringify(item)">
+        <VPNavScreenMenuLink v-if="'link' in item" :item />
+        <component
+          v-else-if="'component' in item"
+          :is="item.component"
+          v-bind="item.props"
+          screen-menu
+        />
+        <VPNavScreenMenuGroup
+          v-else
+          :text="item.text || ''"
+          :items="item.items"
+        />
+      </li>
+    </ul>
   </nav>
 </template>

--- a/src/client/theme-default/components/VPNavScreenMenuGroup.vue
+++ b/src/client/theme-default/components/VPNavScreenMenuGroup.vue
@@ -31,8 +31,8 @@ function toggle() {
       <span class="vpi-plus button-icon" />
     </button>
 
-    <div :id="groupId" class="items">
-      <template v-for="item in items" :key="JSON.stringify(item)">
+    <ul :id="groupId" class="items">
+      <li v-for="item in items" :key="JSON.stringify(item)">
         <div v-if="'link' in item" class="item">
           <VPNavScreenMenuGroupLink :item />
         </div>
@@ -44,8 +44,8 @@ function toggle() {
         <div v-else class="group">
           <VPNavScreenMenuGroupSection :text="item.text" :items="item.items" />
         </div>
-      </template>
-    </div>
+      </li>
+    </ul>
   </div>
 </template>
 

--- a/src/client/theme-default/components/VPNavScreenMenuGroupSection.vue
+++ b/src/client/theme-default/components/VPNavScreenMenuGroupSection.vue
@@ -11,7 +11,11 @@ defineProps<{
 <template>
   <div class="VPNavScreenMenuGroupSection">
     <p v-if="text" class="title">{{ text }}</p>
-    <VPNavScreenMenuGroupLink v-for="item in items" :key="item.text" :item />
+    <ul>
+      <li v-for="item in items" :key="item.text">
+        <VPNavScreenMenuGroupLink :item="item" />
+      </li>
+    </ul>
   </div>
 </template>
 

--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -94,16 +94,16 @@ function onCaretClick() {
       </div>
     </div>
 
-    <div v-if="item.items && item.items.length" class="items">
-      <template v-if="depth < 5">
+    <ul v-if="item.items && item.items.length" class="items">
+      <li v-if="depth < 5">
         <VPSidebarItem
           v-for="i in item.items"
           :key="i.text"
           :item="i"
           :depth="depth + 1"
         />
-      </template>
-    </div>
+      </li>
+    </ul>
   </component>
 </template>
 

--- a/src/client/theme-default/components/VPSocialLinks.vue
+++ b/src/client/theme-default/components/VPSocialLinks.vue
@@ -11,17 +11,17 @@ withDefaults(defineProps<{
 </script>
 
 <template>
-  <div class="VPSocialLinks">
-    <VPSocialLink
-      v-for="{ link, icon, ariaLabel, target } in links"
-      :key="link"
-      :icon
-      :link
-      :ariaLabel
-      :target
-      :me
-    />
-  </div>
+  <ul class="VPSocialLinks">
+    <li v-for="{ link, icon, ariaLabel, target } in links" :key="link">
+      <VPSocialLink
+        :icon
+        :link
+        :ariaLabel
+        :target
+        :me
+      />
+    </li>
+  </ul>
 </template>
 
 <style scoped>

--- a/src/client/theme-default/components/VPSocialLinks.vue
+++ b/src/client/theme-default/components/VPSocialLinks.vue
@@ -33,6 +33,7 @@ withDefaults(defineProps<{
 /* Reset styles from vp-doc if used in markdown */
 .vp-doc .VPSocialLinks,
 .vp-doc .VPSocialLinks .item {
+  list-style: none;
   margin: 0;
   padding: 0;
 }

--- a/src/client/theme-default/components/VPSocialLinks.vue
+++ b/src/client/theme-default/components/VPSocialLinks.vue
@@ -12,7 +12,7 @@ withDefaults(defineProps<{
 
 <template>
   <ul class="VPSocialLinks">
-    <li v-for="{ link, icon, ariaLabel, target } in links" :key="link">
+    <li v-for="{ link, icon, ariaLabel, target } in links" :key="link" class="item">
       <VPSocialLink
         :icon
         :link
@@ -28,5 +28,12 @@ withDefaults(defineProps<{
 .VPSocialLinks {
   display: flex;
   justify-content: center;
+}
+
+/* Reset styles from vp-doc if used in markdown */
+.vp-doc .VPSocialLinks,
+.vp-doc .VPSocialLinks .item {
+  margin: 0;
+  padding: 0;
 }
 </style>

--- a/src/client/theme-default/components/VPSponsorsGrid.vue
+++ b/src/client/theme-default/components/VPSponsorsGrid.vue
@@ -22,8 +22,8 @@ useSponsorsGrid({ el, size: props.size })
 </script>
 
 <template>
-  <div class="VPSponsorsGrid vp-sponsor-grid" :class="[size]" ref="el">
-    <div
+  <ul class="VPSponsorsGrid vp-sponsor-grid" :class="[size]" ref="el">
+    <li
       v-for="sponsor in data"
       :key="sponsor.name"
       class="vp-sponsor-grid-item"
@@ -42,6 +42,6 @@ useSponsorsGrid({ el, size: props.size })
           />
         </article>
       </a>
-    </div>
-  </div>
+    </li>
+  </ul>
 </template>

--- a/src/client/theme-default/components/VPTeamMembers.vue
+++ b/src/client/theme-default/components/VPTeamMembers.vue
@@ -66,6 +66,7 @@ const classes = computed(() => [props.size, `count-${props.members.length}`])
 
 /* Reset styles from vp-doc if used in markdown */
 .vp-doc .VPTeamMembers .container {
+  list-style: none;
   margin: 0 auto;
   padding: 0;
 }

--- a/src/client/theme-default/components/VPTeamMembers.vue
+++ b/src/client/theme-default/components/VPTeamMembers.vue
@@ -17,11 +17,11 @@ const classes = computed(() => [props.size, `count-${props.members.length}`])
 
 <template>
   <div class="VPTeamMembers" :class="classes">
-    <div class="container">
-      <div v-for="member in members" :key="member.name" class="item">
+    <ul class="container">
+      <li v-for="member in members" :key="member.name" class="item">
         <VPTeamMembersItem :size :member />
-      </div>
-    </div>
+      </li>
+    </ul>
   </div>
 </template>
 
@@ -62,5 +62,15 @@ const classes = computed(() => [props.size, `count-${props.members.length}`])
   gap: 24px;
   margin: 0 auto;
   max-width: 1152px;
+}
+
+/* Reset styles from vp-doc if used in markdown */
+.vp-doc .VPTeamMembers .container {
+  margin: 0 auto;
+  padding: 0;
+}
+.vp-doc .VPTeamMembers .item {
+  margin: 0;
+  padding: 0;
 }
 </style>

--- a/src/client/theme-default/styles/components/vp-sponsor.css
+++ b/src/client/theme-default/styles/components/vp-sponsor.css
@@ -153,3 +153,10 @@
 .dark .vp-sponsor-grid-image {
   filter: grayscale(1) invert(1);
 }
+
+/* Reset styles from vp-doc if used in markdown */
+.vp-doc .vp-sponsor-grid,
+.vp-doc .vp-sponsor-grid-item {
+  margin: 0;
+  padding: 0;
+}

--- a/src/client/theme-default/styles/components/vp-sponsor.css
+++ b/src/client/theme-default/styles/components/vp-sponsor.css
@@ -157,6 +157,7 @@
 /* Reset styles from vp-doc if used in markdown */
 .vp-doc .vp-sponsor-grid,
 .vp-doc .vp-sponsor-grid-item {
+  list-style: none;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
### Description

For list-like content, use `ul` and `li` tags. I go through these by searching for `v-for` and decide whether they should be using the `ul` and `li` tags.

Note that some changes may result in a nested `li` tag, but visually they should look the same. Also, I have to "reset" some of the `ul` and `li` margins as they may be added by `vp-doc`.

I manually verified the UI as best as I could to ensure nothing visually changes.

### Linked Issues

Addresses part of #5056

### Additional Context

Some markup I didn't treat as a list, such as sidebar groups, sponsor tier sections, and home page action buttons. Since they're not much of a list of content.

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
