### PR TITLE
Deal with Chromium's implementation flaw lacking support for `:lang(A, B)`

### DIFF
--- a/src/client/theme-default/styles/vars.css
+++ b/src/client/theme-default/styles/vars.css
@@ -274,13 +274,13 @@
    [lang] covers the case of e.g. <div lang="zh-CN"> in a non-Chinese page.
 */
 /* Korean compatibility is unverified, so application of custom Inter to Korean is pending. */
-[lang]:where(:lang(zh, ja)) {
+[lang]:where(:lang(zh), :lang(ja)) {
   --vp-font-family-base:
     'Inter4CJK', -apple-system, BlinkMacSystemFont, sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
-[lang]:where(:lang(zh, ja, ko)) {
+[lang]:where(:lang(zh), :lang(ja), :lang(ko)) {
   h1,
   h2,
   h3,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

https://issues.chromium.org/issues/40811938
https://github.com/mdn/browser-compat-data/pull/29642
https://github.com/withastro/starlight/pull/3890

Some changes by #4988 have not been reflected in Chrome/Edge due to the lack of the support for `:lang(A, B)`. `:where(:lang(A, B))` must be changed to `:where(:lang(A), :lang(B))`.

### Linked Issues

<!-- e.g. fixes #123 -->



### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
