### PR TITLE
docs: add Lizard deployment instructions

### DIFF
--- a/docs/en/guide/deploy.md
+++ b/docs/en/guide/deploy.md
@@ -316,6 +316,20 @@ You can deploy your VitePress project with [CloudRay](https://cloudray.io/) by f
 
 You can deploy your VitePress project with [Hostinger](https://www.hostinger.com/web-apps-hosting) by following these [instructions](https://www.hostinger.com/support/how-to-deploy-a-nodejs-website-in-hostinger/). While configuring build settings, choose VitePress as the framework and adjust the root directory to `./docs`.
 
+### Lizard
+
+[Lizard (lizard.build)](https://lizard.build) builds VitePress sites from source and serves the generated HTML. For the layout used in this guide, it detects `docs:build` and serves `docs/.vitepress/dist` on port `80`.
+
+Install the [Lizard CLI](https://lizard.build/docs/cli) and sign in with `lizard login`. To deploy a local source directory, run these commands from the project root containing `package.json`:
+
+```sh
+lizard init --name vitepress-docs
+lizard add --service web
+lizard up --service web --port 80
+```
+
+Leave build and start command overrides unset to use automatic detection. For GitHub deployments or other layouts, see the [Lizard VitePress guide](https://lizard.build/docs/framework-guides/vitepress).
+
 ### Stormkit
 
 You can deploy your VitePress project to [Stormkit](https://www.stormkit.io) by following these [instructions](https://stormkit.io/blog/how-to-deploy-vitepress).


### PR DESCRIPTION
### Description

Add a Lizard (lizard.build) section to the English deployment guide, between Hostinger and Stormkit. It explains the detected docs root/output, port 80, local source upload commands, and links to the full guide for other layouts and GitHub deployments.

### Linked Issues

None.

### Additional Context

I work on Lizard.

Validation:
- Built the documented docs-root example with VitePress 1.6.4 and a committed npm lockfile.
- Rechecked its existing public deployment: home, clean inner route, and asset returned 200; missing page and script returned 404.
- Production configuration has no custom Dockerfile, build command, or start command.
- Built and inspected the changed page's HTML in an isolated VitePress preview. This was not a full repository build; unrelated links absent from the isolated preview were ignored.
- CLI commands match Lizard CLI 0.3.94.

The temporary test deployment was removed on 9 September 2026 after validation. The results above record that completed run; the source example and full guide remain available.
Guide: https://lizard.build/docs/framework-guides/vitepress

---

> [!TIP]
> The author can publish a _preview release_ by commenting `/publish` after creating the PR.