### PR TITLE
fix(theme): remove invalid role and tabindex from VPSidebarItem wrapper

### DIFF
--- a/src/client/theme-default/components/VPSidebarItem.vue
+++ b/src/client/theme-default/components/VPSidebarItem.vue
@@ -31,8 +31,6 @@ const textTag = computed(() => {
       : `h${props.depth + 2}`
 })
 
-const itemRole = computed(() => (isLink.value ? undefined : 'button'))
-
 const classes = computed(() => [
   [`level-${props.depth}`],
   { collapsible: collapsible.value },
@@ -59,13 +57,11 @@ function onCaretClick() {
     <div
       v-if="item.text"
       class="item"
-      :role="itemRole"
       v-on="
         item.items
           ? { click: onItemInteraction, keydown: onItemInteraction }
           : {}
       "
-      :tabindex="item.items && 0"
     >
       <div class="indicator" />
 


### PR DESCRIPTION
### Description

This PR fixes an issue where the `VPSidebarItem` component generated invalid HTML, which caused W3C validation errors and created an improper accessibility tree. 

Specifically, the outer wrapper `<div class="item">` was being assigned `role="button"` and `tabindex="0"`. Because this wrapper contains the heading (`h2`-`h6`) and the caret toggle button (`<div class="caret" role="button">`), it resulted in:
1. An `h2` element being illegally nested inside a `button`.
2. A focusable `button` (caret) being illegally nested inside another `button`.

This PR removes the `role` and `tabindex` attributes from the outer `.item` wrapper (and cleans up the unused `itemRole` computed property).

### Linked Issues

fixes #5366

### Additional Context

- Mouse functionality is fully preserved (clicking anywhere on the item still bubbles up and toggles the section).
- Keyboard functionality is preserved (the `.caret` button remains the accessible, focusable element for screen readers to toggle the section).
- The HTML perfectly passes the W3C Nu Html Checker without any nested button or heading errors.

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
