### PR TITLE
fix(cli): keep dev server alive when a restart after config change fails

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -1,6 +1,6 @@
 import minimist from 'minimist'
 import c from 'picocolors'
-import { createLogger } from 'vite'
+import { createLogger, type ViteDevServer } from 'vite'
 
 import {
   build,
@@ -16,6 +16,7 @@ import { logVersion } from './utils/logVersion'
 
 const argv: any = minimist(process.argv.slice(2))
 
+// minimist keeps `--flag=true` as the string 'true'
 Object.keys(argv).forEach((key) => {
   if (argv[key] === 'true') {
     argv[key] = true
@@ -24,16 +25,33 @@ Object.keys(argv).forEach((key) => {
   }
 })
 
+// vitepress [command] [root]
 const command = argv._[0]
 const root = argv._[command ? 1 : 0]
 if (root) {
   argv.root = root
 }
 
-let restartPromise: Promise<void> | undefined
-
 if (!command || command === 'dev') {
+  runDev(root, argv).catch(
+    logErrorAndExit.bind(null, `failed to start server. error:`)
+  )
+} else if (command === 'init') {
+  createLogger().info('', { clear: true })
+  init(argv.root)
+} else if (command === 'build') {
+  build(root, argv).catch(logErrorAndExit.bind(null, `build error:`))
+} else if (command === 'serve' || command === 'preview') {
+  serve(argv).catch(
+    logErrorAndExit.bind(null, `failed to start server. error:`)
+  )
+} else {
+  logErrorAndExit(`unknown command "${command}".`)
+}
+
+async function runDev(root: string, argv: any) {
   if (argv.force) {
+    // vite moved --force under optimizeDeps
     delete argv.force
     argv.optimizeDeps = { force: true }
   }
@@ -41,48 +59,41 @@ if (!command || command === 'dev') {
   let config = await resolveConfig(root, argv).catch(
     logErrorAndExit.bind(null, `failed to resolve config. error:`)
   )
-  const createDevServer = async (isRestart = true) => {
-    const server = await createServer(root, argv, restartServer, config)
-    function restartServer() {
-      if (!restartPromise) {
-        restartPromise = (async () => {
-          try {
-            config = await resolveConfig(root, argv)
-          } catch (err: any) {
-            logError(`failed to resolve config. error:`, err)
-            return
-          }
-          disposeMdItInstance()
-          clearCache()
-          await server.close()
-          await createDevServer()
-        })().finally(() => {
-          restartPromise = undefined
-        })
-      }
-      return restartPromise
-    }
+  let server: ViteDevServer
+  let restartPromise: Promise<void> | undefined
+
+  async function startServer(isRestart = true) {
+    server = await createServer(root, argv, restartServer, config)
+    // isRestart keeps vite from reopening the browser
     await server.listen(undefined, isRestart)
     logVersion(server.config.logger)
     server.printUrls()
     bindShortcuts(server, restartServer)
   }
-  createDevServer(false).catch(
-    logErrorAndExit.bind(null, `failed to start server. error:`)
-  )
-} else if (command === 'init') {
-  createLogger().info('', { clear: true })
-  init(argv.root)
-} else {
-  if (command === 'build') {
-    build(root, argv).catch(logErrorAndExit.bind(null, `build error:`))
-  } else if (command === 'serve' || command === 'preview') {
-    serve(argv).catch(
-      logErrorAndExit.bind(null, `failed to start server. error:`)
-    )
-  } else {
-    logErrorAndExit(`unknown command "${command}".`)
+
+  // the config watcher and the r shortcut can both ask at once
+  function restartServer() {
+    restartPromise ??= restart().finally(() => {
+      restartPromise = undefined
+    })
+    return restartPromise
   }
+
+  async function restart() {
+    try {
+      config = await resolveConfig(root, argv)
+    } catch (err: any) {
+      logError(`failed to resolve config. error:`, err)
+      return
+    }
+
+    disposeMdItInstance()
+    clearCache()
+    await server.close()
+    await startServer()
+  }
+
+  await startServer(false)
 }
 
 function logErrorAndExit(message: string, err?: any): never {

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -14,6 +14,8 @@ import { clearCache } from './markdownToVue'
 import { bindShortcuts } from './shortcuts'
 import { logVersion } from './utils/logVersion'
 
+const CLOSE_TIMEOUT = 10000
+
 const argv: any = minimist(process.argv.slice(2))
 
 // minimist keeps `--flag=true` as the string 'true'
@@ -71,15 +73,50 @@ async function runDev(root: string, argv: any) {
     bindShortcuts(server, restartServer)
   }
 
+  // vite's close waits for in-flight transform requests, which never settle
+  // once the plugin container and dep optimizer are torn down under them. the
+  // port, the watcher and the ws server are released well before that, so stop
+  // waiting and let the restart go on
+  async function closeServer() {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const closed = await Promise.race([
+      server.close().then(
+        () => true,
+        (err: any) => {
+          logError(`failed to close server. error:`, err)
+          return true
+        }
+      ),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(resolve, CLOSE_TIMEOUT, false)
+      })
+    ])
+    clearTimeout(timer)
+    if (!closed) {
+      createLogger().warn(
+        c.yellow(
+          `server didn't close in ${CLOSE_TIMEOUT / 1000}s, restarting anyway`
+        )
+      )
+    }
+  }
+
   // the config watcher and the r shortcut can both ask at once
   function restartServer() {
-    restartPromise ??= restart().finally(() => {
-      restartPromise = undefined
-    })
+    if (!restartPromise) {
+      // between the two servers nothing references the event loop, so a stall
+      // anywhere in a restart would drain node into a silent exit(0)
+      const keepAlive = setInterval(() => {}, 1 << 30)
+      restartPromise = restart().finally(() => {
+        clearInterval(keepAlive)
+        restartPromise = undefined
+      })
+    }
     return restartPromise
   }
 
   async function restart() {
+    const prevConfig = config
     try {
       config = await resolveConfig(root, argv)
     } catch (err: any) {
@@ -89,9 +126,31 @@ async function runDev(root: string, argv: any) {
 
     disposeMdItInstance()
     clearCache()
-    await server.close()
-    await startServer()
+    await closeServer()
+
+    try {
+      await startServer()
+    } catch (err: any) {
+      logError(`failed to restart server. error:`, err)
+      // the old server is already closed, so bailing out here leaves the
+      // session with no server and no watcher — come back up on the last
+      // known good config so a fix can trigger a fresh restart
+      config = prevConfig
+      // the failed attempt may have memoized a half-configured renderer
+      disposeMdItInstance()
+      clearCache()
+      createLogger().warn(c.yellow(`falling back to the previous config`))
+      await startServer().catch(
+        logErrorAndExit.bind(null, `failed to restore server. error:`)
+      )
+    }
   }
+
+  // a stray unhandled rejection (from a user config, a theme, or a plugin)
+  // must not take down a long-lived dev session
+  process.on('unhandledRejection', (err) => {
+    logError(`unhandled rejection:`, err)
+  })
 
   await startServer(false)
 }


### PR DESCRIPTION
## Reorganization first (per review)

The branch leads with a **behavior-neutral** commit that cleans up `src/node/cli.ts`, and the fix sits on top of that structure:

- argv parsing/normalization, then a flat dispatch chain — no more `else { if / else if }` nesting with inline command bodies.
- the dev session is a single unit, `runDev(root, argv)`, owning the resolved config, the current server and the restart de-duplication. `restartServer` is no longer redefined per server generation and `restartPromise` is no longer a module-level `let`.
- the restart sequence reads in order: resolve config → dispose renderer + cache → close server → start server, with the recovery path separated out.

Nothing else moves in that commit: `--force` → `optimizeDeps.force`, boot failures exiting 1, `server.listen(undefined, isRestart)`, `bindShortcuts`, version logging + `printUrls`, and the init/build/serve dispatch all behave exactly as before.

## Problem

`restartServer` only guards `resolveConfig`. When starting the new server itself rejects during a config-reload restart — e.g. a theme/plugin `markdown.config` hook throwing while the markdown renderer is rebuilt — the old server has already been closed. The rejection propagates through `hotUpdate` into Vite's `handleHMRUpdate`, which converts it into a client error event that no client can receive anymore, and the process then drains and exits **without printing anything**.

Repro: run `vitepress dev`, then save a config whose `markdown.config` throws (VitePress's own `markdown.math` path throws exactly like this when `markdown-it-mathjax3` is missing). The log ends at `config.ts changed, restarting server...` and the process is gone.

## Fix

- Guard the `startServer()` call in the restart path: log the failure, restore the previous (known-good) config, dispose the markdown renderer + cache again, and bring a server back up so the watcher keeps running and a config fix triggers a fresh restart.
- The second `disposeMdItInstance()` is load-bearing: `md` is memoized before the user config hook runs, so the failed attempt can leave a half-configured renderer behind.
- Log stray `unhandledRejection`s in dev instead of dying (an un-awaited rejecting promise created during config evaluation previously also killed the process).
- This also fixes the `r` shortcut dying on the same path (its action awaits `restartServer` with no rejection handler).

**A wedged `close()` was killing restarts on its own.** Guarding `startServer()` alone only healed ~60-75% of runs; the rest still exited `0` in silence, and instrumenting Vite's close showed why. `server.close()` awaits `environment.close()`, which drains `_pendingRequests` and `pluginContainer.close()` — and the client environment's in-flight transform requests (the ones `preTransformRequests` kicks off after the first page load) never settle once the dep optimizer and plugin container are torn down under them. `watcher`, `ws`, `httpServer` and the whole `ssr` environment all resolve; `client:pendingRequests` and `client:container` never do, the loop runs dry and Node exits `0` at `beforeExit`. So: bound the wait (10s), warn, and carry on — the http server is already closed by then, so the port is free and the new server binds it even under `--strictPort` (verified). And because nothing references the event loop between the two servers, a ref'd handle is held for the length of a restart, so a stall anywhere in one can never drain Node into a silent `exit(0)` again. The underlying stall looks like a Vite bug and is worth reporting upstream; this just stops it from taking the dev session with it.

## Verified

A scripted CLI harness — dev boot, a normal config edit restarting, a restart that fails, a boot-time failure, `--force`, and `build` / `serve` / `init` / unknown-command dispatch — run at `main`, at the refactor commit and at the fix commit:

- **behavior parity**: `main` and the refactor commit produce identical results across the whole suite, including the crash this PR fixes — the reorganization changes nothing observable.
- **the fix**: 27/27, i.e. on a broken config the process survives, the failure is logged, the previous config is restored and pages still return 200, and the next (fixed) save is picked up. Same for two consecutive failed restarts, and for a save that lands while the recovery restart is still in flight.
- **stress**: the failing-restart scenario **22/22 consecutive runs surviving** (up from ~60-75% with only the `startServer()` guard), each on a fixed `--strictPort` port. 10 of the 22 hit the wedged close and recovered through the timeout.
- boot-time failure still exits 1; normal config edits restart as before.
- `pnpm typecheck` and `pnpm test:unit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
