### PR TITLE
feat: show vite version in startup log

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -1,6 +1,6 @@
 import minimist from 'minimist'
 import c from 'picocolors'
-import { createLogger, type Logger } from 'vite'
+import { createLogger, version as viteVersion, type Logger } from 'vite'
 import {
   build,
   createServer,
@@ -24,9 +24,12 @@ Object.keys(argv).forEach((key) => {
 })
 
 const logVersion = (logger: Logger) => {
-  logger.info(`\n  ${c.green(`${c.bold('vitepress')} v${version}`)}\n`, {
-    clear: !logger.hasWarned
-  })
+  logger.info(
+    `\n  ${c.green(`${c.bold('vitepress')} v${version}`)} ${c.gray(`vite v${viteVersion}`)}\n`,
+    {
+      clear: !logger.hasWarned
+    }
+  )
 }
 
 const command = argv._[0]

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -25,10 +25,8 @@ Object.keys(argv).forEach((key) => {
 
 const logVersion = (logger: Logger) => {
   logger.info(
-    `\n  ${c.green(`${c.bold('vitepress')} v${version}`)} ${c.gray(`vite v${viteVersion}`)}\n`,
-    {
-      clear: !logger.hasWarned
-    }
+    `\n  ${c.green(`${c.bold('vitepress')} ${version}`)}  ${c.gray(`(using vite ${viteVersion})`)}\n`,
+    { clear: !logger.hasWarned }
   )
 }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
<img width="610" height="64" alt="image" src="https://github.com/user-attachments/assets/73c9c99e-ac2e-41d4-b76b-7ca91fb248a6" />

Explicitly print out the Vite versions that the current version depends on, which helps in troubleshooting issues and the use of new features.
### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
