### PR TITLE
fix(theme): use relative length units to auto-close nav screen menu

### DIFF
--- a/src/client/theme-default/composables/nav.ts
+++ b/src/client/theme-default/composables/nav.ts
@@ -1,3 +1,4 @@
+import { useMediaQuery, whenever } from '@vueuse/core'
 import { useRoute } from 'vitepress'
 import { ref, watch, type InjectionKey } from 'vue'
 
@@ -6,24 +7,19 @@ export function useNav() {
 
   function openScreen() {
     isScreenOpen.value = true
-    window.addEventListener('resize', closeScreenOnTabletWindow)
   }
 
   function closeScreen() {
     isScreenOpen.value = false
-    window.removeEventListener('resize', closeScreenOnTabletWindow)
   }
 
   function toggleScreen() {
     isScreenOpen.value ? closeScreen() : openScreen()
   }
 
-  /**
-   * Close screen when the user resizes the window wider than tablet size.
-   */
-  function closeScreenOnTabletWindow() {
-    window.outerWidth >= 768 && closeScreen()
-  }
+  // Close screen when the user resizes the window wider than tablet size.
+  const isTablet = useMediaQuery('(min-width: 48rem)')
+  whenever(isTablet, closeScreen)
 
   const route = useRoute()
   watch(() => route.path, closeScreen)


### PR DESCRIPTION
### Description

The `VPNavScreenMenu` auto-closes when it's tablet size or bigger, but it's based on `768px` rather than `48rem` as converted in #5323. This PR updates to based on `48rem` with refactors and optimization.

### Linked Issues

n/a

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.
