### PR TITLE
fix(theme): decouple VPButton height from line-height

### DIFF
--- a/src/client/theme-default/components/VPButton.vue
+++ b/src/client/theme-default/components/VPButton.vue
@@ -42,7 +42,9 @@ const component = computed(() => {
 
 <style scoped>
 .VPButton {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid transparent;
   text-align: center;
   font-weight: 600;
@@ -56,16 +58,16 @@ const component = computed(() => {
 }
 
 .VPButton.medium {
+  height: 2.5rem;
   border-radius: 1.25rem;
   padding: 0 1.25rem;
-  line-height: 2.7142857;
   font-size: 0.875rem;
 }
 
 .VPButton.big {
+  height: 3rem;
   border-radius: 1.5rem;
   padding: 0 1.5rem;
-  line-height: 2.875;
   font-size: 1rem;
 }
 


### PR DESCRIPTION
### Description

The default theme sizes `.VPButton` using a large unitless `line-height`, so the button's height comes from the font's line box instead of an explicit size. A line box centers around ascender/descender metrics, not glyph ink, so with a custom font and a non-default root font size the label can end up visibly off-center. At the default 16px root size the line-height math happens to match `2 * border-radius`, which is why it looks fine there.

This switches `.VPButton` to `inline-flex` with `align-items: center` and gives `.medium`/`.big` an explicit `height` matching what the old line-height produced at the default root size (2.5rem and 3rem), so centering comes from flexbox instead of the text line box. Padding, border-radius, and font-size are unchanged. Both current usages (`VPHero`, `VPHomeSponsors`) already wrap the button in their own flex container rather than inline text, so switching from `inline-block` to `inline-flex` doesn't change wrapping behavior anywhere.

I can't render this visually in my environment, so please check it at a couple of root font sizes / with a custom font before merging.

### Linked Issues

Fixes #5420

### Additional Context

`pnpm build`, `pnpm test:unit` (367 passed), and `prettier --check` all pass locally. No visual-regression suite exists in this repo to run.