### PR TITLE
fix: don't let meta attribute order affect head tag deduping

### DIFF
--- a/__tests__/unit/shared/shared.test.ts
+++ b/__tests__/unit/shared/shared.test.ts
@@ -1,0 +1,19 @@
+import { mergeHead } from 'shared/shared'
+
+describe('shared/shared', () => {
+  test('mergeHead dedupes meta tags regardless of attribute order', () => {
+    const result = mergeHead([
+      ['meta', { content: 'contentA', name: 'name1' }],
+      ['meta', { content: 'contentA', name: 'name2' }],
+      ['meta', { name: 'name3', content: 'contentB' }],
+      ['meta', { name: 'name4', content: 'contentB' }]
+    ])
+
+    expect(result).toEqual([
+      ['meta', { content: 'contentA', name: 'name1' }],
+      ['meta', { content: 'contentA', name: 'name2' }],
+      ['meta', { name: 'name3', content: 'contentB' }],
+      ['meta', { name: 'name4', content: 'contentB' }]
+    ])
+  })
+})

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -203,7 +203,9 @@ export function mergeHead(...headArrays: HeadConfig[][]): HeadConfig[] {
   for (const current of headArrays) {
     for (const tag of current) {
       const [type, attrs] = tag
-      const keyAttr = Object.entries(attrs)[0]
+      const keyAttr =
+        Object.entries(attrs).find(([name]) => name !== 'content') ??
+        Object.entries(attrs)[0]
 
       if (type !== 'meta' || !keyAttr) {
         merged.push(tag)


### PR DESCRIPTION
### Description

`mergeHead` picks whatever attribute happens to be first in the object as the key for deduping meta tags. If a tag is written with `content` before `name` (or `property`, etc.), it gets keyed on the content value instead of the name, so two different meta tags with the same content collide and one silently disappears. This skips `content` when choosing the key attribute, so dedup keys on the actual identifying attribute regardless of how the object is written.

### Linked Issues

fixes #5362

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->