### PR TITLE
fix(theme): fix social links spacing in dropdown

### DIFF
--- a/src/client/theme-default/components/VPSocialLinks.vue
+++ b/src/client/theme-default/components/VPSocialLinks.vue
@@ -12,7 +12,7 @@ withDefaults(defineProps<{
 
 <template>
   <ul class="VPSocialLinks">
-    <li v-for="{ link, icon, ariaLabel, target } in links" :key="link" class="item">
+    <li v-for="{ link, icon, ariaLabel, target } in links" :key="link">
       <VPSocialLink
         :icon
         :link
@@ -32,7 +32,7 @@ withDefaults(defineProps<{
 
 /* Reset styles from vp-doc if used in markdown */
 .vp-doc .VPSocialLinks,
-.vp-doc .VPSocialLinks .item {
+.vp-doc .VPSocialLinks > li {
   list-style: none;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
### Description

Before & after:

<img width="260" height="126" alt="image" src="https://github.com/user-attachments/assets/844a4161-efc3-40e1-9ac4-1e306fd734cf" />

<img width="234" height="131" alt="image" src="https://github.com/user-attachments/assets/32f68d69-9d8e-4047-9e6d-e241a6614a2e" />

The reason was because the class `"item"` added was interferred by this styling in VPMenu:

https://github.com/vuejs/vitepress/blob/9d521db8671a53d5a5f23baf5226879ce2d25960/src/client/theme-default/components/VPMenu.vue#L61-L64

I think it's easier to avoid the `"item"` class instead of overriding the padding.


### Linked Issues

n/a. stumbled on this while checking some sites

### Additional Context

caused by #5326

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
