### PR TITLE
docs(wizard-bun): fix error when run setup wizard with bun without x

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -68,7 +68,7 @@ $ yarn vitepress init
 ```
 
 ```sh [bun]
-$ bun vitepress init
+$ bunx vitepress init
 ```
 
 :::


### PR DESCRIPTION
### Description

This error happen when you run setup wizard without `x` in `bun`:

```bash
$ bun vitepress init
error: Script not found "vitepress"
```

fix:
```bash
$ bunx vitepress init
```

or

```bash
$ bun x vitepress init
```