### PR TITLE
fix(theme): prevent scroll chaining in local nav outline dropdown

### DIFF
--- a/src/client/theme-default/components/VPLocalNavOutlineDropdown.vue
+++ b/src/client/theme-default/components/VPLocalNavOutlineDropdown.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { onKeyStroke } from '@vueuse/core'
-import { onContentUpdated } from 'vitepress'
+import { onKeyStroke, useScrollLock } from '@vueuse/core'
+import { inBrowser, onContentUpdated } from 'vitepress'
 import type { DefaultTheme } from 'vitepress/theme'
 import { nextTick, ref, watch } from 'vue'
 import { useData } from '../composables/data'
@@ -18,6 +18,9 @@ const vh = ref(0)
 const main = ref<HTMLDivElement>()
 const items = ref<HTMLDivElement>()
 
+// lock body scroll while the dropdown is open to prevent scroll chaining
+const isLocked = useScrollLock(inBrowser ? document.body : null)
+
 function closeOnClickOutside(e: Event) {
   if (!main.value?.contains(e.target as Node)) {
     open.value = false
@@ -25,6 +28,7 @@ function closeOnClickOutside(e: Event) {
 }
 
 watch(open, (value) => {
+  isLocked.value = value
   if (value) {
     document.addEventListener('click', closeOnClickOutside)
     return
@@ -148,6 +152,7 @@ function scrollToTop() {
   background-color: var(--vp-c-gutter);
   max-height: calc(var(--vp-vh, 100vh) - 5.375rem);
   overflow: hidden auto;
+  overscroll-behavior: contain;
   box-shadow: var(--vp-shadow-3);
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes scroll chaining (滑动穿透) on the mobile **"On this page" outline dropdown** (`VPLocalNavOutlineDropdown`). When the dropdown is open and its scrollable list reaches the top/bottom boundary, further touch drags scroll the page behind it instead of stopping.

The mobile sidebar (`VPSidebar`) already handles this correctly with `useScrollLock` + `overscroll-behavior: contain`; the outline dropdown is the only overlay in the default theme missing the lock.

### Reproduction

1. Open any doc page with many headings on a mobile viewport (e.g. 390×844).
2. Scroll the page down, open the "On this page" dropdown.
3. Drag inside the dropdown list past its scroll boundary.

Result: the background page scrolls together with the drag (body is never locked; `window.scrollY` moves while dragging inside the dropdown).

Measured with Playwright touch emulation on a page with 71 headings (window.scrollY before/after dragging past the boundary inside the dropdown):

| state | before fix | after fix |
| --- | --- | --- |
| dropdown open | `body` overflow `visible` | `body` overflow `hidden` |
| drag inside dropdown past boundary | `scrollY` 2500 → **1524** (page dragged ~976px) | `scrollY` stays **2500** |

### Changes

- Lock body scroll via `useScrollLock` while the dropdown is open (same pattern as `VPSidebar`), and unlock on close / Escape / content update.
- Add `overscroll-behavior: contain` to the `.items` panel as a second layer of protection (also matches `VPSidebar`).

### Validation

- Reproduced the bug and verified the fix with Playwright mobile touch emulation (see table above).
- Dropdown scrolling itself works normally; Escape and click-outside close still unlock body scroll.
