### PR TITLE
fix(node): resolve markdown options when the renderer is created

### DIFF
--- a/__tests__/unit/node/markdownToVue.test.ts
+++ b/__tests__/unit/node/markdownToVue.test.ts
@@ -3,10 +3,17 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { resolveConfig } from 'node/config'
+import { disposeMdItInstance } from 'node/markdown/markdown'
 import { createMarkdownToVueRenderFn } from 'node/markdownToVue'
 
 describe('node/markdownToVue', () => {
   let root: string | undefined
+
+  beforeEach(() => {
+    // the markdown renderer is a module-level singleton — reset it so each
+    // test's options actually reach it
+    disposeMdItInstance()
+  })
 
   afterEach(async () => {
     if (root) {
@@ -23,9 +30,9 @@ describe('node/markdownToVue', () => {
     await writeFile(file, src)
 
     const siteConfig = await resolveConfig(root, 'build', 'production')
+    siteConfig.markdown = { cache: false }
     const render = await createMarkdownToVueRenderFn(
       siteConfig.srcDir,
-      { cache: false },
       '/',
       false,
       false,
@@ -50,9 +57,9 @@ describe('node/markdownToVue', () => {
     await writeFile(file, src)
 
     const siteConfig = await resolveConfig(root, 'build', 'production')
+    siteConfig.markdown = { cache: false }
     const render = await createMarkdownToVueRenderFn(
       siteConfig.srcDir,
-      { cache: false },
       '/',
       false,
       false,
@@ -105,9 +112,9 @@ describe('node/markdownToVue', () => {
     await writeFile(file, src)
 
     const siteConfig = await resolveConfig(root, 'build', 'production')
+    siteConfig.markdown = { cache: false }
     const render = await createMarkdownToVueRenderFn(
       siteConfig.srcDir,
-      { cache: false },
       '/',
       false,
       false,
@@ -125,6 +132,37 @@ describe('node/markdownToVue', () => {
     expect(result.vueSrc).not.toContain('shared after target')
   })
 
+  test('reads markdown options when the renderer is created', async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'vitepress-md-options-'))
+
+    const file = path.join(root, 'index.md')
+    const src = '# Home\n'
+    await writeFile(file, src)
+
+    const siteConfig = await resolveConfig(root, 'build', 'production')
+    const render = await createMarkdownToVueRenderFn(
+      siteConfig.srcDir,
+      '/',
+      false,
+      false,
+      siteConfig
+    )
+
+    // a vite plugin extending the markdown options from its own configResolved
+    // hook, i.e. after the render fn has been created but before it is used
+    siteConfig.markdown = {
+      cache: false,
+      config: (md) => {
+        md.renderer.rules.text = (tokens, idx) =>
+          `${tokens[idx].content}__MARKER__`
+      }
+    }
+
+    const result = await render(src, file)
+
+    expect(result.vueSrc).toContain('Home__MARKER__')
+  })
+
   test('applies rewrites with mismatched Windows drive letter case', async () => {
     root = await mkdtemp(path.join(tmpdir(), 'vitepress-rewrite-'))
 
@@ -140,9 +178,9 @@ describe('node/markdownToVue', () => {
     }
     ;(siteConfig as any).__dirty = true
 
+    siteConfig.markdown = { cache: false }
     const render = await createMarkdownToVueRenderFn(
       siteConfig.srcDir,
-      { cache: false },
       '/',
       false,
       false,

--- a/__tests__/unit/node/plugins/localSearchPlugin.test.ts
+++ b/__tests__/unit/node/plugins/localSearchPlugin.test.ts
@@ -142,17 +142,18 @@ describe('node/plugins/localSearchPlugin', () => {
     const siteConfig = await resolveConfig(root, 'build', 'production')
     const plugin = await localSearchPlugin(siteConfig)
 
-    // configResolved hooks run concurrently, so the search plugin may be the
-    // one that creates the shared markdown renderer — page renders must still
-    // pick up per-locale options from it
     await (plugin.configResolved as any)?.call(
       {},
       { publicDir: siteConfig.publicDir }
     )
 
+    // the markdown renderer is a singleton created on first use, and indexing
+    // here gets there before the page renderer does — page renders must still
+    // pick up per-locale options from the instance the search plugin built
+    await (plugin.load as any)?.handler.call({}, '/@localSearchIndex')
+
     const render = await createMarkdownToVueRenderFn(
       siteConfig.srcDir,
-      siteConfig.markdown ?? {},
       siteConfig.site.base,
       false,
       false,
@@ -167,7 +168,6 @@ describe('node/plugins/localSearchPlugin', () => {
     expect(zhPage.vueSrc).toContain('zhtiplabel')
 
     // the indexed text must use the localized labels too
-    await (plugin.load as any)?.handler.call({}, '/@localSearchIndex')
     const rootIndex = loadIndex(
       (await (plugin.load as any)?.handler.call(
         {},

--- a/src/node/markdown/markdown.ts
+++ b/src/node/markdown/markdown.ts
@@ -350,27 +350,64 @@ export function mergeMarkdownLocales(
 }
 
 let md: MarkdownRenderer | undefined
+let mdPromise: Promise<MarkdownRenderer> | undefined
+let mdGeneration = 0
 let _disposeHighlighter: (() => void) | undefined
 
 export function disposeMdItInstance() {
-  if (md) {
+  if (md || mdPromise) {
     md = undefined
+    mdPromise = undefined
+    // a creation that is still in flight must not install itself afterwards
+    mdGeneration++
     _disposeHighlighter?.()
+    _disposeHighlighter = undefined
   }
 }
 
 /**
  * @experimental
  */
-export async function createMarkdownRenderer(
+export function createMarkdownRenderer(
   srcDir: string,
   options: MarkdownOptions = {},
   base = '/',
   logger: Pick<Logger, 'warn'> = console,
   publicDir?: string
 ): Promise<MarkdownRenderer> {
-  if (md) return md
+  if (md) return Promise.resolve(md)
+  // the renderer is a process-wide singleton and creating it is async, so
+  // concurrent first calls share one instance instead of each building their
+  // own - the options of whichever call comes first are the ones that apply
+  const generation = mdGeneration
+  return (mdPromise ??= createMarkdownRendererInstance(
+    srcDir,
+    options,
+    base,
+    logger,
+    publicDir
+  ).then(
+    ({ md: instance, dispose }) => {
+      // disposed while we were building it: hand the instance to this caller,
+      // but leave the slot empty so the next one rebuilds from fresh options
+      if (generation !== mdGeneration) return instance
+      _disposeHighlighter = dispose
+      return (md = instance)
+    },
+    (err) => {
+      if (generation === mdGeneration) mdPromise = undefined
+      throw err
+    }
+  ))
+}
 
+async function createMarkdownRendererInstance(
+  srcDir: string,
+  options: MarkdownOptions,
+  base: string,
+  logger: Pick<Logger, 'warn'>,
+  publicDir: string | undefined
+): Promise<{ md: MarkdownRenderer; dispose: () => void }> {
   publicDir ??= path.resolve(srcDir, 'public')
 
   const theme = options.theme ?? { light: 'github-light', dark: 'github-dark' }
@@ -383,9 +420,15 @@ export async function createMarkdownRenderer(
     ? [options.highlight, () => {}]
     : await createHighlighter(theme, options, logger)
 
-  _disposeHighlighter = dispose
-
-  md = new MarkdownItAsync({ html: true, linkify: true, highlight, ...options })
+  // deliberately shadows the module-level instance - it is only installed
+  // there once fully configured, so that a concurrent consumer can never get
+  // hold of a half-built renderer
+  const md: MarkdownRenderer = new MarkdownItAsync({
+    html: true,
+    linkify: true,
+    highlight,
+    ...options
+  })
 
   md.linkify.set({ fuzzyLink: false })
   restoreEntities(md)
@@ -563,7 +606,7 @@ export async function createMarkdownRenderer(
     await options.config(md)
   }
 
-  return md
+  return { md, dispose }
 }
 
 // `true` and `undefined` enable a plugin with its default options - only an

--- a/src/node/markdownToVue.ts
+++ b/src/node/markdownToVue.ts
@@ -10,7 +10,6 @@ import type { SiteConfig } from './config'
 import {
   createMarkdownRenderer,
   mergeMarkdownLocales,
-  type MarkdownOptions,
   type MarkdownRenderer
 } from './markdown/markdown'
 import { getPageDataTransformer } from './plugins/dynamicRoutesPlugin'
@@ -100,21 +99,27 @@ function getResolutionCache(siteConfig: SiteConfig) {
 
 export async function createMarkdownToVueRenderFn(
   srcDir: string,
-  options: MarkdownOptions,
   base: string,
   includeLastUpdatedData: boolean,
   cleanUrls: boolean,
   siteConfig: SiteConfig
 ) {
-  const md = await createMarkdownRenderer(
-    srcDir,
-    mergeMarkdownLocales(options, siteConfig?.site.locales),
-    base,
-    siteConfig?.logger,
-    siteConfig?.publicDir
-  )
+  // the markdown options are read when the renderer is actually created, i.e.
+  // on the first render, not here - that way a vite plugin can still extend
+  // `config.vitepress.markdown` from its own `configResolved` hook
+  let mdPromise: Promise<MarkdownRenderer> | undefined
+  const getMarkdownRenderer = () =>
+    (mdPromise ??= createMarkdownRenderer(
+      srcDir,
+      mergeMarkdownLocales(siteConfig?.markdown, siteConfig?.site.locales),
+      base,
+      siteConfig?.logger,
+      siteConfig?.publicDir
+    ))
 
   return async (src: string, file: string): Promise<MarkdownCompileResult> => {
+    const md = await getMarkdownRenderer()
+    const useCache = siteConfig?.markdown?.cache !== false
     const { pages, dynamicRoutes, rewrites, ts } =
       getResolutionCache(siteConfig)
 
@@ -130,7 +135,7 @@ export async function createMarkdownToVueRenderFn(
 
     const srcHash = hash('sha256', src, 'base64url')
     const cacheKey = `${srcHash}:${ts}:${relativePath}`
-    if (options.cache !== false) {
+    if (useCache) {
       const cached = cache.get(cacheKey)
       if (cached) {
         debug(`[cache hit] ${relativePath}`)
@@ -296,7 +301,7 @@ export async function createMarkdownToVueRenderFn(
     debug(`[render] ${file} in ${Date.now() - start}ms.`)
 
     const result = { vueSrc, pageData, deadLinks, includes }
-    if (options.cache !== false) cache.set(cacheKey, result)
+    if (useCache) cache.set(cacheKey, result)
     return result
   }
 }

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -84,7 +84,6 @@ export async function createVitePressPlugin(
     srcDir,
     configPath,
     configDeps,
-    markdown,
     site,
     vue: userVuePluginOptions,
     vite: userViteConfig,
@@ -128,7 +127,6 @@ export async function createVitePressPlugin(
       if (lastUpdated) await cacheAllGitTimestamps(srcDir)
       markdownToVue = await createMarkdownToVueRenderFn(
         srcDir,
-        markdown ?? {},
         config.base,
         lastUpdated ?? false,
         cleanUrls ?? false,

--- a/src/node/plugins/localSearchPlugin.ts
+++ b/src/node/plugins/localSearchPlugin.ts
@@ -10,7 +10,8 @@ import type { SiteConfig } from '../config'
 import type { DefaultTheme } from '../defaultTheme'
 import {
   createMarkdownRenderer,
-  mergeMarkdownLocales
+  mergeMarkdownLocales,
+  type MarkdownRenderer
 } from '../markdown/markdown'
 import { getLocaleForPath, slash, type MarkdownEnv } from '../shared'
 import { readTextFile } from '../utils/fs'
@@ -51,8 +52,20 @@ export async function localSearchPlugin(
     }
   }
 
-  // created in configResolved to use the resolved publicDir
-  let md: Awaited<ReturnType<typeof createMarkdownRenderer>>
+  // the resolved publicDir, picked up in configResolved
+  let publicDir: string | undefined
+  // the renderer is created on first use rather than in configResolved, so
+  // that markdown options a vite plugin adds from its own configResolved hook
+  // reach it too - it is a singleton shared with the page renderer (#5350)
+  let mdPromise: Promise<MarkdownRenderer> | undefined
+  const getMarkdownRenderer = () =>
+    (mdPromise ??= createMarkdownRenderer(
+      siteConfig.srcDir,
+      mergeMarkdownLocales(siteConfig.markdown, siteConfig.site.locales),
+      siteConfig.site.base,
+      siteConfig.logger,
+      publicDir
+    ))
 
   const options = siteConfig.site.themeConfig.search.options || {}
 
@@ -72,6 +85,7 @@ export async function localSearchPlugin(
       }
       throw e
     })
+    const md = await getMarkdownRenderer()
     if (options._render) {
       return options._render(raw, env, md)
     } else {
@@ -187,17 +201,8 @@ export async function localSearchPlugin(
   return {
     name: 'vitepress:local-search',
 
-    async configResolved(config) {
-      // fold in `locales.*.markdown` like markdownToVue does — the renderer
-      // is a singleton, so whichever configResolved hook creates it first
-      // must pass the complete options (#5350)
-      md = await createMarkdownRenderer(
-        siteConfig.srcDir,
-        mergeMarkdownLocales(siteConfig.markdown, siteConfig.site.locales),
-        siteConfig.site.base,
-        siteConfig.logger,
-        config.publicDir
-      )
+    configResolved(config) {
+      publicDir = config.publicDir
     },
 
     config() {


### PR DESCRIPTION
## Problem

`markdown` options are captured while the plugin array is being built (before any Vite hook runs) and threaded into `createMarkdownToVueRenderFn`. A Vite plugin therefore cannot extend them: mutating `config.vitepress.markdown` from `configResolved` silently no-ops whenever the user config has no top-level `markdown` key (the common shape), and `mergeMarkdownLocales` snapshots, so the mutation is also lost whenever any locale defines `markdown`.

Worse, `localSearchPlugin` already reads `siteConfig.markdown` live while `markdownToVue` uses the captured value — measured on `main`: with locales present, the search index was built by a renderer with a plugin's added markdown-it rule while pages were rendered by a second instance without it. Two differently-configured renderers coexisted, and whichever ran first installed the module singleton.

## Fix

Resolve markdown options when the renderer is actually created (first render), not at plugin-array construction:

- `markdownToVue` and `localSearchPlugin` both build the renderer lazily from `siteConfig.markdown` + locale merge at first use, after every `configResolved` has run — both readers now see the same final state.
- `createMarkdownRenderer` memoizes the in-flight creation so concurrent first callers share one instance (previously each built one and raced to install it), retries after a rejected creation, and guards installation with a generation counter bumped by `disposeMdItInstance()` so a creation in flight across a restart can't resurrect a stale renderer.

Public API unchanged (`createMarkdownToVueRenderFn` is internal).

## Verified

Scripted dev servers with a test Vite plugin composing `config.vitepress.markdown.config` from `configResolved`, across the 2×2 matrix (top-level `markdown` key present/absent × locale `markdown` present/absent): previously only present/no-locales worked; now all four do, with the locale's own settings still applied. Also verified: a config hot edit re-applies the plugin's additions after restart (previously lost in 3 of 4 cases), and local search still indexes correctly through the shared singleton. `pnpm typecheck`, `test:unit`, `build`, and both e2e suites pass; new unit coverage asserts options are read at creation time.

This unlocks markdown-extending VitePress plugins that are plain Vite plugins (cf. #3180 / #3966).

🤖 Generated with [Claude Code](https://claude.com/claude-code)