### PR TITLE
fix(theme): handle outline bottom overscroll

### DIFF
--- a/src/client/theme-default/composables/outline.ts
+++ b/src/client/theme-default/composables/outline.ts
@@ -128,7 +128,7 @@ export function useActiveAnchor(
     const scrollY = window.scrollY
     const innerHeight = window.innerHeight
     const offsetHeight = document.body.offsetHeight
-    const isBottom = Math.abs(scrollY + innerHeight - offsetHeight) < 1
+    const isBottom = offsetHeight - innerHeight - scrollY <= 0
 
     // resolvedHeaders may be repositioned, hidden or fix positioned
     const headers = resolvedHeaders

--- a/src/client/theme-default/composables/outline.ts
+++ b/src/client/theme-default/composables/outline.ts
@@ -128,7 +128,7 @@ export function useActiveAnchor(
     const scrollY = window.scrollY
     const innerHeight = window.innerHeight
     const offsetHeight = document.body.offsetHeight
-    const isBottom = offsetHeight - innerHeight - scrollY <= 0
+    const isBottom = scrollY + innerHeight - offsetHeight >= 0
 
     // resolvedHeaders may be repositioned, hidden or fix positioned
     const headers = resolvedHeaders


### PR DESCRIPTION
### Description

When reaching the bottom of the page, the outline marker will always mark the last item. However, on Safari where you can overscroll the bottom (which have the elastic effect), the `Math.abs` was preventing the detection for values that would go negative because of the overscroll.

This PR updates the calculation to account for overscroll, so that the marker doesn't jump between the last and second last item during overscroll

### Linked Issues

n/a

### Additional Context

You can check the outline marker behaviour during overscroll like on this page: https://vitepress.dev/guide/i18n

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
