### PR TITLE
fix(theme): treat negative scrollY as top

### DIFF
--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -28,7 +28,7 @@ const { isHome, hasSidebar } = useLayout()
     :class="{
       'has-sidebar': hasSidebar,
       'home': isHome,
-      'top': y === 0,
+      'top': y <= 0,
       'screen-open': isScreenOpen
     }"
   >


### PR DESCRIPTION
### Description

Boring change. For Safari where you can over-scroll upwards till negative value (which has an elastic effect that brings it back to 0), in this PR, treat negative scroll Y as also `top` so that the navbar transparency is kept when over-scrolling upwards.

### Linked Issues

n/a

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
