### PR TITLE
fix(theme): fix nav screen and divider appearance

### DIFF
--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -23,7 +23,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <header v-if="hasNavbar" class="VPNav" :class="{ 'screen-open': isScreenOpen }">
+  <header v-if="hasNavbar" class="VPNav">
     <VPNavBar :is-screen-open="isScreenOpen" @toggle-screen="toggleScreen">
       <template #nav-bar-title-before><slot name="nav-bar-title-before" /></template>
       <template #nav-bar-title-after><slot name="nav-bar-title-after" /></template>
@@ -47,11 +47,6 @@ watchEffect(() => {
   width: 100%;
   pointer-events: none;
   transition: background-color 0.5s;
-}
-
-.screen-open {
-  position: sticky;
-  top: 0;
 }
 
 @media (min-width: 60rem) {

--- a/src/client/theme-default/components/VPNav.vue
+++ b/src/client/theme-default/components/VPNav.vue
@@ -23,7 +23,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <header v-if="hasNavbar" class="VPNav">
+  <header v-if="hasNavbar" class="VPNav" :class="{ 'screen-open': isScreenOpen }">
     <VPNavBar :is-screen-open="isScreenOpen" @toggle-screen="toggleScreen">
       <template #nav-bar-title-before><slot name="nav-bar-title-before" /></template>
       <template #nav-bar-title-after><slot name="nav-bar-title-after" /></template>
@@ -47,6 +47,11 @@ watchEffect(() => {
   width: 100%;
   pointer-events: none;
   transition: background-color 0.5s;
+}
+
+.screen-open {
+  position: sticky;
+  top: 0;
 }
 
 @media (min-width: 60rem) {

--- a/src/client/theme-default/components/VPNavBar.vue
+++ b/src/client/theme-default/components/VPNavBar.vue
@@ -79,7 +79,6 @@ const { isHome, hasSidebar } = useLayout()
 .VPNavBar.screen-open {
   transition: none;
   background-color: var(--vp-nav-bg-color);
-  border-bottom: 1px solid var(--vp-c-divider);
 }
 
 .VPNavBar:not(.home) {
@@ -252,19 +251,23 @@ const { isHome, hasSidebar } = useLayout()
 .divider-line {
   width: 100%;
   height: 1px;
-  transition: background-color 0.5s;
+  transition: background-color 0.25s;
 }
 
 .VPNavBar:not(.home) .divider-line {
   background-color: var(--vp-c-gutter);
 }
 
+.VPNavBar.screen-open .divider-line {
+  background-color: var(--vp-c-divider);
+}
+
 @media (min-width: 60rem) {
-  .VPNavBar:not(.home.top) .divider-line {
-    background-color: var(--vp-c-gutter);
+  .divider-line {
+    transition: background-color 0.5s;
   }
 
-  .VPNavBar:not(.has-sidebar):not(.home.top) .divider {
+  .VPNavBar:not(.home.top) .divider-line {
     background-color: var(--vp-c-gutter);
   }
 }

--- a/src/client/theme-default/components/VPNavScreen.vue
+++ b/src/client/theme-default/components/VPNavScreen.vue
@@ -35,7 +35,8 @@ const isLocked = useScrollLock(inBrowser ? document.body : null)
 <style scoped>
 .VPNavScreen {
   position: fixed;
-  top: calc(var(--vp-nav-height) + var(--vp-layout-top-height, 0px));
+  /* reserve 1px for the VPNavBar divider */
+  top: calc(var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 1px);
   /*rtl:ignore*/
   right: 0;
   bottom: 0;

--- a/src/client/theme-default/components/VPNavScreen.vue
+++ b/src/client/theme-default/components/VPNavScreen.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useScrollLock } from '@vueuse/core'
+import { useScrollLock, useWindowScroll } from '@vueuse/core'
 import { inBrowser } from 'vitepress'
 import VPNavScreenAppearance from './VPNavScreenAppearance.vue'
 import VPNavScreenMenu from './VPNavScreenMenu.vue'
@@ -11,6 +11,7 @@ defineProps<{
 }>()
 
 const isLocked = useScrollLock(inBrowser ? document.body : null)
+const { y } = useWindowScroll()
 </script>
 
 <template>
@@ -19,7 +20,7 @@ const isLocked = useScrollLock(inBrowser ? document.body : null)
     @enter="isLocked = true"
     @after-leave="isLocked = false"
   >
-    <div v-if="open" class="VPNavScreen" id="VPNavScreen">
+    <div v-if="open" class="VPNavScreen" id="VPNavScreen" :style="{ '--vp-y': y + 'px' }">
       <div class="container">
         <slot name="nav-screen-content-before" />
         <VPNavScreenMenu class="menu" />
@@ -36,13 +37,14 @@ const isLocked = useScrollLock(inBrowser ? document.body : null)
 .VPNavScreen {
   position: fixed;
   /* reserve 1px for the VPNavBar divider */
-  top: calc(var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 1px);
+  top: calc(var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 1px - var(--vp-y));
   /*rtl:ignore*/
   right: 0;
   bottom: 0;
   /*rtl:ignore*/
   left: 0;
   padding: 0 2rem;
+  padding-top: var(--vp-y);
   width: 100%;
   background-color: var(--vp-nav-screen-bg-color);
   overflow-y: auto;


### PR DESCRIPTION
### Description

So I ended up implemented no2 of https://github.com/vuejs/vitepress/issues/4972#issuecomment-5276394598 by adjusting the `top` and using `padding-top` to offset it back. no3 feels too jarring to me, you can try no3 out by checking out the first commit though.

I fixed the divider issue by using the divider element always instead of the border-bottom.

### Linked Issues

fix https://github.com/vuejs/vitepress/issues/4972
fix https://github.com/vuejs/vitepress/issues/5361

### Additional Context

Here's a video of me testing:

https://github.com/user-attachments/assets/ed7693c6-b1ed-4e53-ba76-bf24604ce5a8

If you're testing yourself, something I found difficult to handle is if the page is pinch-zoomed, the offset starts to become erratic. It happens previously too, but with this PR's `y` calculation, it's slightly more erratic. And sometimes to offset when zoomed seems wrong and covers over the divider (which it shouldn't).

Tried some tricks like `visualViewport.scale` but couldn't figure out one that works.


---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
