### PR TITLE
Fix TypeError on the home page

### DIFF
--- a/src/client/theme-default/composables/outline.ts
+++ b/src/client/theme-default/composables/outline.ts
@@ -100,7 +100,6 @@ export function useActiveAnchor(
 
   onUnmounted(() => {
     window.removeEventListener('scroll', onScroll)
-    container.value?.removeEventListener('click', onClick)
   })
 
   function onClick(e: MouseEvent) {

--- a/src/client/theme-default/composables/outline.ts
+++ b/src/client/theme-default/composables/outline.ts
@@ -100,7 +100,7 @@ export function useActiveAnchor(
 
   onUnmounted(() => {
     window.removeEventListener('scroll', onScroll)
-    container.value.removeEventListener('click', onClick)
+    container.value?.removeEventListener('click', onClick)
   })
 
   function onClick(e: MouseEvent) {


### PR DESCRIPTION
### Description

Fixes the following error:

```js
TypeError: can't access property "removeEventListener", e.value is null
```

See screenshot below

<img width="1680" height="1050" alt="Screenshot 2026-07-22 at 00 09 03" src="https://github.com/user-attachments/assets/4dd7a1c5-1457-4ebc-b2a4-47c5fa7d33dd" />




### Linked Issues

N/A

### Additional Context

There might be a better fix here than a simple "no-op" 🤷‍♂️ 

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
