### PR TITLE
fix(theme): truncate long nav title with ellipsis

### DIFF
--- a/__tests__/e2e/.vitepress/config.ts
+++ b/__tests__/e2e/.vitepress/config.ts
@@ -173,7 +173,8 @@ const sidebar: DefaultTheme.Config['sidebar'] = {
 }
 
 export default defineConfig({
-  title: 'Example',
+  title:
+    'Example with an exceedingly long site title that surely overflows the sidebar width',
   description: 'An example app using VitePress.',
   srcExclude: ['**/parts/**'],
   markdown: {

--- a/__tests__/e2e/nav-title.test.ts
+++ b/__tests__/e2e/nav-title.test.ts
@@ -1,0 +1,26 @@
+describe('nav title overflow', () => {
+  beforeAll(async () => {
+    await goto('/frontmatter/multiple-levels-outline')
+  })
+
+  test('title text does not overflow the sidebar', async () => {
+    const spanBox = await page
+      .locator('.VPNavBarTitle .title span')
+      .boundingBox()
+    const sidebarBox = await page.locator('.VPSidebar').boundingBox()
+
+    expect(spanBox).not.toBeNull()
+    expect(sidebarBox).not.toBeNull()
+    expect(spanBox!.x + spanBox!.width).toBeLessThanOrEqual(
+      sidebarBox!.x + sidebarBox!.width
+    )
+  })
+
+  test('title text is truncated with ellipsis', async () => {
+    const truncated = await page
+      .locator('.VPNavBarTitle .title span')
+      .evaluate((el) => el.scrollWidth > el.clientWidth)
+
+    expect(truncated).toBe(true)
+  })
+})

--- a/src/client/theme-default/components/VPNavBarTitle.vue
+++ b/src/client/theme-default/components/VPNavBarTitle.vue
@@ -60,8 +60,6 @@ const target = computed(() =>
 }
 
 .title span {
-  min-width: 0;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/src/client/theme-default/components/VPNavBarTitle.vue
+++ b/src/client/theme-default/components/VPNavBarTitle.vue
@@ -59,6 +59,13 @@ const target = computed(() =>
   transition: opacity 0.25s;
 }
 
+.title span {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @media (min-width: 60rem) {
   .title {
     flex-shrink: 0;


### PR DESCRIPTION
### Problem

When the site title is longer than the sidebar width, the nav title text visually overflows its bordered title area and spills over the page content — e.g. `从零实现 DeepSeek Harness` (~330px) vs the 17rem sidebar.

The title `<span>` is a flex item inside `.VPNavBarTitle .title` (`display: flex`). Flex items default to `min-width: auto`, so the span refuses to shrink below its text width and simply overflows the container (`overflow: visible`). The wrapper is already sized to `var(--vp-sidebar-width)` when a sidebar is present, so the only leak is the text itself.

### Fix

Constrain the title text:

```css
.title span {
  min-width: 0;
  white-space: nowrap;
  overflow: hidden;
  text-overflow: ellipsis;
}
```

- `min-width: 0` lets the flex item shrink below its content width
- `white-space: nowrap` + `overflow: hidden` + `text-overflow: ellipsis` truncate the text instead of overflowing

No layout change when the title is short (no truncation kicks in), and non-sidebar pages are untouched (the wrapper there sizes to content).

### Tests

Added `__tests__/e2e/nav-title.test.ts` with a deliberately long site title in the e2e fixture site:
- title text does not overflow the sidebar (bounding-box comparison)
- title text is truncated with ellipsis (`scrollWidth > clientWidth`)

Both fail without the fix, pass with it. Full suite green: `test:types`, `test:unit` (296), e2e dev (41) and e2e build (39) all pass.

### Checklist

- [x] `pnpm test:types` passes
- [x] `pnpm test:unit` passes
- [x] `pnpm test:e2e` (dev + build) passes