### PR TITLE
fix(theme): fix menu dropdown group dividers

### DIFF
--- a/src/client/theme-default/components/VPMenu.vue
+++ b/src/client/theme-default/components/VPMenu.vue
@@ -11,7 +11,7 @@ defineProps<{
 <template>
   <div class="VPMenu">
     <ul v-if="items" class="items">
-      <li v-for="item in items" :key="JSON.stringify(item)">
+      <template v-for="item in items" :key="JSON.stringify(item)">
         <VPMenuLink v-if="'link' in item" :item />
         <component
           v-else-if="'component' in item"
@@ -19,7 +19,7 @@ defineProps<{
           v-bind="item.props"
         />
         <VPMenuGroup v-else :text="item.text" :items="item.items" />
-      </li>
+      </template>
     </ul>
 
     <slot />

--- a/src/client/theme-default/components/VPMenuGroup.vue
+++ b/src/client/theme-default/components/VPMenuGroup.vue
@@ -9,13 +9,15 @@ defineProps<{
 </script>
 
 <template>
-  <div class="VPMenuGroup">
+  <li class="VPMenuGroup">
     <p v-if="text" class="title">{{ text }}</p>
 
-    <template v-for="item in items" :key="JSON.stringify(item)">
-      <VPMenuLink v-if="'link' in item" :item />
-    </template>
-  </div>
+    <ul>
+      <template v-for="item in items" :key="JSON.stringify(item)">
+        <VPMenuLink v-if="'link' in item" :item />
+      </template>
+    </ul>
+  </li>
 </template>
 
 <style scoped>

--- a/src/client/theme-default/components/VPMenuLink.vue
+++ b/src/client/theme-default/components/VPMenuLink.vue
@@ -31,7 +31,7 @@ defineOptions({ inheritAttrs: false })
 </script>
 
 <template>
-  <div class="VPMenuLink">
+  <li class="VPMenuLink">
     <VPLink
       v-bind="$attrs"
       :class="{ active: isActiveLink }"
@@ -42,7 +42,7 @@ defineOptions({ inheritAttrs: false })
     >
       <span v-html="item.text"></span>
     </VPLink>
-  </div>
+  </li>
 </template>
 
 <style scoped>

--- a/src/client/theme-default/components/VPNavBarExtra.vue
+++ b/src/client/theme-default/components/VPNavBarExtra.vue
@@ -32,7 +32,7 @@ const hasExtraContent = computed(
     >
       <li class="trans-title">{{ currentLang.label }}</li>
 
-      <li v-for="locale in localeLinks" :key="locale.link">
+      <template v-for="locale in localeLinks" :key="locale.link">
         <VPMenuLink
           :item="locale"
           :external="false"
@@ -42,7 +42,7 @@ const hasExtraContent = computed(
           :dir="locale.dir"
           data-allow-mismatch="attribute"
         />
-      </li>
+      </template>
     </ul>
 
     <div

--- a/src/client/theme-default/components/VPNavBarTranslations.vue
+++ b/src/client/theme-default/components/VPNavBarTranslations.vue
@@ -20,7 +20,7 @@ const { localeLinks, currentLang } = useLangs({
     <ul class="items">
       <li class="title">{{ currentLang.label }}</li>
 
-      <li v-for="locale in localeLinks" :key="locale.link">
+      <template v-for="locale in localeLinks" :key="locale.link">
         <VPMenuLink
           :item="locale"
           :external="false"
@@ -30,7 +30,7 @@ const { localeLinks, currentLang } = useLangs({
           :dir="locale.dir"
           data-allow-mismatch="attribute"
         />
-      </li>
+      </template>
     </ul>
   </VPFlyout>
 </template>


### PR DESCRIPTION
### Description

#5326 introduced a bug where items in a dropdown menu didn't have the dividers properly rendered. This is because the styles are like `.VPMenuGroup + .VPMenuGroup` and `.VPMenuGroup:first-child` which didn't work because there's now a `li` wrapping the `.VPMenuGroup`.

In this PR, I took the simple approach of removing the nesting, and rendering the `li` directly in the components, i.e. `VPMenuLink` and `VPMenuGroup`. I don't know if this is the best pattern for project, but it seems somewhat safe as both are only used by `VPMenu`.

Alternatively, I was testing with `:global(li:has(> .VPMenuGroup) + li:has(> .VPMenuGroup))` for example, but it didn't look great so I tossed it. However, it's still an option on the table.


### Linked Issues

n/a. found this while checking things myself.

### Additional Context

Note, this doesn't affect `VPNavScreenMenu`. It looks like its components don't depend on this kind of dependent style.

Screenshots before & after (using groups syntax in the config):

<img width="230" height="345" alt="image" src="https://github.com/user-attachments/assets/d4bed408-8809-495d-94da-24491ae37231" />


<img width="265" height="396" alt="image" src="https://github.com/user-attachments/assets/c0cf2ee8-6bfd-4865-9876-b2d54347613c" />

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
