### PR TITLE
feat(theme): scroll toc if active item is out of view

### DIFF
--- a/src/client/theme-default/components/VPDocOutlineItem.vue
+++ b/src/client/theme-default/components/VPDocOutlineItem.vue
@@ -37,6 +37,8 @@ defineProps<{
   font-size: 0.875rem;
   font-weight: 400;
   color: var(--vp-c-text-2);
+  scroll-margin-top: calc(var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + var(--vp-doc-top-height, 0px) + 2rem);
+  scroll-margin-bottom: 3rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/client/theme-default/composables/outline.ts
+++ b/src/client/theme-default/composables/outline.ts
@@ -171,19 +171,17 @@ export function useActiveAnchor(
   }
 
   function activateLink(hash: string | null) {
-    if (prevActiveLink) {
-      prevActiveLink.classList.remove('active')
-    }
+    const activeLink =
+      hash != null
+        ? container.value.querySelector<HTMLAnchorElement>(
+            `a[href$="${decodeURIComponent(hash)}"]`
+          )
+        : null
 
-    if (hash == null) {
-      prevActiveLink = null
-    } else {
-      prevActiveLink = container.value.querySelector(
-        `a[href$="${decodeURIComponent(hash)}"]`
-      )
-    }
+    if (activeLink === prevActiveLink) return
 
-    const activeLink = prevActiveLink
+    prevActiveLink?.classList.remove('active')
+    prevActiveLink = activeLink
 
     if (activeLink) {
       activeLink.classList.add('active')
@@ -195,6 +193,7 @@ export function useActiveAnchor(
         (activeLink.offsetHeight - marker.value.offsetHeight) / 2 +
         'px'
       marker.value.style.opacity = '1'
+      activeLink.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
     } else {
       marker.value.style.top = ''
       marker.value.style.opacity = '0'


### PR DESCRIPTION
### Description

Adds a `activeLink.scrollIntoView({ block: 'nearest', behavior: 'smooth' })` to auto-scroll to the toc active item if it's out of view. An alternative to #4735 where it always scrolls, this PR is less aggressive.

### Linked Issues

fixes #4734

### Additional Context

Test this on https://deploy-preview-5377--vitepress-docs.netlify.app/reference/site-config

NOTE: Because the outline marker has a transition on `top`, it'll look a bit jittery when auto-scrolling for both smooth and non-smooth scrolling. I found enabling smooth scrolling when calling `scrollIntoView` to be less distracting though.

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
