### PR TITLE
fix(theme): clip overflowed navbar menu

### DIFF
--- a/src/client/theme-default/components/VPFlyout.vue
+++ b/src/client/theme-default/components/VPFlyout.vue
@@ -82,14 +82,12 @@ function onBlur() {
 .button[aria-expanded="false"] + .menu {
   opacity: 0;
   visibility: hidden;
-  transform: translateY(0);
 }
 
 .VPFlyout:hover .menu,
 .button[aria-expanded="true"] + .menu {
   opacity: 1;
   visibility: visible;
-  transform: translateY(0);
 }
 
 .button {
@@ -132,6 +130,6 @@ function onBlur() {
   right: 0;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.25s, visibility 0.25s, transform 0.25s;
+  transition: opacity 0.25s, visibility 0.25s;
 }
 </style>

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -164,6 +164,7 @@ const { isHome, hasSidebar } = useLayout()
 
 .content {
   flex-grow: 1;
+  min-width: 0;
 }
 
 @media (min-width: 60rem) {

--- a/src/client/theme-default/components/VPNavBarMenu.vue
+++ b/src/client/theme-default/components/VPNavBarMenu.vue
@@ -16,7 +16,7 @@ const { theme } = useData()
       Main Navigation
     </span>
     <ul class="list">
-      <li v-for="item in theme.nav.toReversed()" :key="JSON.stringify(item)">
+      <li v-for="item in theme.nav" :key="JSON.stringify(item)">
         <VPNavBarMenuLink v-if="'link' in item" :item />
         <component
           v-else-if="'component' in item"
@@ -33,6 +33,7 @@ const { theme } = useData()
 .VPNavBarMenu {
   display: none;
   flex-grow: 1;
+  justify-content: flex-end;
   min-width: 0;
   margin-left: 1rem;
   overflow-x: clip;
@@ -40,12 +41,11 @@ const { theme } = useData()
 
 .list {
   display: flex;
-  flex-direction: row-reverse;
 }
 
 @media (min-width: 48rem) {
   .VPNavBarMenu {
-    display: block;
+    display: flex;
   }
 }
 </style>

--- a/src/client/theme-default/components/VPNavBarMenu.vue
+++ b/src/client/theme-default/components/VPNavBarMenu.vue
@@ -16,7 +16,7 @@ const { theme } = useData()
       Main Navigation
     </span>
     <ul class="list">
-      <li v-for="item in theme.nav" :key="JSON.stringify(item)">
+      <li v-for="item in theme.nav.toReversed()" :key="JSON.stringify(item)">
         <VPNavBarMenuLink v-if="'link' in item" :item />
         <component
           v-else-if="'component' in item"
@@ -32,10 +32,15 @@ const { theme } = useData()
 <style scoped>
 .VPNavBarMenu {
   display: none;
+  flex-grow: 1;
+  min-width: 0;
+  margin-left: 1rem;
+  overflow-x: clip;
 }
 
 .list {
   display: flex;
+  flex-direction: row-reverse;
 }
 
 @media (min-width: 48rem) {

--- a/src/client/theme-default/components/VPNavBarSearch.vue
+++ b/src/client/theme-default/components/VPNavBarSearch.vue
@@ -203,7 +203,6 @@ function isEditingContent(event: KeyboardEvent): boolean {
 @media (min-width: 48rem) {
   .VPNavBarSearch {
     gap: 0.5rem;
-    flex-grow: 1;
     padding-left: 1.5rem;
   }
 }


### PR DESCRIPTION
### Description

In the navbar, make the navbar menu `flex-grow: 1` (instead of the search bar) and clip it if there's no more space left, e.g. the screen isn't wide enough. Now, the navbar shouldn't ever exceed the screen width and cause the scrolling in the first place

I'll make some comments below explaining some of the changes.

Here's also a video of the new behaviour:

https://github.com/user-attachments/assets/e38f8c41-1109-41c2-8d01-db7f9a169e9b


### Linked Issues

fix #2842

### Additional Context

In the linked issue, the scrolling happened in the first place on smaller screens is because the navbar became `position: relative`, while in larger screens it was `position: fixed`. I decided to fix this differently by making the navbar menu properly clipped in both cases instead.

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
