### PR TITLE
docs: correct withBase description to say it prepends the base

### DIFF
--- a/docs/en/reference/runtime-api.md
+++ b/docs/en/reference/runtime-api.md
@@ -140,7 +140,7 @@ For custom themes, the same router is available from [`enhanceApp`](../guide/cus
 
 - **Type**: `(path: string) => string`
 
-Appends the configured [`base`](./site-config#base) to a given URL path. Also see [Base URL](../guide/asset-handling#base-url).
+Prepends the configured [`base`](./site-config#base) to a given URL path. Also see [Base URL](../guide/asset-handling#base-url).
 
 ## `<Content />` <Badge type="info" text="component" />
 

--- a/src/client/app/utils.ts
+++ b/src/client/app/utils.ts
@@ -18,7 +18,7 @@ export function joinPath(base: string, path: string) {
 }
 
 /**
- * Append base to internal (non-relative) urls
+ * Prepend base to internal (non-relative) urls
  */
 export function withBase(path: string) {
   return EXTERNAL_URL_RE.test(path) || !path.startsWith('/')


### PR DESCRIPTION
### Description

The `withBase` docs and its JSDoc comment both say the helper appends the configured base to the URL path, but the code actually prepends it. This fixes the wording in both places to match what the function does.

### Linked Issues

fixes #5338

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
