### PR TITLE
refactor: use JSON import attributes instead of createRequire in config

### DIFF
--- a/docs/config.ts
+++ b/docs/config.ts
@@ -1,8 +1,5 @@
-import { createRequire } from 'node:module'
 import { defineAdditionalConfig, type DefaultTheme } from 'vitepress'
-
-const require = createRequire(import.meta.url)
-const pkg = require('vitepress/package.json')
+import { version } from 'vitepress/package.json' with { type: 'json' }
 
 export default defineAdditionalConfig({
   description: 'Vite & Vue powered static site generator.',
@@ -40,7 +37,7 @@ function nav(): DefaultTheme.NavItem[] {
       activeMatch: '/reference/'
     },
     {
-      text: pkg.version,
+      text: version,
       items: [
         {
           text: '1.6.4',

--- a/docs/es/config.ts
+++ b/docs/es/config.ts
@@ -1,12 +1,9 @@
-import { createRequire } from 'node:module'
 import {
   defineAdditionalConfig,
   type DefaultTheme,
   type MarkdownLocaleOptions
 } from 'vitepress'
-
-const require = createRequire(import.meta.url)
-const pkg = require('vitepress/package.json')
+import { version } from 'vitepress/package.json' with { type: 'json' }
 
 export const markdown: MarkdownLocaleOptions = {
   container: {
@@ -92,7 +89,7 @@ function nav(): DefaultTheme.NavItem[] {
       activeMatch: '/es/reference/'
     },
     {
-      text: pkg.version,
+      text: version,
       items: [
         {
           text: '1.6.4',

--- a/docs/fa/config.ts
+++ b/docs/fa/config.ts
@@ -1,12 +1,9 @@
-import { createRequire } from 'node:module'
 import {
   defineAdditionalConfig,
   type DefaultTheme,
   type MarkdownLocaleOptions
 } from 'vitepress'
-
-const require = createRequire(import.meta.url)
-const pkg = require('vitepress/package.json')
+import { version } from 'vitepress/package.json' with { type: 'json' }
 
 export const markdown: MarkdownLocaleOptions = {
   container: {
@@ -100,7 +97,7 @@ function nav(): DefaultTheme.NavItem[] {
       activeMatch: '/reference/'
     },
     {
-      text: pkg.version,
+      text: version,
       items: [
         {
           text: '1.6.4',

--- a/docs/ja/config.ts
+++ b/docs/ja/config.ts
@@ -1,12 +1,9 @@
-import { createRequire } from 'node:module'
 import {
   defineAdditionalConfig,
   type DefaultTheme,
   type MarkdownLocaleOptions
 } from 'vitepress'
-
-const require = createRequire(import.meta.url)
-const pkg = require('vitepress/package.json')
+import { version } from 'vitepress/package.json' with { type: 'json' }
 
 export const markdown: MarkdownLocaleOptions = {
   container: {
@@ -63,7 +60,7 @@ function nav(): DefaultTheme.NavItem[] {
       activeMatch: '/reference/'
     },
     {
-      text: pkg.version,
+      text: version,
       items: [
         {
           text: '1.6.4',

--- a/docs/ko/config.ts
+++ b/docs/ko/config.ts
@@ -1,12 +1,9 @@
-import { createRequire } from 'node:module'
 import {
   defineAdditionalConfig,
   type DefaultTheme,
   type MarkdownLocaleOptions
 } from 'vitepress'
-
-const require = createRequire(import.meta.url)
-const pkg = require('vitepress/package.json')
+import { version } from 'vitepress/package.json' with { type: 'json' }
 
 export const markdown: MarkdownLocaleOptions = {
   container: {
@@ -92,7 +89,7 @@ function nav(): DefaultTheme.NavItem[] {
       activeMatch: '/ko/reference/'
     },
     {
-      text: pkg.version,
+      text: version,
       items: [
         {
           text: '1.6.4',

--- a/docs/pt/config.ts
+++ b/docs/pt/config.ts
@@ -1,12 +1,9 @@
-import { createRequire } from 'node:module'
 import {
   defineAdditionalConfig,
   type DefaultTheme,
   type MarkdownLocaleOptions
 } from 'vitepress'
-
-const require = createRequire(import.meta.url)
-const pkg = require('vitepress/package.json')
+import { version } from 'vitepress/package.json' with { type: 'json' }
 
 export const markdown: MarkdownLocaleOptions = {
   container: {
@@ -92,7 +89,7 @@ function nav(): DefaultTheme.NavItem[] {
       activeMatch: '/pt/reference/'
     },
     {
-      text: pkg.version,
+      text: version,
       items: [
         {
           text: '1.6.4',

--- a/docs/ru/config.ts
+++ b/docs/ru/config.ts
@@ -1,12 +1,9 @@
-import { createRequire } from 'node:module'
 import {
   defineAdditionalConfig,
   type DefaultTheme,
   type MarkdownLocaleOptions
 } from 'vitepress'
-
-const require = createRequire(import.meta.url)
-const pkg = require('vitepress/package.json')
+import { version } from 'vitepress/package.json' with { type: 'json' }
 
 export const markdown: MarkdownLocaleOptions = {
   container: {
@@ -90,7 +87,7 @@ function nav(): DefaultTheme.NavItem[] {
       activeMatch: '/ru/reference/'
     },
     {
-      text: pkg.version,
+      text: version,
       items: [
         {
           text: '1.6.4',

--- a/docs/zh/config.ts
+++ b/docs/zh/config.ts
@@ -1,12 +1,9 @@
-import { createRequire } from 'node:module'
 import {
   defineAdditionalConfig,
   type DefaultTheme,
   type MarkdownLocaleOptions
 } from 'vitepress'
-
-const require = createRequire(import.meta.url)
-const pkg = require('vitepress/package.json')
+import { version } from 'vitepress/package.json' with { type: 'json' }
 
 export const markdown: MarkdownLocaleOptions = {
   container: {
@@ -92,7 +89,7 @@ function nav(): DefaultTheme.NavItem[] {
       activeMatch: '/zh/reference/'
     },
     {
-      text: pkg.version,
+      text: version,
       items: [
         {
           text: '1.6.4',

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "build": "pnpm build:prepare && pnpm build:client && pnpm build:node && node scripts/genWebTypes.ts",
     "build:prepare": "pnpm clean && node scripts/copyShared.ts",
     "build:client": "vue-tsc --noEmit -p src/client && tsc -p src/client && node scripts/copyClient.ts",
-    "build:node": "tsc -p src/node --noEmit && rollup --config rollup.config.ts --configPlugin esbuild",
+    "build:node": "tsc -p src/node --noEmit && rollup --config rollup.config.ts",
     "test": "pnpm --aggregate-output --reporter=append-only '/^test:(types|unit|e2e|init)$/'",
     "test:types": "tsc -p __tests__/unit && tsc -p __tests__/e2e && tsc -p __tests__/init && vue-tsc -p docs",
     "test:unit": "vitest run -r __tests__/unit",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -4,14 +4,12 @@ import json from '@rollup/plugin-json'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
 import { rm } from 'node:fs/promises'
-import { builtinModules, createRequire } from 'node:module'
+import { builtinModules } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { type RollupOptions, defineConfig } from 'rollup'
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
-
-const require = createRequire(import.meta.url)
-const pkg = require('./package.json')
+import pkg from './package.json' with { type: 'json' }
 
 const DEV = !!process.env.DEV
 const PROD = !DEV


### PR DESCRIPTION
### Description
Replace manual createRequire with native `import { version } from 'vitepress/package.json' with { type: 'json' }` in `config.ts`.
[developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#importing_non-javascript_modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#importing_non-javascript_modules)
<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
