### PR TITLE
docs: add harvis to the deploy platform guides

### DIFF
--- a/docs/en/guide/deploy.md
+++ b/docs/en/guide/deploy.md
@@ -304,6 +304,16 @@ You can deploy your VitePress project to [Stormkit](https://www.stormkit.io) by 
    npx surge docs/.vitepress/dist
    ```
 
+### harvis
+
+1. After running `npm run docs:build`, run this command to deploy:
+
+   ```sh
+   npx harvis docs/.vitepress/dist
+   ```
+
+   [harvis](https://harvis.dev) prints a live URL for the uploaded files — no account or configuration required. Run it again to update the same site.
+
 ### nginx
 
 Here is a example of an nginx server block configuration. This setup includes gzip compression for common text-based assets, rules for serving your VitePress site's static files with proper caching headers as well as handling `cleanUrls: true`.

--- a/docs/en/guide/deploy.md
+++ b/docs/en/guide/deploy.md
@@ -298,21 +298,19 @@ You can deploy your VitePress project to [Stormkit](https://www.stormkit.io) by 
 
 ### Surge
 
-1. After running `npm run docs:build`, run this command to deploy:
+After running `npm run docs:build`, run this command to deploy to [Surge](https://surge.sh):
 
-   ```sh
-   npx surge docs/.vitepress/dist
-   ```
+```sh
+npx surge docs/.vitepress/dist
+```
 
 ### harvis
 
-1. After running `npm run docs:build`, run this command to deploy:
+After running `npm run docs:build`, run this command to deploy to [harvis](https://harvis.dev):
 
-   ```sh
-   npx harvis docs/.vitepress/dist
-   ```
-
-   [harvis](https://harvis.dev) prints a live URL for the uploaded files — no account or configuration required. Run it again to update the same site.
+```sh
+npx harvis docs/.vitepress/dist
+```
 
 ### nginx
 


### PR DESCRIPTION
Adds a `### harvis` section to the Platform Guides, modeled on the Surge section (single CLI command over the build output). Companion issue: #5384.

[harvis](https://harvis.dev) is zero-setup static hosting: `npx harvis docs/.vitepress/dist` uploads the files and prints a live URL — no account or config; running it again updates the same site. Free tier for small sites.

Disclosure: I'm the maintainer of harvis.